### PR TITLE
Snowpark packaging improvements

### DIFF
--- a/src/snowcli/__about__.py
+++ b/src/snowcli/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-VERSION = "0.1.8"
+VERSION = "0.1.9"

--- a/src/snowcli/cli/function.py
+++ b/src/snowcli/cli/function.py
@@ -7,6 +7,9 @@ from shutil import copytree
 
 import pkg_resources
 import typer
+from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
+from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
+from snowcli.cli.snowpark_shared import PyPiDownloadOption
 from snowcli.cli.snowpark_shared import snowpark_create
 from snowcli.cli.snowpark_shared import snowpark_describe
 from snowcli.cli.snowpark_shared import snowpark_drop
@@ -14,9 +17,6 @@ from snowcli.cli.snowpark_shared import snowpark_execute
 from snowcli.cli.snowpark_shared import snowpark_list
 from snowcli.cli.snowpark_shared import snowpark_package
 from snowcli.cli.snowpark_shared import snowpark_update
-from snowcli.cli.snowpark_shared import PyPiDownloadOption
-from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
-from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
 from snowcli.utils import conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
@@ -79,7 +79,11 @@ def function_create(
         help='Replace if existing function',
     ),
 ):
-    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
+    snowpark_package(
+        pypi_download,  # type: ignore[arg-type]
+        check_anaconda_for_pypi_deps,
+        package_native_libraries,  # type: ignore[arg-type]
+    )
     snowpark_create(
         type='function',
         environment=environment,
@@ -131,7 +135,11 @@ def function_update(
         help='Replace function, even if no detected changes to metadata',
     ),
 ):
-    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
+    snowpark_package(
+        pypi_download,  # type: ignore[arg-type]
+        check_anaconda_for_pypi_deps,
+        package_native_libraries,  # type: ignore[arg-type]
+    )
     snowpark_update(
         type='function',
         environment=environment,
@@ -148,8 +156,13 @@ def function_update(
 def function_package(
     pypi_download: str = PyPiDownloadOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
-    package_native_libraries: str = PackageNativeLibrariesOption):
-    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
+    package_native_libraries: str = PackageNativeLibrariesOption,
+):
+    snowpark_package(
+        pypi_download,  # type: ignore[arg-type]
+        check_anaconda_for_pypi_deps,
+        package_native_libraries,  # type: ignore[arg-type]
+    )
 
 
 @app.command("execute")

--- a/src/snowcli/cli/function.py
+++ b/src/snowcli/cli/function.py
@@ -14,7 +14,10 @@ from snowcli.cli.snowpark_shared import snowpark_execute
 from snowcli.cli.snowpark_shared import snowpark_list
 from snowcli.cli.snowpark_shared import snowpark_package
 from snowcli.cli.snowpark_shared import snowpark_update
-from snowcli.utils import conf_callback
+from snowcli.cli.snowpark_shared import PyPiDownloadOption
+from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
+from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
+from snowcli.utils import YesNoAskOptionsType, conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 EnvironmentOption = typer.Option(
@@ -37,6 +40,9 @@ def function_init():
 @app.command("create")
 def function_create(
     environment: str = EnvironmentOption,
+    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption,
+    check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
     name: str = typer.Option(
         ..., '--name', '-n',
         help="Name of the function",
@@ -73,7 +79,7 @@ def function_create(
         help='Replace if existing function',
     ),
 ):
-    snowpark_package()
+    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
     snowpark_create(
         type='function',
         environment=environment,
@@ -89,6 +95,9 @@ def function_create(
 @app.command("update")
 def function_update(
     environment: str = EnvironmentOption,
+    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
+    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption,
     name: str = typer.Option(..., '--name', '-n', help="Name of the function"),
     file: Path = typer.Option(
         'app.zip',
@@ -122,7 +131,7 @@ def function_update(
         help='Replace function, even if no detected changes to metadata',
     ),
 ):
-    snowpark_package()
+    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
     snowpark_update(
         type='function',
         environment=environment,
@@ -136,8 +145,11 @@ def function_update(
 
 
 @app.command("package")
-def function_package():
-    snowpark_package()
+def function_package(
+    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
+    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption):
+    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
 
 
 @app.command("execute")

--- a/src/snowcli/cli/function.py
+++ b/src/snowcli/cli/function.py
@@ -17,7 +17,7 @@ from snowcli.cli.snowpark_shared import snowpark_update
 from snowcli.cli.snowpark_shared import PyPiDownloadOption
 from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
 from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
-from snowcli.utils import YesNoAskOptionsType, conf_callback
+from snowcli.utils import conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 EnvironmentOption = typer.Option(
@@ -40,8 +40,8 @@ def function_init():
 @app.command("create")
 def function_create(
     environment: str = EnvironmentOption,
-    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
-    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption,
+    pypi_download: str = PyPiDownloadOption,
+    package_native_libraries: str = PackageNativeLibrariesOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
     name: str = typer.Option(
         ..., '--name', '-n',
@@ -95,9 +95,9 @@ def function_create(
 @app.command("update")
 def function_update(
     environment: str = EnvironmentOption,
-    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    pypi_download: str = PyPiDownloadOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
-    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption,
+    package_native_libraries: str = PackageNativeLibrariesOption,
     name: str = typer.Option(..., '--name', '-n', help="Name of the function"),
     file: Path = typer.Option(
         'app.zip',
@@ -146,9 +146,9 @@ def function_update(
 
 @app.command("package")
 def function_package(
-    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    pypi_download: str = PyPiDownloadOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
-    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption):
+    package_native_libraries: str = PackageNativeLibrariesOption):
     snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
 
 

--- a/src/snowcli/cli/procedure.py
+++ b/src/snowcli/cli/procedure.py
@@ -17,7 +17,7 @@ from snowcli.cli.snowpark_shared import snowpark_execute
 from snowcli.cli.snowpark_shared import snowpark_list
 from snowcli.cli.snowpark_shared import snowpark_package
 from snowcli.cli.snowpark_shared import snowpark_update
-from snowcli.utils import YesNoAskOptionsType, conf_callback
+from snowcli.utils import conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 EnvironmentOption = typer.Option(
@@ -39,9 +39,9 @@ def procedure_init():
 @app.command("create")
 def procedure_create(
     environment: str = EnvironmentOption,
-    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    pypi_download: str = PyPiDownloadOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
-    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption,
+    package_native_libraries: str = PackageNativeLibrariesOption,
     name: str = typer.Option(
         ..., '--name', '-n',
         help="Name of the procedure",
@@ -141,9 +141,9 @@ def procedure_update(
 
 @app.command("package")
 def procedure_package(
-    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    pypi_download: str = PyPiDownloadOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
-    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption):
+    package_native_libraries: str = PackageNativeLibrariesOption):
     snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
 
 

--- a/src/snowcli/cli/procedure.py
+++ b/src/snowcli/cli/procedure.py
@@ -7,6 +7,9 @@ from shutil import copytree
 
 import pkg_resources
 import typer
+from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
+from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
+from snowcli.cli.snowpark_shared import PyPiDownloadOption
 from snowcli.cli.snowpark_shared import snowpark_create
 from snowcli.cli.snowpark_shared import snowpark_describe
 from snowcli.cli.snowpark_shared import snowpark_drop
@@ -14,13 +17,12 @@ from snowcli.cli.snowpark_shared import snowpark_execute
 from snowcli.cli.snowpark_shared import snowpark_list
 from snowcli.cli.snowpark_shared import snowpark_package
 from snowcli.cli.snowpark_shared import snowpark_update
-from snowcli.utils import conf_callback
+from snowcli.utils import YesNoAskOptionsType, conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 EnvironmentOption = typer.Option(
     "dev", help='Environment name', callback=conf_callback, is_eager=True,
 )
-
 
 @app.command("init")
 def procedure_init():
@@ -37,6 +39,9 @@ def procedure_init():
 @app.command("create")
 def procedure_create(
     environment: str = EnvironmentOption,
+    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
+    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption,
     name: str = typer.Option(
         ..., '--name', '-n',
         help="Name of the procedure",
@@ -76,7 +81,7 @@ def procedure_create(
         False, '--execute-as-caller', help='Execute as caller',
     ),
 ):
-    snowpark_package()
+    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
     snowpark_create(
         'procedure', environment, name, file, handler,
         input_parameters, return_type, overwrite, execute_as_caller,
@@ -86,6 +91,9 @@ def procedure_create(
 @app.command("update")
 def procedure_update(
     environment: str = EnvironmentOption,
+    pypi_download: str = PyPiDownloadOption,
+    check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
+    package_native_libraries: str = PackageNativeLibrariesOption,
     name: str = typer.Option(
         ..., '--name', '-n',
         help="Name of the procedure",
@@ -124,7 +132,7 @@ def procedure_update(
         False, '--execute-as-caller', help='Execute as caller',
     ),
 ):
-    snowpark_package()
+    (pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
     snowpark_update(
         'procedure', environment, name, file, handler,
         input_parameters, return_type, replace, execute_as_caller,
@@ -132,8 +140,11 @@ def procedure_update(
 
 
 @app.command("package")
-def procedure_package():
-    snowpark_package()
+def procedure_package(
+    pypi_download: YesNoAskOptionsType = PyPiDownloadOption,
+    check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
+    package_native_libraries: YesNoAskOptionsType = PackageNativeLibrariesOption):
+    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
 
 
 @app.command("execute")

--- a/src/snowcli/cli/procedure.py
+++ b/src/snowcli/cli/procedure.py
@@ -24,6 +24,7 @@ EnvironmentOption = typer.Option(
     "dev", help='Environment name', callback=conf_callback, is_eager=True,
 )
 
+
 @app.command("init")
 def procedure_init():
     """
@@ -81,7 +82,11 @@ def procedure_create(
         False, '--execute-as-caller', help='Execute as caller',
     ),
 ):
-    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
+    snowpark_package(
+        pypi_download,  # type: ignore[arg-type]
+        check_anaconda_for_pypi_deps,
+        package_native_libraries,  # type: ignore[arg-type]
+    )
     snowpark_create(
         'procedure', environment, name, file, handler,
         input_parameters, return_type, overwrite, execute_as_caller,
@@ -132,7 +137,7 @@ def procedure_update(
         False, '--execute-as-caller', help='Execute as caller',
     ),
 ):
-    (pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
+    (pypi_download, check_anaconda_for_pypi_deps, package_native_libraries)
     snowpark_update(
         'procedure', environment, name, file, handler,
         input_parameters, return_type, replace, execute_as_caller,
@@ -143,8 +148,13 @@ def procedure_update(
 def procedure_package(
     pypi_download: str = PyPiDownloadOption,
     check_anaconda_for_pypi_deps: bool = CheckAnacondaForPyPiDependancies,
-    package_native_libraries: str = PackageNativeLibrariesOption):
-    snowpark_package(pypi_download,check_anaconda_for_pypi_deps,package_native_libraries)
+    package_native_libraries: str = PackageNativeLibrariesOption,
+):
+    snowpark_package(
+        pypi_download,  # type: ignore[arg-type]
+        check_anaconda_for_pypi_deps,
+        package_native_libraries,  # type: ignore[arg-type]
+    )
 
 
 @app.command("execute")

--- a/src/snowcli/cli/snowpark_shared.py
+++ b/src/snowcli/cli/snowpark_shared.py
@@ -10,25 +10,29 @@ from rich import print
 from snowcli import config
 from snowcli import utils
 from snowcli.config import AppConfig
-from snowcli.utils import YesNoAskOptionsType
-from snowcli.utils import yes_no_ask_callback
 from snowcli.utils import generate_deploy_stage_name
 from snowcli.utils import print_db_cursor
 from snowcli.utils import print_list_tuples
+from snowcli.utils import yes_no_ask_callback
+from snowcli.utils import YesNoAskOptionsType
 
 # common CLI options
 PyPiDownloadOption = typer.Option(
-    "ask", help='Download non-Anaconda packages from PyPi (yes/no/ask)', callback=yes_no_ask_callback,
+    "ask", help='Download non-Anaconda packages from PyPi (yes/no/ask)',
+    callback=yes_no_ask_callback,
 )
 PackageNativeLibrariesOption = typer.Option(
-    "ask", help='When using packages from PyPi, allow native libraries', callback=yes_no_ask_callback,
+    "ask", help='When using packages from PyPi, allow native libraries',
+    callback=yes_no_ask_callback,
 )
 CheckAnacondaForPyPiDependancies: bool = typer.Option(
     True,
     '--check-anaconda-for-pypi-deps',
     '-a',
-    help='When downloading missing Anaconda packages, check if any of their dependancies can be imported directly from Anaconda',
+    help="""When downloading missing Anaconda packages, check if any of
+    their dependancies can be imported directly from Anaconda""",
 )
+
 
 def snowpark_create(
     type: str,
@@ -44,8 +48,9 @@ def snowpark_create(
     env_conf = AppConfig().config.get(environment)
     if env_conf is None:
         print(
-            f"The {environment} environment is not configured in app.toml "
-            f"yet, please run `snow configure {environment}` first before continuing.",
+            f"""The {environment} environment is not configured in app.toml
+            yet, please run `snow configure {environment}` first before
+            continuing.""",
         )
         raise typer.Abort()
 
@@ -119,8 +124,9 @@ def snowpark_update(
     env_conf: dict = AppConfig().config.get(environment)  # type: ignore
     if env_conf is None:
         print(
-            f"The {environment} environment is not configured in app.toml yet, "
-            f"please run `snow configure {environment}` first before continuing.",
+            f"""The {environment} environment is not configured in app.toml
+            yet, please run `snow configure {environment}` first before
+            continuing.""",
         )
         raise typer.Abort()
     if config.isAuth():
@@ -245,9 +251,11 @@ def snowpark_update(
                 print('No packages to update. Deployment complete!')
 
 
-def snowpark_package(pypi_download: YesNoAskOptionsType,
-                    check_anaconda_for_pypi_dependencies: bool, 
-                    package_native_libraries: YesNoAskOptionsType):
+def snowpark_package(
+    pypi_download: YesNoAskOptionsType,
+    check_anaconda_for_pypi_dependencies: bool,
+    package_native_libraries: YesNoAskOptionsType,
+):
     print('Resolving any requirements from requirements.txt...')
     requirements = utils.parseRequirements()
     pack_dir: str = None  # type: ignore
@@ -266,20 +274,29 @@ def snowpark_package(pypi_download: YesNoAskOptionsType,
             do_download = click.confirm(
                 'Do you want to try to download non-Anaconda packages?',
                 default=True,
-            ) if pypi_download=='ask' else pypi_download=='yes'
+            ) if pypi_download == 'ask' else pypi_download == 'yes'
             if do_download:
                 print('Installing non-Anaconda packages...')
-                should_pack,second_chance_results = utils.installPackages('requirements.other.txt',check_anaconda_for_pypi_dependencies,package_native_libraries)
+                should_pack, second_chance_results = utils.installPackages(
+                    'requirements.other.txt',
+                    check_anaconda_for_pypi_dependencies,
+                    package_native_libraries,
+                )
                 if should_pack:
                     pack_dir = '.packages'
                     # add the Anaconda packages discovered as dependancies
                     if second_chance_results is not None:
-                        parsedRequirements['snowflake'] = parsedRequirements['snowflake'] + second_chance_results['snowflake']
-                
+                        parsedRequirements['snowflake'] = \
+                            parsedRequirements['snowflake'] + \
+                            second_chance_results['snowflake']
+
         # write requirements.snowflake.txt file
         if parsedRequirements['snowflake']:
             print('Writing requirements.snowflake.txt file...')
-            with open('requirements.snowflake.txt', 'w', encoding='utf-8') as f:
+            with open(
+                'requirements.snowflake.txt', 'w',
+                encoding='utf-8',
+            ) as f:
                 for package in parsedRequirements['snowflake']:
                     f.write(package + '\n')
         if pack_dir:

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -151,14 +151,9 @@ def installPackages(file_name: str,perform_anaconda_check:bool=True, package_nat
     second_chance_results = None
     if perform_anaconda_check:
         # it's not over just yet. a non-Anaconda package may have brought in a package available on Anaconda.
-        # We can pip freeze and do another pass over the resulting full requirements
-        os.system('pip freeze > requirements_deps.txt')
-        full_requirements = parseRequirements('requirements_deps.txt')
-        os.remove('requirements_deps.txt')
         # use each folder's METADATA file to determine its real name
         downloaded_packages = getDownloadedPackageNames()
         click.echo(f'Downloaded packages: {downloaded_packages.values()}')
-        click.echo(f'All requirements: {full_requirements}')
         # look for all the downloaded packages on the Anaconda channel
         second_chance_results = parseAnacondaPackages(downloaded_packages.keys())
         second_chance_snowflake_packages = second_chance_results['snowflake']

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -4,6 +4,8 @@ import glob
 import json
 import os
 import shutil
+import re
+from typing import List, Literal, Tuple
 
 import click
 import requests
@@ -13,6 +15,15 @@ from rich import print
 from rich.table import Table
 from snowcli.config import AppConfig
 from snowflake.connector.cursor import SnowflakeCursor
+
+YesNoAskOptions = ['yes,no,ask']
+YesNoAskOptionsType = Literal['yes,no,ask']
+def yes_no_ask_callback(value:str):
+    """
+    A typer callback to handle yes/no/ask parameters
+    """
+    if value not in YesNoAskOptions:
+        raise typer.BadParameter(f"Valid values: {YesNoAskOptions}. You provided: {value}")
 
 
 def getDeployNames(database, schema, name) -> dict:
@@ -35,14 +46,22 @@ def prepareAppZip(file_path, temp_dir) -> str:
     return temp_path
 
 
-def parseRequirements() -> list[str]:
+def parseRequirements(requirements_file:str='requirements.txt') -> list[str]:
+    """Reads and parses a python requirements.txt file.
+
+    Args:
+        requirements_file (str, optional): The name of the file. Defaults to 'requirements.txt'.
+
+    Returns:
+        list[str]: A flat list of package names, without versions
+    """
     reqs = []
-    if os.path.exists('requirements.txt'):
-        with open('requirements.txt') as f:
+    if os.path.exists(requirements_file):
+        with open(requirements_file, encoding='utf-8') as f:
             for req in requirements.parse(f):
                 reqs.append(req.name)
     else:
-        click.echo('No requirements.txt found')
+        click.echo(f'No {requirements_file} found')
 
     return reqs
 
@@ -60,7 +79,8 @@ def parseAnacondaPackages(packages: list[str]) -> dict:
     if response.status_code == 200:
         channel_data = response.json()
         for package in packages:
-            if package in channel_data['packages']:
+            # pip package names are case insensitive, Anaconda package names are lowercased
+            if package.lower() in channel_data['packages']:
                 snowflakePackages.append(
                     f'{package}',
                 )
@@ -74,26 +94,108 @@ def parseAnacondaPackages(packages: list[str]) -> dict:
         click.echo(f'Error: {response.status_code}')
         return {}
 
+def getDownloadedPackageNames() -> dict[str:str]:
+    """Returns a dict of official package names mapped to the files/folders
+    that belong to it under the .packages directory.
 
-def installPackages(file_name: str) -> bool:
+    Returns:
+        dict[str:str]: a dict of package folder names to package name
+    """
+    metadata_files = glob.glob('.packages/*dist-info/METADATA')
+    packages_full_path = os.path.abspath('.packages')
+    return_dict={}
+    for metadata_file in metadata_files:
+        parent_folder = os.path.dirname(metadata_file)
+        package_name = getPackageNameFromMetadata(metadata_file)
+        if package_name is not None:
+            # since we found a package name, we can now look at the RECORD file (a sibling of METADATA)
+            # to determine which files and folders that belong to it
+            record_file_path = os.path.join(parent_folder,'RECORD')
+            if os.path.exists(record_file_path):
+                # the RECORD file contains a list of files included in the package, get the unique 
+                # root folder names and delete them recursively
+                with open(record_file_path, encoding='utf-8') as record_file:
+                    # we want the part up until the first '/'. 
+                    # Sometimes it's a file with a trailing ",sha256=abcd....", so we trim that off too
+                    record_entries = list(set([line.split('/')[0].split(',')[0] for line in record_file.readlines()]))
+                    included_record_entries=[]
+                    for record_entry in record_entries:
+                        record_entry_full_path = os.path.abspath(os.path.join('.packages',record_entry))
+                        # it's possible for the RECORD file to contain relative paths to items outside of the packages folder.
+                        # We'll ignore those by asserting that the full packages path exists in the full path of each item.
+                        if os.path.exists(record_entry_full_path) and packages_full_path in record_entry_full_path:
+                            included_record_entries.append(record_entry)
+                    return_dict[package_name] = included_record_entries
+    return return_dict
+
+def getPackageNameFromMetadata(metadata_file_path:str) -> str:
+    """Loads a METADATA file from the dist-info directory of an installed
+    Python package, finds the name of the package.
+    This is found on a line containing "Name: my_package".
+
+    Args:
+        metadata_file_path (str): The path to the METADATA file
+
+    Returns:
+        str: the name of the package.
+    """
+    with open(metadata_file_path, encoding='utf-8') as metadata_file:
+        contents = metadata_file.read()
+        results = re.search('^Name: (.*)$',contents,flags=re.MULTILINE)
+        if results is None:
+            return None
+        return results.group(1)
+
+def installPackages(file_name: str,perform_anaconda_check:bool=True, package_native_libraries:YesNoAskOptionsType = 'ask') -> Tuple[bool,dict[str,List[str]]]:
     os.system(f'pip install -t .packages/ -r {file_name}')
+    second_chance_results = None
+    if perform_anaconda_check:
+        # it's not over just yet. a non-Anaconda package may have brought in a package available on Anaconda.
+        # We can pip freeze and do another pass over the resulting full requirements
+        os.system('pip freeze > requirements_deps.txt')
+        full_requirements = parseRequirements('requirements_deps.txt')
+        os.remove('requirements_deps.txt')
+        # use each folder's METADATA file to determine its real name
+        downloaded_packages = getDownloadedPackageNames()
+        click.echo(f'Downloaded packages: {downloaded_packages.values()}')
+        click.echo(f'All requirements: {full_requirements}')
+        # look for all the downloaded packages on the Anaconda channel
+        second_chance_results = parseAnacondaPackages(downloaded_packages.keys())
+        second_chance_snowflake_packages = second_chance_results['snowflake']
+        if len(second_chance_snowflake_packages) > 0:
+            click.echo('Good news! The following package dependencies can be imported directly from Anaconda, '+
+                        f'and will be excluded from the zip: {second_chance_snowflake_packages}')
+        else:
+            click.echo('None of the package dependencies were found on Anaconda')
+        downloaded_packages_not_needed = {k:v for k,v in downloaded_packages.items() if k in second_chance_snowflake_packages}
+        for package,items in downloaded_packages_not_needed.items():
+            click.echo(f"Package {package}: deleting {items}")
+            for item in items:
+                item_path = os.path.join('.packages',item)
+                if os.path.exists(item_path):
+                    if os.path.isdir(item_path):
+                        shutil.rmtree(item_path)
+                    else:
+                        os.remove(item_path)
+
     click.echo('Checking to see if packages have native libaries...\n')
     # use glob to see if any files in packages have a .so extension
     if glob.glob('.packages/**/*.so'):
         for path in glob.glob('.packages/**/*.so'):
             click.echo(f'Potential native library: {path}')
-        if click.confirm(
+        continue_installation = click.confirm(
             '\n\nWARNING! Some packages appear to have native libraries!\n'
             'Continue with package installation?',
             default=False,
-        ):
-            return True
+        ) if package_native_libraries=='ask' else package_native_libraries=='yes'
+        if continue_installation:
+            return True,second_chance_results
         else:
             shutil.rmtree('.packages')
-            return False
+            return False,second_chance_results
     else:
         click.echo('No native libraries found in packages (Good news!)...')
-        return True
+        return True,second_chance_results
 
 
 def recursiveZipPackagesDir(pack_dir: str, dest_zip: str) -> bool:
@@ -112,7 +214,7 @@ def standardZipDir(dest_zip: str) -> bool:
 
 def getSnowflakePackages() -> list[str]:
     if os.path.exists('requirements.snowflake.txt'):
-        with open('requirements.snowflake.txt') as f:
+        with open('requirements.snowflake.txt', encoding='utf-8') as f:
             return [line.strip() for line in f]
     else:
         return []
@@ -121,7 +223,7 @@ def getSnowflakePackages() -> list[str]:
 def getSnowflakePackagesDelta(anaconda_packages) -> list[str]:
     updatedPackageList = []
     if os.path.exists('requirements.snowflake.txt'):
-        with open('requirements.snowflake.txt') as f:
+        with open('requirements.snowflake.txt', encoding='utf-8') as f:
             # for each line, check if it exists in anaconda_packages. If it
             # doesn't, add it to the return string
             for line in f:


### PR DESCRIPTION
## Reason for the change

Currently snowcli can examine a requirements.txt file, identify which packages are available on Anaconda, and download the remainder from PyPi to include in the app.zip artefact.

All of the dependencies of those PyPi packages are included, because pip has no way of knowing that Anaconda could provide some packages to the Snowpark object.

So this change is aimed at providing a second chance at leveraging Anaconda for packages not directly listed in requirements.txt.

## What's included

This change adds a boolean parameter `--check-anaconda-for-pypi-deps` which performs an optional second Anaconda check over the full list of packages pip downloaded. This naturally only comes into effect if a pip install occurs. The default value is True which is a change in behaviour, I figured this is probably desirable and the project is still in concept phase.

It does this by:
1. Scanning the downloaded package files, determining their package names and list of files/folders included
2. Comparing the list of packages with the Anaconda channel
3. For all matches, add the Anaconda package to the snowpark packages list and delete the local files/folders before they are zipped up.

As part of the change, I added a couple of other parameters to prevent prompts from occurring during packaging. I did this mainly because I'm using parts of snowcli in another app and needed programmatic control.
- `--package-native-libraries` allows you to pre-answer 'yes' or 'no' to the question of native libraries. Defaults to 'ask' so that current behaviour continues.
- `--pypi-download` allows you to pre-answer 'yes' or 'no' to the question of downloading missing Anaconda libraries from PyPi. . Defaults to 'ask' so that current behaviour continues.

## Alternate approaches

I could have leaned more on pip to find out about the dependant packages, maybe via a wrapper library like [johnnydep](https://pypi.org/project/johnnydep/). For example, you could pip freeze, filter the resulting requirements file, then purge/reinstall without dependencies.

However, I didn't want to risk interfering with snowcli itself by removing actual packages. By parsing the package metadata directly, it's more easily confined to the .packages folder.