### PR TITLE
Linting and sorting imports with Ruff's `isort` tool.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: 'v0.0.217'
     hooks:
         - id: ruff
+          args: [--fix]
   -   repo: https://github.com/asottile/pyupgrade
       rev: v3.2.2
       hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,9 @@ packages = ["src/snowcli", "src/templates"]
 
 [tool.ruff]
 line-length = 88
+select = [
+    # Pyflakes
+    "F",
+    # isort
+    "I001"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ packages = ["src/snowcli", "src/templates"]
 [tool.ruff]
 line-length = 88
 select = [
-    # Pyflakes
-    "F",
     # isort
     "I001"
 ]

--- a/src/snowcli/cli/connection.py
+++ b/src/snowcli/cli/connection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import typer
 from rich import print
 from rich.table import Table
+
 from snowcli.config import AppConfig
 from snowcli.snowsql_config import SnowsqlConfig
 

--- a/src/snowcli/cli/function.py
+++ b/src/snowcli/cli/function.py
@@ -7,16 +7,19 @@ from shutil import copytree
 
 import pkg_resources
 import typer
-from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
-from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
-from snowcli.cli.snowpark_shared import PyPiDownloadOption
-from snowcli.cli.snowpark_shared import snowpark_create
-from snowcli.cli.snowpark_shared import snowpark_describe
-from snowcli.cli.snowpark_shared import snowpark_drop
-from snowcli.cli.snowpark_shared import snowpark_execute
-from snowcli.cli.snowpark_shared import snowpark_list
-from snowcli.cli.snowpark_shared import snowpark_package
-from snowcli.cli.snowpark_shared import snowpark_update
+
+from snowcli.cli.snowpark_shared import (
+    CheckAnacondaForPyPiDependancies,
+    PackageNativeLibrariesOption,
+    PyPiDownloadOption,
+    snowpark_create,
+    snowpark_describe,
+    snowpark_drop,
+    snowpark_execute,
+    snowpark_list,
+    snowpark_package,
+    snowpark_update,
+)
 from snowcli.utils import conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})

--- a/src/snowcli/cli/procedure.py
+++ b/src/snowcli/cli/procedure.py
@@ -7,16 +7,19 @@ from shutil import copytree
 
 import pkg_resources
 import typer
-from snowcli.cli.snowpark_shared import CheckAnacondaForPyPiDependancies
-from snowcli.cli.snowpark_shared import PackageNativeLibrariesOption
-from snowcli.cli.snowpark_shared import PyPiDownloadOption
-from snowcli.cli.snowpark_shared import snowpark_create
-from snowcli.cli.snowpark_shared import snowpark_describe
-from snowcli.cli.snowpark_shared import snowpark_drop
-from snowcli.cli.snowpark_shared import snowpark_execute
-from snowcli.cli.snowpark_shared import snowpark_list
-from snowcli.cli.snowpark_shared import snowpark_package
-from snowcli.cli.snowpark_shared import snowpark_update
+
+from snowcli.cli.snowpark_shared import (
+    CheckAnacondaForPyPiDependancies,
+    PackageNativeLibrariesOption,
+    PyPiDownloadOption,
+    snowpark_create,
+    snowpark_describe,
+    snowpark_drop,
+    snowpark_execute,
+    snowpark_list,
+    snowpark_package,
+    snowpark_update,
+)
 from snowcli.utils import conf_callback
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})

--- a/src/snowcli/cli/snowpark_shared.py
+++ b/src/snowcli/cli/snowpark_shared.py
@@ -7,14 +7,16 @@ from pathlib import Path
 import click
 import typer
 from rich import print
-from snowcli import config
-from snowcli import utils
+
+from snowcli import config, utils
 from snowcli.config import AppConfig
-from snowcli.utils import generate_deploy_stage_name
-from snowcli.utils import print_db_cursor
-from snowcli.utils import print_list_tuples
-from snowcli.utils import yes_no_ask_callback
-from snowcli.utils import YesNoAskOptionsType
+from snowcli.utils import (
+    YesNoAskOptionsType,
+    generate_deploy_stage_name,
+    print_db_cursor,
+    print_list_tuples,
+    yes_no_ask_callback,
+)
 
 # common CLI options
 PyPiDownloadOption = typer.Option(

--- a/src/snowcli/cli/warehouse.py
+++ b/src/snowcli/cli/warehouse.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import typer
+
 from snowcli import config
 from snowcli.config import AppConfig
 from snowcli.utils import print_db_cursor

--- a/src/snowcli/config.py
+++ b/src/snowcli/config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 import toml
+
 from snowcli.snow_connector import SnowflakeConnector
 from snowcli.snowsql_config import SnowsqlConfig
 

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -13,8 +13,9 @@ import requirements
 import typer
 from rich import print
 from rich.table import Table
-from snowcli.config import AppConfig
 from snowflake.connector.cursor import SnowflakeCursor
+
+from snowcli.config import AppConfig
 
 YesNoAskOptions = ["yes", "no", "ask"]
 YesNoAskOptionsType = Literal["yes", "no", "ask"]


### PR DESCRIPTION
#59 added linting with ruff via a pre-commit hook. This PR:
1. Adds the ability for ruff to automatically sort imports in `.py` files and modules via ruff's `isort` plugin, and uses ruff's `pyflakes` tool to detect errors.
2. Runs ruff on the codebase to sort imports.