### PR TITLE
Added parameter to specify a section of the app.toml to use.  Allowin…

### DIFF
--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -525,9 +525,10 @@ def conf_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
             # Initialize the default map
             ctx.default_map = ctx.default_map or {}
             # if app_config has key 'default'
-            if "default" in app_config:
+            config_section = os.getenv("SNOWCLI_CONFIG_SECTION", "default")
+            if config_section in app_config:
                 ctx.default_map.update(
-                    app_config.get("default"),
+                    app_config.get(config_section),
                 )  # type: ignore
             if value in app_config:
                 # TODO: Merge the config dict into default_map


### PR DESCRIPTION
I needed a way to create overloaded stored procedure versions.  IE:

do_stuff(varchar, varchar, varchar)
do_stuff() - calls do_stuff(varchar, varchar, varchar) so I can have defaults

I tried to add a CLI parameter, but making the rest of the CLI params dependent on one parameter with Typer was proving difficult.  So instead I created an env var called SNOWCLI_CONFIG_SECTION that defaults to "default".  This allowed me to do the following:

app.toml:

snowsql_config_path = "~/.snowsql/config"
snowsql_connection_name = "blah"

[default]
input_parameters = "(start_time string, end_time string)"
return_type = "string"
file = "app.zip"
name = "do_stuff"
handler = "app.main"
execute_as_caller = true

[helpversion]
input_parameters = "()"
return_type = "string"
file = "app.zip"
name = "do_stuff"
handler = "default.main"
execute_as_caller = true

[dev]
database = "temp"
schema = "scratch"
warehouse = "MY_WAREHOUSE"
role = "MY_ROLE"
overwrite = true