### PR TITLE
Fix stage name case since quotes are now added

### DIFF
--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -500,7 +500,7 @@ class SnowflakeConnector:
         drop_stage: bool = True,
     ) -> SnowflakeCursor:
 
-        drop_command = f'drop stage "{name}_stage";' if drop_stage else ""
+        drop_command = f'drop stage "{name}_STAGE";' if drop_stage else ""
 
         return self.runSql(
             "drop_streamlit",


### PR DESCRIPTION
Without the quotes it seems it automatically upper-cased the stage name, but with the quotes it doesn't, causing "does not exist" errors.