### PR TITLE
Fix bug in option validator causing PyPi download preference to be ignored

### DIFF
--- a/src/snowcli/__about__.py
+++ b/src/snowcli/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-VERSION = "0.1.9"
+VERSION = "0.1.10"

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -28,6 +28,7 @@ def yes_no_ask_callback(value: str):
         raise typer.BadParameter(
             f"Valid values: {YesNoAskOptions}. You provided: {value}",
         )
+    return value
 
 
 def getDeployNames(database, schema, name) -> dict:


### PR DESCRIPTION
As raised in #51, the pypi download cli parameter does not appear to work correctly.

This is due to a bug in the callback function which validates its value, by failing to return a value it causes the pypi downloads to be skipped.

I've tested all variations of the yes/no/ask parameters and all work as expected after this fix. 