### PR TITLE
Use filename when creating streamlit app, not full path

### DIFF
--- a/src/snowcli/cli/streamlit.py
+++ b/src/snowcli/cli/streamlit.py
@@ -79,7 +79,7 @@ def streamlit_create(
             role=env_conf.get('role'),
             warehouse=env_conf.get('warehouse'),
             name=name,
-            file=str(file),
+            file=file.name,
         )
         print_db_cursor(results)
 


### PR DESCRIPTION
Fixes #54 

This makes `streamlit create --file relative/path.py` work the same as `streamlit deploy --file relative/path.py`, so that they both only look at the filename `path.py`.

Previously, `streamlit deploy` would create the file `path.py` in the new stage, but `streamlit create` would create a streamlit app that was expecting a path to be located at `relative/path.py`