### PR TITLE
Minor Linting, Reworking Response Status Return, Config File Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 .idea
 .tox
 .packages
+.mypy_cache
+.ruff_cache

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you do not want to install SnowSQL, you can add Snowflake account credentials
 
 1. In your home directory, make `.snowsql` directory with a `config` file:
 
-   `touch ~/.snowsql/config`
+   `mkdir -p ~/.snowsql && touch ~/.snowsql/config`
 
 2. Open the config file for editing:
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ If you do not want to install SnowSQL, you can add Snowflake account credentials
 
 1. In your home directory, make `.snowsql` directory with a `config` file:
 
-   `mkdir .snowsql`
-   `cd .snowsql`
-   `touch config`
+   `touch ~/.snowsql/config`
 
 2. Open the config file for editing:
 

--- a/src/snowcli/cli/package.py
+++ b/src/snowcli/cli/package.py
@@ -43,7 +43,7 @@ def package_lookup(
         click.echo(f"Package {name} is available on the Snowflake anaconda channel.")
         if _run_nested:
             click.echo(
-                f"No need to create a package. Just include in your `packages` declaration."
+                "No need to create a package. Just include in your `packages` declaration."
             )
     else:
         if not install_packages:

--- a/src/snowcli/cli/procedure_coverage/report.py
+++ b/src/snowcli/cli/procedure_coverage/report.py
@@ -8,7 +8,7 @@ import typer
 
 from snowcli import config, utils
 from snowcli.config import AppConfig
-from snowcli.utils import conf_callback, generate_deploy_stage_name, print_db_cursor
+from snowcli.utils import conf_callback, generate_deploy_stage_name
 
 from . import app
 

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import pkgutil
 from io import StringIO
 from pathlib import Path
 from typing import Optional

--- a/src/snowcli/snowsql_config.py
+++ b/src/snowcli/snowsql_config.py
@@ -7,10 +7,11 @@ import os
 class SnowsqlConfig:
     def __init__(self, path="~/.snowsql/config"):
         self.path = path
+        self.expanded_path = os.path.expanduser(path)
         self.config = configparser.ConfigParser(
             inline_comment_prefixes="#", interpolation=None
         )
-        self.config.read(os.path.expanduser(path))
+        self.config.read(self.expanded_path)
 
     def get_connection(self, connection_name):
         connection = self.config["connections." + connection_name]
@@ -26,5 +27,6 @@ class SnowsqlConfig:
         for (k, v) in entry.items():
             connection[k] = v
 
-        with open(os.path.expanduser(self.path), "w+") as f:
+    def write(self):
+        with open(self.expanded_path, "w+") as f:
             self.config.write(f)

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -99,28 +99,27 @@ def parseAnacondaPackages(packages: list[str]) -> dict:
     response = requests.get(url)
     snowflakePackages = []
     otherPackages = []
-    if response.status_code == 200:
-        channel_data = response.json()
-        for package in packages:
-            # pip package names are case insensitive,
-            # Anaconda package names are lowercased
-            if package.lower() in channel_data["packages"]:
-                snowflakePackages.append(
-                    f"{package}",
-                )
-            else:
-                click.echo(
-                    f'"{package}" not found in Snowflake anaconda channel...',
-                )
-                otherPackages.append(package)
-        # As at April 2023, streamlit appears unavailable in the Snowflake Anaconda channel
-        # but actually works if specified in the environment
-        if "streamlit" in otherPackages:
-            otherPackages.remove("streamlit")
-        return {"snowflake": snowflakePackages, "other": otherPackages}
-    else:
+    if response.status_code is not 200:
         click.echo(f"Error: {response.status_code}")
         return {}
+    channel_data_packages = response.json().get("packages")
+    for package in packages:
+        # pip package names are case insensitive,
+        # Anaconda package names are lowercased
+        if package.lower() in channel_data_packages:
+            snowflakePackages.append(
+                f"{package}",
+            )
+        else:
+            click.echo(
+                f'"{package}" not found in Snowflake Anaconda channel...',
+            )
+            otherPackages.append(package)
+    # As at April 2023, streamlit appears unavailable in the Snowflake Anaconda channel
+    # but actually works if specified in the environment
+    if "streamlit" in otherPackages:
+        otherPackages.remove("streamlit")
+    return {"snowflake": snowflakePackages, "other": otherPackages}
 
 
 def generateStreamlitEnvironmentFile(


### PR DESCRIPTION
- Performed flake8 checks for quality checks; more info on F401 and F451 at [Error / Violation Codes](https://flake8.pycqa.org/en/latest/user/error-codes.html)
- Added cache folders for mypy and ruff to gitignore
- Exit [src/snowcli/utils.py](https://github.com/Snowflake-Labs/snowcli/commit/88f3a0f7615d331269401c4da92785d9f7d0928f#diff-b3e7f12457b86d4c37c642c8026f99672c7857e94da58c9204d843ba17298767) earlier to reduce conditional nesting. 
- `os.path.expanduser(path)` being used multiple times in `src/snowcli/snowsql_config.py`, initializing that with the class.
- Single command `touch` in README for Unix systems