### PR TITLE
Snowpark packaging for Streamlit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 dist/
 .idea
 .tox
+app.toml
+.packages

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ Note: Your account must have access to the Streamlit in Snowflake private previe
 
     `snow streamlit deploy <name> -o`
 
+#### Deploy a packaged Streamlit app (temporary workaround)
+
+As at April 2023, you must provide a single file script to Streamlit, with an optional environment.yml file containing a list of Anaconda packages.
+
+By adding the `--use-packaging-workaround` parameter during `snow streamlit create` and `snow streamlit deploy`, you can have your directory packaged into an app.zip file with PyPi packages.
+
+A wrapper file will be generated as a Streamlit entrypoint, and it will download the app.zip from the stage, add it to the system path and import the original Streamlit script.
+
 ### Create a stored procedure
 
 See [Build a function](#build-a-function).

--- a/src/snowcli/__about__.py
+++ b/src/snowcli/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-VERSION = "0.2.3"
+VERSION = "0.2.4"

--- a/src/snowcli/cli/snowpark_shared.py
+++ b/src/snowcli/cli/snowpark_shared.py
@@ -382,7 +382,7 @@ def snowpark_package(
                 "w",
                 encoding="utf-8",
             ) as f:
-                for package in parsedRequirements["snowflake"]:
+                for package in sorted(list(set(parsedRequirements["snowflake"]))):
                     f.write(package + "\n")
         if pack_dir:
             utils.recursiveZipPackagesDir(pack_dir, "app.zip")

--- a/src/snowcli/python_templates/environment.yml.jinja
+++ b/src/snowcli/python_templates/environment.yml.jinja
@@ -1,0 +1,5 @@
+name: sf_env
+channels:
+- snowflake
+dependencies:
+{{dependencies}}

--- a/src/snowcli/python_templates/streamlit_app_launcher.py.jinja
+++ b/src/snowcli/python_templates/streamlit_app_launcher.py.jinja
@@ -1,0 +1,19 @@
+from snowflake.snowpark.context import get_active_session
+import sys,os,zipfile,importlib
+import_dir = '/tmp/streamlit_app'
+if not os.path.exists(import_dir):
+    os.makedirs(import_dir, exist_ok=True)
+    session = get_active_session()
+    session.file.get(stage_location='{{stage_name}}',target_directory=import_dir)
+    if {{extract_zip}}:
+      with zipfile.ZipFile('app.zip', 'r') as myzip:
+          myzip.extractall(import_dir)
+      sys.path.append(import_dir)
+    else:
+      sys.path.append(f"{import_dir}/app.zip")
+    os.chdir(import_dir)
+
+if "{{main_module}}" in sys.modules:
+  importlib.reload(sys.modules["{{main_module}}"])
+else:
+  importlib.import_module("{{main_module}}")

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -111,6 +111,10 @@ def parseAnacondaPackages(packages: list[str]) -> dict:
                     f'"{package}" not found in Snowflake anaconda channel...',
                 )
                 otherPackages.append(package)
+        # As at April 2023, streamlit appears unavailable in the Snowflake Anaconda channel
+        # but actually works if specified in the environment
+        if "streamlit" in otherPackages:
+            otherPackages.remove("streamlit")
         return {"snowflake": snowflakePackages, "other": otherPackages}
     else:
         click.echo(f"Error: {response.status_code}")
@@ -357,7 +361,7 @@ def recursiveZipPackagesDir(pack_dir: str, dest_zip: str) -> bool:
     # zip all files in the current directory except the ones that start with "." or are in the pack_dir
     for file in pathlib.Path(".").glob("**/*"):
         if (
-            not file.match(".*")
+            not str(file).startswith(".")
             and not file.match(f"{pack_dir}/*")
             and not file.match(dest_zip)
         ):


### PR DESCRIPTION
This PR introduces the ability to have Streamlit-in-Snowflake launch from a packaged directory instead of a single script. The packaging process is identical to the existing Snowpark UDF/sproc process, including the ability to download PyPi packages in the absence of an Anaconda option.

Where Anaconda packages exist (either directly specified in requirements.txt or as dependencies of PyPi packages), an environment.yml file will be generated and uploaded to the stage.

I've been cautious to word it as a temporary workaround, with the expectation that eventually it won't be necessary.