### PR TITLE
Fix "Create Function Failure" by ensuring role is set prior to db/schema setting

### DIFF
--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -111,8 +111,8 @@ class SnowflakeConnector:
         schema,
         overwrite,
     ):
-        self.cs.execute(f"use database {database}")
         self.cs.execute(f"use role {role}")
+        self.cs.execute(f"use database {database}")
         self.cs.execute(f"use schema {schema}")
         self.cs.execute(
             f"create stage if not exists {destination_stage} "


### PR DESCRIPTION
When create a function with snowcli, it fails with the following stacktrace

```
 /opt/homebrew/Cellar/snowcli/0.1.14/libexec/lib/python3.10/site-packages/snowcli/snow_connector. │
│ py:114 in uploadFileToStage                                                                      │
│                                                                                                  │
│   111 │   │   schema,                                                                            │
│   112 │   │   overwrite,                                                                         │
│   113 │   ):                                                                                     │
│ ❱ 114 │   │   self.cs.execute(f"use database {database}")                                        │
│   115 │   │   self.cs.execute(f"use role {role}")                                                │
│   116 │   │   self.cs.execute(f"use schema {schema}")                                            │
│   117 │   │   self.cs.execute(                                                                   │
│                                                                                                  │
│ ╭────────────────────────────────────────── locals ──────────────────────────────────────────╮   │
│ │          database = 'INFERENCE_CONTAINER_DB'                                               │   │
│ │ destination_stage = 'INFERENCE_CONTAINER_DB.INFERENCE_CONTAINER_SCHEMA.deployments'        │   │
│ │         file_path = '/var/folders/5y/jyk6xhv575vb9dq1h8s5b0140000gn/T/tmph50hptrm/app.zip' │   │
│ │         overwrite = False                                                                  │   │
│ │              path = '/hellofunction'                                                       │   │
│ │              role = 'sysadmin'                                                             │   │
│ │            schema = 'INFERENCE_CONTAINER_SCHEMA'                                           │   │
│ │              self = <snowcli.snow_connector.SnowflakeConnector object at 0x1202c3070>      │   │
│ ╰────────────────────────────────────────────────────────────────────────────────────────────╯

ProgrammingError: 002043 (02000): SQL compilation error:
Object does not exist, or operation cannot be performed.
```
By looking into this issue, it appears that role needs to be set first in order for the db object to be accessible, hence this diff. 