### PR TITLE
Fix bug in certain code paths in second-change packaging

### DIFF
--- a/src/snowcli/__about__.py
+++ b/src/snowcli/__about__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-VERSION = "0.2.5"
+VERSION = "0.2.6"

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -302,6 +302,7 @@ def installPackages(
     package_name: str | None = None,
 ) -> tuple[bool, dict[str, list[str]] | None]:
     pip_install_result = None
+    second_chance_results = None
     if file_name is not None:
         try:
             process = subprocess.Popen(


### PR DESCRIPTION
This PR fixes a small bug which sometimes occurs when doing a second-round check of Anaconda packages