### PR TITLE
Add simple sql command allowing to execute any query from cli

### DIFF
--- a/src/snowcli/cli/__init__.py
+++ b/src/snowcli/cli/__init__.py
@@ -15,6 +15,7 @@ from . import (
     package,
     procedure,
     render,
+    sql,
     stage,
     streamlit,
     warehouse,
@@ -146,7 +147,8 @@ app.add_typer(connection.app, name="connection")
 app.add_typer(warehouse.app, name="warehouse")
 app.add_typer(stage.app, name="stage")
 app.add_typer(package.app, name="package")
-app.add_typer(render.app, name="render", hidden=True)
+app.add_typer(render.app, name="render")
+app.command("sql")(sql.execute_sql)
 
 
 if __name__ == "__main__":

--- a/src/snowcli/cli/snowpark_shared.py
+++ b/src/snowcli/cli/snowpark_shared.py
@@ -51,13 +51,7 @@ def snowpark_create(
     install_coverage_wrapper: bool = False,
 ):
     env_conf = AppConfig().config.get(environment)
-    if env_conf is None:
-        print(
-            f"""The {environment} environment is not configured in app.toml
-            yet, please run `snow configure -e {environment}` first before
-            continuing.""",
-        )
-        raise typer.Abort()
+    validate_configuration(env_conf, environment)
     if type == "function" and install_coverage_wrapper:
         print(
             """You cannot install a code coverage wrapper on a function, only a procedure."""
@@ -136,6 +130,16 @@ def snowpark_create(
         print_list_tuples(results)
 
 
+def validate_configuration(env_conf, environment):
+    if env_conf is None:
+        print(
+            f"""The {environment} environment is not configured in app.toml
+            yet, please run `snow configure -e {environment}` first before
+            continuing.""",
+        )
+        raise typer.Abort()
+
+
 def snowpark_update(
     type: str,
     environment: str,
@@ -149,13 +153,7 @@ def snowpark_update(
     install_coverage_wrapper: bool = False,
 ) -> None:
     env_conf: dict = AppConfig().config.get(environment)  # type: ignore
-    if env_conf is None:
-        print(
-            f"""The {environment} environment is not configured in app.toml
-            yet, please run `snow configure {environment}` first before
-            continuing.""",
-        )
-        raise typer.Abort()
+    validate_configuration(env_conf, environment)
     if type == "function" and install_coverage_wrapper:
         print(
             """You cannot install a code coverage wrapper on a function, only a procedure."""
@@ -395,12 +393,7 @@ def snowpark_package(
 
 def snowpark_execute(type: str, environment: str, select: str):
     env_conf = AppConfig().config.get(environment)
-    if env_conf is None:
-        print(
-            f"The {environment} environment is not configured in app.toml "
-            "yet, please run `snow configure -e dev` first before continuing.",
-        )
-        raise typer.Abort()
+    validate_configuration(env_conf, environment)
     if config.isAuth():
         config.connectToSnowflake()
         if type == "function":
@@ -432,12 +425,7 @@ def snowpark_describe(
     signature: str,
 ):
     env_conf = AppConfig().config.get(environment)
-    if env_conf is None:
-        print(
-            "The {environment} environment is not configured in app.toml yet, "
-            "please run `snow configure -e dev` first before continuing.",
-        )
-        raise typer.Abort()
+    validate_configuration(env_conf, environment)
 
     if config.isAuth():
         config.connectToSnowflake()
@@ -476,12 +464,7 @@ def snowpark_describe(
 
 def snowpark_list(type, environment, like):
     env_conf = AppConfig().config.get(environment)
-    if env_conf is None:
-        print(
-            f"The {environment} environment is not configured in app.toml "
-            f"yet, please run `snow configure -e dev` first before continuing.",
-        )
-        raise typer.Abort()
+    validate_configuration(env_conf, environment)
     if config.isAuth():
         config.connectToSnowflake()
         if type == "function":
@@ -513,12 +496,7 @@ def snowpark_drop(
     signature: str,
 ):
     env_conf = AppConfig().config.get(environment)
-    if env_conf is None:
-        print(
-            "The {environment} environment is not configured in app.toml "
-            "yet, please run `snow configure -e dev` first before continuing.",
-        )
-        raise typer.Abort()
+    validate_configuration(env_conf, environment)
 
     if config.isAuth():
         config.connectToSnowflake()

--- a/src/snowcli/cli/sql.py
+++ b/src/snowcli/cli/sql.py
@@ -67,10 +67,8 @@ def execute_sql(
     """
     Executes Snowflake query.
 
-    Query to execute can be specified using
-    - query option
-    - filename option (all queries from file will be executed)
-    - stdin by piping output, for example `snow render template my.sql | snow sql`
+    Query to execute can be specified using query option, filename option (all queries from file will be executed)
+    or via stdin by piping output from other command. For example `snow render template my.sql | snow sql`.
     """
     sys_input = None
 

--- a/src/snowcli/cli/sql.py
+++ b/src/snowcli/cli/sql.py
@@ -1,0 +1,114 @@
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich import box
+from rich.live import Live
+from rich.table import Table
+from snowflake.connector.cursor import SnowflakeCursor
+
+from snowcli import config
+from snowcli.utils import conf_callback
+
+EnvironmentOption = typer.Option(
+    "dev",
+    help="Environment name",
+    callback=conf_callback,
+    is_eager=True,
+)
+
+
+class LiveOutput:
+    def __init__(self, table: Table, live: Live):
+        self.table = table
+        self.live = live
+
+    def add_row(self, *args):
+        self.table.add_row(*args)
+        self.live.refresh()
+
+
+class LoggingCursor(SnowflakeCursor):
+    def __init__(self, live_output: LiveOutput, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.live_output = live_output
+
+    def execute(self, command: str, *args, **kwargs):
+        self.live_output.add_row(command)
+        super(LoggingCursor, self).execute(command, *args, **kwargs)
+
+
+def execute_sql(
+    query: Optional[str] = typer.Option(
+        None,
+        "-q",
+        "--query",
+        help="Query to execute.",
+    ),
+    file: Optional[Path] = typer.Option(
+        None,
+        "-f",
+        "--filename",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="File to execute.",
+    ),
+    connection: Optional[str] = typer.Option(
+        None, "-c", "--connection", help="Connection to be used"
+    ),
+    verbose: Optional[bool] = typer.Option(
+        True, "-v", "--verbose", help="Prints information about executed queries"
+    ),
+):
+    """
+    Executes Snowflake query.
+
+    Query to execute can be specified using
+    - query option
+    - filename option (all queries from file will be executed)
+    - stdin by piping output, for example `snow render template my.sql | snow sql`
+    """
+    sys_input = None
+
+    if query and file:
+        raise ValueError("Both query and file provided, please specify only one.")
+
+    if not sys.stdin.isatty():
+        sys_input = sys.stdin.read()
+
+    if sys_input and (query or file):
+        raise ValueError(
+            "Can't use stdin input together with query or filename option."
+        )
+
+    if not query and not file and not sys_input:
+        raise ValueError("Provide either query or filename argument")
+    elif sys_input:
+        sql = sys_input
+    else:
+        sql = query if query else file.read_text()  # type: ignore
+
+    if not config.isAuth():
+        raise ValueError("Not authorize")
+
+    config.connectToSnowflake(connection)
+
+    table = Table(show_lines=True, box=box.ASCII, width=120)
+    table.add_column("Query")
+
+    if verbose:
+        with Live(table, auto_refresh=False) as live:
+            config.snowflake_connection.ctx.execute_string(
+                sql_text=sql,
+                remove_comments=True,
+                cursor_class=partial(LoggingCursor, LiveOutput(table, live)),
+            )
+    else:
+        config.snowflake_connection.ctx.execute_string(
+            sql_text=sql,
+            remove_comments=True,
+        )

--- a/src/snowcli/config.py
+++ b/src/snowcli/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 import click
 import toml
@@ -36,13 +37,18 @@ class AppConfig:
             toml.dump(self.config, f)
 
 
-def connectToSnowflake():
+def connectToSnowflake(connection: Optional[str] = None):  # type: ignore
     global snowflake_connection
     cfg = AppConfig()
     snowsql_config = SnowsqlConfig(path=cfg.config.get("snowsql_config_path"))
+
+    # If there's no user-provided connection then read
+    # the one specified by configuration file
+    connection = connection or cfg.config.get("snowsql_connection_name")
+
     snowflake_connection = SnowflakeConnector(
         snowsql_config,
-        cfg.config.get("snowsql_connection_name"),
+        connection,
     )
 
 

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import pkgutil
 from io import StringIO
-from typing import List
 
 import snowflake.connector
 from snowflake.connector.cursor import SnowflakeCursor

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,14 +5,28 @@ from tempfile import NamedTemporaryFile
 
 def test_render_template(runner):
     with NamedTemporaryFile("r") as tmp_file, NamedTemporaryFile("r") as json_file:
-        Path(tmp_file.name).write_text("This is my template {{ data.name }}")
-        Path(json_file.name).write_text(json.dumps({"data": {"name": "value"}}))
+        Path(tmp_file.name).write_text(
+            "This is my template {{ data.name }} and {{ toBeUpdated }}"
+        )
+        Path(json_file.name).write_text(
+            json.dumps(
+                {"data": {"name": "value"}, "toBeUpdated": "should not be in output"}
+            )
+        )
         result = runner.invoke(
-            ["render", "template", tmp_file.name, "-d", json_file.name]
+            [
+                "render",
+                "template",
+                tmp_file.name,
+                "-d",
+                json_file.name,
+                "-D",
+                "toBeUpdated=ok",
+            ]
         )
 
     assert result.exit_code == 0
-    assert result.stdout_bytes.decode() == "This is my template value\n"
+    assert result.stdout_bytes.decode() == "This is my template value and ok\n"
 
 
 def test_render_js_proc(runner):

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -29,8 +29,7 @@ def test_sql_execute_file(mock_config, runner):
 
 @mock.patch(CONFIG_MOCK)
 def test_sql_execute_from_stdin(mock_config, runner):
-    with NamedTemporaryFile("r") as tmp_file:
-        result = runner.invoke(["sql", "-f", tmp_file.name], input="query from input")
+    result = runner.invoke(["sql"], input="query from input")
 
     assert result.exit_code == 0
     mock_config.snowflake_connection.ctx.execute_string.assert_called_once_with(

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+CONFIG_MOCK = "snowcli.cli.sql.config"
+
+
+@mock.patch(CONFIG_MOCK)
+def test_sql_execute_query(mock_config, runner):
+    result = runner.invoke(["sql", "-q", "query"])
+
+    assert result.exit_code == 0
+    mock_config.snowflake_connection.ctx.execute_string.assert_called_once_with(
+        sql_text="query", remove_comments=True, cursor_class=mock.ANY
+    )
+
+
+@mock.patch(CONFIG_MOCK)
+def test_sql_execute_file(mock_config, runner):
+    with NamedTemporaryFile("r") as tmp_file:
+        Path(tmp_file.name).write_text("query from file")
+        result = runner.invoke(["sql", "-f", tmp_file.name])
+
+    assert result.exit_code == 0
+    mock_config.snowflake_connection.ctx.execute_string.assert_called_once_with(
+        sql_text="query from file", remove_comments=True, cursor_class=mock.ANY
+    )
+
+
+@mock.patch(CONFIG_MOCK)
+def test_sql_execute_from_stdin(mock_config, runner):
+    with NamedTemporaryFile("r") as tmp_file:
+        result = runner.invoke(["sql", "-f", tmp_file.name], input="query from input")
+
+    assert result.exit_code == 0
+    mock_config.snowflake_connection.ctx.execute_string.assert_called_once_with(
+        sql_text="query from input", remove_comments=True, cursor_class=mock.ANY
+    )
+
+
+def test_sql_execute_from_stdin_with_other_query_source(runner):
+    with NamedTemporaryFile("r") as tmp_file:
+        result = runner.invoke(["sql", "-f", tmp_file.name], input="query from input")
+
+    assert result.exit_code == 1
+    assert "Can't use stdin input together with query or filename" in str(result)
+
+
+def test_sql_execute_fails_if_no_query_file_or_stdin(runner):
+    result = runner.invoke(
+        ["sql"],
+    )
+
+    assert result.exit_code == 1
+    assert "Provide either query or filename argument" in str(result)
+
+
+def test_sql_fails_for_both_query_and_file(runner):
+    with NamedTemporaryFile("r") as tmp_file:
+        result = runner.invoke(["sql", "-f", tmp_file.name, "-q", "query"])
+
+    assert result.exit_code == 1
+    assert "Both query and file provided" in str(result)


### PR DESCRIPTION
This PR adds `snow sql` command that allows executing query from string option, file or stdin:
```
➜ snow sql --help                                                       
                                                                                                                                                                                                                        
 Usage: snow sql [OPTIONS]                                                                                                                                                                                              
                                                                                                                                                                                                                        
 Executes Snowflake query.                                                                                                                                                                                              
 Query to execute can be specified using - query option - filename option (all queries from file will be executed) - stdin by piping output, for example `snow render template my.sql | snow sql`                       
                                                                                                                                                                                                                        
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --query       -q      TEXT  Query to execute. [default: None]                                                                                                                                                        │
│ --filename    -f      FILE  File to execute. [default: None]                                                                                                                                                         │
│ --connection  -c      TEXT  Connection to be used [default: None]                                                                                                                                                    │
│ --verbose     -v            Prints information about executed queries [default: True]                                                                                                                                │
│ --help        -h            Show this message and exit.                                                                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```

Allowing stdin input allows using `snow render template` for example:
```
snow render template create_ml_schema.sql -D "db_name=foo_bar" | snow sql
```