### PR TITLE
Add role usage to create and describe streamlits

### DIFF
--- a/src/snowcli/sql/create_streamlit.sql
+++ b/src/snowcli/sql/create_streamlit.sql
@@ -1,3 +1,4 @@
+use role {role};
 use database {database};
 use schema {schema};
 use warehouse {warehouse};

--- a/src/snowcli/sql/describe_streamlit.sql
+++ b/src/snowcli/sql/describe_streamlit.sql
@@ -1,3 +1,4 @@
+use role {role};
 use database {database};
 use schema {schema};
 use warehouse {warehouse};


### PR DESCRIPTION
Create Streamlit and Describe Streamlit are currently failing because no role is used in the SQL command even though it is passed in the python functions. 