### PR TITLE
Add overwrite and parallel arguments to put_stage command

### DIFF
--- a/src/snowcli/cli/stage.py
+++ b/src/snowcli/cli/stage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import typer
+
 from snowcli import config
 from snowcli.config import AppConfig
 from snowcli.utils import print_db_cursor
@@ -85,9 +86,17 @@ def stage_put(
         dir_okay=True,
         writable=True,
         resolve_path=True,
-        help="Directory location to store downloaded files",
+        help="File or directory to upload to stage",
     ),
     name: str = typer.Argument(..., help="Stage name"),
+    overwrite: bool = typer.Option(
+        False,
+        help="Overwrite existing files in stage",
+    ),
+    parallel: int = typer.Option(
+        4,
+        help="Number of parallel threads to use for upload",
+    ),
 ):
     """
     Upload files to a stage from a local client
@@ -107,5 +116,7 @@ def stage_put(
             warehouse=env_conf.get("warehouse"),
             name=name,
             path=str(filepath),
+            overwrite=overwrite,
+            parallel=parallel,
         )
         print_db_cursor(results)

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -5,8 +5,9 @@ import pkgutil
 from io import StringIO
 
 import snowflake.connector
-from snowcli.snowsql_config import SnowsqlConfig
 from snowflake.connector.cursor import SnowflakeCursor
+
+from snowcli.snowsql_config import SnowsqlConfig
 
 
 class SnowflakeConnector:
@@ -300,6 +301,8 @@ class SnowflakeConnector:
         warehouse,
         name,
         path,
+        overwrite: bool = False,
+        parallel: int = 4,
     ) -> SnowflakeCursor:
         return self.runSql(
             "put_stage",
@@ -310,6 +313,8 @@ class SnowflakeConnector:
                 "warehouse": warehouse,
                 "name": name,
                 "path": path,
+                "overwrite": overwrite,
+                "parallel": parallel,
             },
         )
 

--- a/src/snowcli/sql/put_stage.sql
+++ b/src/snowcli/sql/put_stage.sql
@@ -3,4 +3,4 @@ use warehouse {warehouse};
 use database {database};
 use schema {schema};
 
-put file://{path} @{name} auto_compress=false;
+put file://{path} @{name} auto_compress=false parallel={parallel} overwrite={overwrite};


### PR DESCRIPTION
```
(python-3.10.3) ➜  snowcli git:(add-put-args) ✗ snow stage put test.txt sis_metrics_read_example_stage --no-overwrite
┏━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ source   ┃ target   ┃ source_size ┃ target_size ┃ source_compression ┃ target_compression ┃ status  ┃ message ┃
┡━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ test.txt │ test.txt │ 0           │ 0           │ NONE               │ NONE               │ SKIPPED │         │
└──────────┴──────────┴─────────────┴─────────────┴────────────────────┴────────────────────┴─────────┴─────────┘
(python-3.10.3) ➜  snowcli git:(add-put-args) ✗ snow stage put test.txt sis_metrics_read_example_stage --overwrite   
┏━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ source   ┃ target   ┃ source_size ┃ target_size ┃ source_compression ┃ target_compression ┃ status   ┃ message ┃
┡━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ test.txt │ test.txt │ 0           │ 16          │ NONE               │ NONE               │ UPLOADED │         │
└──────────┴──────────┴─────────────┴─────────────┴────────────────────┴────────────────────┴──────────┴─────────┘
(python-3.10.3) ➜  snowcli git:(add-put-args) ✗ snow stage put test.txt sis_metrics_read_example_stage            
┏━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ source   ┃ target   ┃ source_size ┃ target_size ┃ source_compression ┃ target_compression ┃ status  ┃ message ┃
┡━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ test.txt │ test.txt │ 0           │ 0           │ NONE               │ NONE               │ SKIPPED │         │
└──────────┴──────────┴─────────────┴─────────────┴────────────────────┴────────────────────┴─────────┴─────────┘
```