### PR TITLE
Fix for bug #53 handling parameters with optional parameters

### DIFF
--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -600,4 +600,6 @@ class SnowflakeConnector:
             raise (e)
 
     def generate_signature_from_params(self, params: str) -> str:
-        return "(" + " ".join(params.strip("()").split()[1::2]) + ")"
+        if params == "()":
+            return "()"
+        return "(" + " ".join(params.split()[1::2])


### PR DESCRIPTION
Test case for the fix:

```
params = ['(temp_f number(35,4))','(testparam1 varchar)','(testparam2 varchar(255))','(testparam3 varchar(1), testparam4 varchar)','(testparam5 varchar, testparam6 varchar(1))','()']
for param in params:
    print('Test ' + param)
    if param == "()":
        print('New: ' + param)
    else:
        print('New: (' + ' '.join(param.split(' ')[1::2]))
    print('Old: (' + ' '.join(param.strip("()").split()[1::2]) + ')')
    print()
```
Output of test:

```
Test (temp_f number(35,4))
New: (number(35,4))
Old: (number(35,4)

Test (testparam1 varchar)
New: (varchar)
Old: (varchar)

Test (testparam2 varchar(255))
New: (varchar(255))
Old: (varchar(255)

Test (testparam3 varchar(1), testparam4 varchar)
New: (varchar(1), varchar)
Old: (varchar(1), varchar)

Test (testparam5 varchar, testparam6 varchar(1))
New: (varchar, varchar(1))
Old: (varchar, varchar(1)

Test ()
New: ()
Old: ()
```
I spent time mulling over this exact problem to be able to handle exporting Snowflake objects here: https://github.com/thomaseibner/snowflake-provisioning/blob/main/sf_export
