### PR TITLE
Fix up streamlit deploy URLs

### DIFF
--- a/src/snowcli/cli/streamlit.py
+++ b/src/snowcli/cli/streamlit.py
@@ -109,7 +109,7 @@ def streamlit_deploy(
         schema = env_conf.get('schema')
         role = env_conf.get('role')
         database = env_conf.get('database')
-        result = config.snowflake_connection.deployStreamlit(
+        config.snowflake_connection.deployStreamlit(
             name=name, file_path=str(file), stage_path='/',
             role=role, database=database,
             schema=schema,

--- a/src/snowcli/cli/streamlit.py
+++ b/src/snowcli/cli/streamlit.py
@@ -130,8 +130,10 @@ def streamlit_deploy(
 
         snowflake_host = env_conf.get('snowflake_host', 'app.snowflake.com')
         uppercased_dsn = f"{database}.{schema}.{name}".upper()
-        url = (f"https://{snowflake_host}/{deployment}/{account_name}/"
-               f"#/streamlit-apps/{uppercased_dsn}")
+        url = (
+            f"https://{snowflake_host}/{deployment}/{account_name}/"
+            f"#/streamlit-apps/{uppercased_dsn}"
+        )
 
         if open_:
             typer.launch(url)

--- a/src/snowcli/config.py
+++ b/src/snowcli/config.py
@@ -40,7 +40,8 @@ def connectToSnowflake():
     cfg = AppConfig()
     snowsql_config = SnowsqlConfig(path=cfg.config.get('snowsql_config_path'))
     snowflake_connection = SnowflakeConnector(
-            snowsql_config, cfg.config.get('snowsql_connection_name'))
+        snowsql_config, cfg.config.get('snowsql_connection_name'),
+    )
 
 
 def isAuth():

--- a/src/snowcli/config.py
+++ b/src/snowcli/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 import toml
 from snowcli.snow_connector import SnowflakeConnector
+from snowcli.snowsql_config import SnowsqlConfig
 
 snowflake_connection: SnowflakeConnector
 
@@ -37,11 +38,9 @@ class AppConfig():
 def connectToSnowflake():
     global snowflake_connection
     cfg = AppConfig()
-    snowflake_connection = SnowflakeConnector.fromConfig(
-        cfg.config.get('snowsql_config_path'), cfg.config.get(
-            'snowsql_connection_name',
-        ),
-    )
+    snowsql_config = SnowsqlConfig(path=cfg.config.get('snowsql_config_path'))
+    snowflake_connection = SnowflakeConnector(
+            snowsql_config, cfg.config.get('snowsql_connection_name'))
 
 
 def isAuth():

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -10,24 +10,18 @@ from snowflake.connector.cursor import SnowflakeCursor
 
 
 class SnowflakeConnector():
-    def __init__(self, *args):
-        if len(args) == 3:
-            self.ctx = snowflake.connector.connect(
-                user=args[1],
-                password=args[2],
-                account=args[0],
-            )
-        elif len(args) == 1:
-            config: dict = args[0]
-            config["application"] = "SNOWCLI"
-            self.ctx = snowflake.connector.connect(**config)
+    """Initialize a connection from a snowsql-formatted config"""
+    def __init__(self, snowsql_config: SnowsqlConfig, connection_name: str):
+        self.snowsql_config = snowsql_config
+        self.connection_name = connection_name
+        self.connection_config: dict = snowsql_config.get_connection(
+                connection_name)
+        self.connection_config["application"] = "SNOWCLI"
+        self.ctx = snowflake.connector.connect(**self.connection_config)
         self.cs = self.ctx.cursor()
 
-    """Initialize a connection from a snowsql-formatted config"""
-    @classmethod
-    def fromConfig(cls, path, connection_name):
-        config = SnowsqlConfig(path)
-        return cls(config.get_connection(connection_name))
+    def __del__(self):
+        self.cs.close
 
     def getVersion(self):
         self.cs.execute('SELECT current_version()')
@@ -347,7 +341,7 @@ class SnowflakeConnector():
         schema,
         overwrite,
     ):
-        self.uploadFileToStage(
+        return self.uploadFileToStage(
             file_path,
             f"{name}_stage",
             stage_path,
@@ -355,14 +349,6 @@ class SnowflakeConnector():
             database,
             schema,
             overwrite,
-        )
-        return self.runSql(
-            "get_streamlit_url", {
-                "name": name,
-                "role": role,
-                "database": database,
-                "schema": schema,
-            },
         )
 
     def describeStreamlit(self, name, database, schema, role, warehouse):

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -21,7 +21,8 @@ class SnowflakeConnector():
         self.cs = self.ctx.cursor()
 
     def __del__(self):
-        self.cs.close
+        self.cs.close()
+        self.ctx.close()
 
     def getVersion(self):
         self.cs.execute('SELECT current_version()')

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -11,11 +11,13 @@ from snowflake.connector.cursor import SnowflakeCursor
 
 class SnowflakeConnector():
     """Initialize a connection from a snowsql-formatted config"""
+
     def __init__(self, snowsql_config: SnowsqlConfig, connection_name: str):
         self.snowsql_config = snowsql_config
         self.connection_name = connection_name
         self.connection_config: dict = snowsql_config.get_connection(
-                connection_name)
+            connection_name,
+        )
         self.connection_config["application"] = "SNOWCLI"
         self.ctx = snowflake.connector.connect(**self.connection_config)
         self.cs = self.ctx.cursor()


### PR DESCRIPTION
This "generates" the appropriate Streamlit URLs based on available information.

In pre-prod envs, you'll need to set `snowflake_host` in your app.toml.

Also - I think I managed the fix all the segfaults by defining a destructor for the `SnowflakeConnector` class that closes the connection and cursor.