### PR TITLE
snow packages improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v4.1.0
     hooks:
       - id: trailing-whitespace
+        exclude: tests/
       - id: end-of-file-fixer
         exclude: license_header.txt
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,25 @@
 repos:
-  -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.1.0
-      hooks:
-        -   id: trailing-whitespace
-        -   id: end-of-file-fixer
-            exclude: license_header.txt
-        -   id: check-yaml
-            exclude: .github/repo_meta.yaml
-        -   id: debug-statements
-        -   id: check-ast
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.217'
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
     hooks:
-        - id: ruff
-          args: [--fix]
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+        exclude: license_header.txt
+      - id: check-yaml
+        exclude: .github/repo_meta.yaml
+      - id: debug-statements
+      - id: check-ast
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.217"
+    hooks:
+      - id: ruff
+        args: [--fix, --exclude, "**/tests/"]
   - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
-  -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.990
-      hooks:
-      -   id: mypy
-          additional_dependencies: [types-all]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.990
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-all]

--- a/src/snowcli/__about__.py
+++ b/src/snowcli/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-VERSION = "0.2.2"
+VERSION = "0.2.3"

--- a/src/snowcli/cli/package.py
+++ b/src/snowcli/cli/package.py
@@ -31,9 +31,9 @@ def package_lookup(
     ## if list has any items
 
     if len(packageResponse["snowflake"]) > 0:
-        print(f"Package {name} is available on the Snowflake anaconda channel.")
+        click.echo(f"Package {name} is available on the Snowflake anaconda channel.")
         if run_nested:
-            print(
+            click.echo(
                 f"No need to create a package. Just include in your `packages` declaration."
             )
     else:
@@ -52,7 +52,7 @@ def package_lookup(
             if not run_nested and os.path.exists(".packages"):
                 rmtree(".packages")
             if packages_string is not None:
-                print("\n\n" + packages_string)
+                click.echo("\n\n" + packages_string)
             if run_nested and packages_string is not None:
                 return packages_string
 
@@ -71,11 +71,11 @@ def package_create(
     if os.path.exists(".packages"):
         utils.recursiveZipPackagesDir(".packages", name + ".zip")
         rmtree(".packages")
-        print(
+        click.echo(
             f"\n\nPackage {name}.zip created. You can now upload it to a stage (`snow package upload -f {name}.zip -s packages`) and reference it in your procedure or function."
         )
         if results_string is not None:
-            print("\n" + results_string)
+            click.echo("\n" + results_string)
 
 
 @app.command("upload")
@@ -106,13 +106,14 @@ def package_upload(
     """
     env_conf = AppConfig().config.get(environment)
     if env_conf is None:
-        print(
+        click.echo(
             f"The {environment} environment is not configured in app.toml "
             "yet, please run `snow configure` first before continuing.",
         )
         raise typer.Abort()
     if config.isAuth():
         config.connectToSnowflake()
+        click.echo(f"Uploading {file} to Snowflake @{stage}/{file}...")
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_app_zip_path = utils.prepareAppZip(file, temp_dir)
             deploy_response = config.snowflake_connection.uploadFileToStage(
@@ -124,8 +125,8 @@ def package_upload(
                 overwrite=overwrite,
                 role=env_conf["role"],
             )
-        print(f"Package {file} {deploy_response[6]} to Snowflake @{stage}/{file}.")
+        click.echo(f"Package {file} {deploy_response[6]} to Snowflake @{stage}/{file}.")
         if deploy_response[6] == "SKIPPED":
-            print(
+            click.echo(
                 "Package already exists on stage. Consider using --overwrite to overwrite the file."
             )

--- a/src/snowcli/cli/package.py
+++ b/src/snowcli/cli/package.py
@@ -12,7 +12,10 @@ import typer
 from snowcli import config, utils
 from snowcli.config import AppConfig
 
-app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
+app = typer.Typer(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Manage custom Python packages for Snowpark",
+)
 EnvironmentOption = typer.Option("dev", help="Environment name")
 
 
@@ -22,7 +25,13 @@ def package_lookup(
         ...,
         help="Name of the package",
     ),
-    run_nested: bool = False,
+    install_packages: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Install packages that are not available on the Snowflake anaconda channel",
+    ),
+    _run_nested: bool = False,
 ):
     """
     Check to see if a package is available on the Snowflake anaconda channel.
@@ -32,16 +41,17 @@ def package_lookup(
 
     if len(packageResponse["snowflake"]) > 0:
         click.echo(f"Package {name} is available on the Snowflake anaconda channel.")
-        if run_nested:
+        if _run_nested:
             click.echo(
                 f"No need to create a package. Just include in your `packages` declaration."
             )
     else:
-        check_if_native = click.confirm(
-            "The package is not in Anaconda. Do you want to try to see if it's supported as a custom package (requires pip)?",
-            default=True,
-        )
-        if check_if_native:
+        if not install_packages:
+            install_packages = click.confirm(
+                "The package is not in Anaconda. Do you want to try to see if it's supported as a custom package (requires pip)?",
+                default=True,
+            )
+        if install_packages:
             packages_string = None
             status, results = utils.installPackages(
                 perform_anaconda_check=True, package_name=name, file_name=None
@@ -49,11 +59,11 @@ def package_lookup(
             if status and results is not None and len(results["snowflake"]) > 0:
                 packages_string = f"The package {name} is supported, but does depend on the following Snowflake supported native libraries you should include the following in your packages: {results['snowflake']}"
             # if .packages subfolder exists, delete it
-            if not run_nested and os.path.exists(".packages"):
+            if not _run_nested and os.path.exists(".packages"):
                 rmtree(".packages")
             if packages_string is not None:
                 click.echo("\n\n" + packages_string)
-            if run_nested and packages_string is not None:
+            if _run_nested and packages_string is not None:
                 return packages_string
 
 
@@ -62,12 +72,18 @@ def package_create(
     name: str = typer.Argument(
         ...,
         help="Name of the package",
-    )
+    ),
+    install_packages: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Install packages that are not available on the Snowflake anaconda channel",
+    ),
 ):
     """
     Create a python package as a zip file that can be uploaded to a stage and imported for a Snowpark python app.
     """
-    results_string = package_lookup(name, run_nested=True)
+    results_string = package_lookup(name, install_packages, _run_nested=True)
     if os.path.exists(".packages"):
         utils.recursiveZipPackagesDir(".packages", name + ".zip")
         rmtree(".packages")

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -28,6 +28,8 @@ warnings.filterwarnings("ignore", category=UserWarning)
 YesNoAskOptions = ["yes", "no", "ask"]
 YesNoAskOptionsType = Literal["yes", "no", "ask"]
 
+PIP_PATH = os.environ.get("SNOWCLI_PIP_PATH", "pip")
+
 
 def yes_no_ask_callback(value: str):
     """
@@ -242,25 +244,39 @@ def installPackages(
 ) -> tuple[bool, dict[str, list[str]] | None]:
     pip_install_result = None
     if file_name is not None:
-        process = subprocess.Popen(
-            ["pip", "install", "-t", ".packages/", "-r", file_name],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-        )
-        for line in process.stdout:  # type: ignore
-            click.echo(line.strip())
-        process.wait()
-        pip_install_result = process.returncode
+        try:
+            process = subprocess.Popen(
+                [PIP_PATH, "install", "-t", ".packages/", "-r", file_name],
+                stdout=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            for line in process.stdout:  # type: ignore
+                click.echo(line.strip())
+            process.wait()
+            pip_install_result = process.returncode
+        except FileNotFoundError:
+            click.echo(
+                "pip not found. Please install pip and try again.",
+                err=True,
+            )
+            return False, None
     if package_name is not None:
-        process = subprocess.Popen(
-            ["pip", "install", "-t", ".packages/", package_name],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-        )
-        for line in process.stdout:  # type: ignore
-            click.echo(line.strip())
-        process.wait()
-        pip_install_result = process.returncode
+        try:
+            process = subprocess.Popen(
+                [PIP_PATH, "install", "-t", ".packages/", package_name],
+                stdout=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            for line in process.stdout:  # type: ignore
+                click.echo(line.strip())
+            process.wait()
+            pip_install_result = process.returncode
+        except FileNotFoundError:
+            click.echo(
+                "\n\npip not found. Please install pip and try again.\nHINT: you can also set the environment variable 'SNOWCLI_PIP_PATH' to the path of pip.",
+                err=True,
+            )
+            return False, None
 
     if pip_install_result is not None and pip_install_result != 0:
         print(

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -256,7 +256,7 @@ def installPackages(
             pip_install_result = process.returncode
         except FileNotFoundError:
             click.echo(
-                "pip not found. Please install pip and try again.",
+                "\n\npip not found. Please install pip and try again.\nHINT: you can also set the environment variable 'SNOWCLI_PIP_PATH' to the path of pip.",
                 err=True,
             )
             return False, None

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -27,7 +27,7 @@ def test_render_js_proc(runner):
     assert (
         result.stdout_bytes.decode()
         == """\
-CREATE PROCEDURE
+CREATE PROCEDURE 
 var module = {};
 var exports = {};
 module.exports = exports;
@@ -82,7 +82,7 @@ def test_render_metadata(runner):
     assert (
         result.stdout_bytes.decode()
         == """\
-CREATE OR REPLACE PROCEDURE APP.PYTHON_HELLO(
+CREATE OR REPLACE PROCEDURE APP.PYTHON_HELLO(    
 ARG1 STRING
 )
 RETURNS STRING

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -79,7 +79,6 @@ def test_render_metadata(runner):
         result = runner.invoke(["render", "template", tmp_file.name])
 
     assert result.exit_code == 0
-    print(result.stdout_bytes.decode())
     assert (
         result.stdout_bytes.decode()
         == """\


### PR DESCRIPTION
- Allow `-y` or `--yes` to install packages without prompt
- Use `subprocess` instead of `os.system()` so I can correctly catch errors when pip exits and return code
- Allow users to specify the path to pip if not found. This is helpful if `pip` doesn't exist because it's `pip3` or something