### PR TITLE
snowcli poc

### DIFF
--- a/src/snowcli/cli/__init__.py
+++ b/src/snowcli/cli/__init__.py
@@ -9,6 +9,7 @@ from snowcli.cli import function
 from snowcli.cli import procedure
 from snowcli.cli import streamlit
 from snowcli.cli import warehouse
+from snowcli.cli import gettoken
 from rich import print
 
 app = typer.Typer()
@@ -84,6 +85,7 @@ app.add_typer(procedure.app, name="procedure")
 app.add_typer(streamlit.app, name="streamlit")
 app.add_typer(connection.app, name="connection")
 app.add_typer(warehouse.app, name="warehouse")
+app.add_typer(gettoken.app, name="gettoken")
 
 if __name__ == '__main__':
     app()

--- a/src/snowcli/cli/gettoken.py
+++ b/src/snowcli/cli/gettoken.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import typer
+
+from snowcli import config, utils
+from snowcli.config import AppConfig
+from snowcli.snowsql_config import SnowsqlConfig
+from snowcli.utils import print_db_cursor
+
+app = typer.Typer()
+EnvironmentOption = typer.Option("dev", help='Environment name')
+
+@app.command("session")
+def get_sess_token(environment: str = EnvironmentOption):
+    """
+    get a Token that can be used with DockerCli, GitCli
+    """
+    if config.isAuth():
+        config.connectToSnowflake()
+        print(config.snowflake_connection.ctx._rest._token)


### PR DESCRIPTION
SnowService made modification in this "Internal Fork" of Snowcli, to serve as a POC to show that SnowCli can work with Docker login.

Users do this to login Snowflake :
snow gettoken session | docker login acc1.temptest1323.registry.snowflakecomputing.com -u 0sess --password-stdin

This PR is only the Client.  The Server change is https://github.com/snowflakedb/snowflake/pull/75653