### PR TITLE
824873 rename functions to stick with pep 8 naming conventions

### DIFF
--- a/src/snowcli/cli/snowpark/package.py
+++ b/src/snowcli/cli/snowpark/package.py
@@ -37,10 +37,10 @@ def package_lookup(
     """
     Check to see if a package is available on the Snowflake anaconda channel.
     """
-    packageResponse = utils.parse_anaconda_packages([name])
+    package_response = utils.parse_anaconda_packages([name])
     ## if list has any items
 
-    if len(packageResponse["snowflake"]) > 0:
+    if len(package_response["snowflake"]) > 0:
         click.echo(f"Package {name} is available on the Snowflake anaconda channel.")
         if _run_nested:
             click.echo(
@@ -128,8 +128,8 @@ def package_upload(
             "yet, please run `snow configure` first before continuing.",
         )
         raise typer.Abort()
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         click.echo(f"Uploading {file} to Snowflake @{stage}/{file}...")
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_app_zip_path = utils.prepare_app_zip(file, temp_dir)

--- a/src/snowcli/cli/snowpark/package.py
+++ b/src/snowcli/cli/snowpark/package.py
@@ -133,7 +133,7 @@ def package_upload(
         click.echo(f"Uploading {file} to Snowflake @{stage}/{file}...")
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_app_zip_path = utils.prepare_app_zip(file, temp_dir)
-            deploy_response = config.snowflake_connection.uploadFileToStage(
+            deploy_response = config.snowflake_connection.upload_file_to_stage(
                 file_path=temp_app_zip_path,
                 destination_stage=stage,
                 path="/",

--- a/src/snowcli/cli/snowpark/procedure_coverage/clear.py
+++ b/src/snowcli/cli/snowpark/procedure_coverage/clear.py
@@ -53,7 +53,7 @@ def procedure_coverage_clear(
             ),
         )
         coverage_path = f"""{deploy_dict["directory"]}/coverage"""
-        results = config.snowflake_connection.removeFromStage(
+        results = config.snowflake_connection.remove_from_stage(
             database=env_conf["database"],
             schema=env_conf["schema"],
             role=env_conf["role"],

--- a/src/snowcli/cli/snowpark/procedure_coverage/clear.py
+++ b/src/snowcli/cli/snowpark/procedure_coverage/clear.py
@@ -42,8 +42,8 @@ def procedure_coverage_clear(
             "yet, please run `snow configure -e dev` first before continuing.",
         )
         raise typer.Abort()
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         deploy_dict = utils.get_deploy_names(
             env_conf["database"],
             env_conf["schema"],

--- a/src/snowcli/cli/snowpark/procedure_coverage/report.py
+++ b/src/snowcli/cli/snowpark/procedure_coverage/report.py
@@ -63,8 +63,8 @@ def procedure_coverage_report(
             "yet, please run `snow configure -e dev` first before continuing.",
         )
         raise typer.Abort()
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         deploy_dict = utils.get_deploy_names(
             env_conf["database"],
             env_conf["schema"],

--- a/src/snowcli/cli/snowpark/procedure_coverage/report.py
+++ b/src/snowcli/cli/snowpark/procedure_coverage/report.py
@@ -92,7 +92,7 @@ def procedure_coverage_report(
             stage_path = deploy_dict["directory"]
             report_files = f"{stage_name}{stage_path}/coverage/"
             try:
-                results = config.snowflake_connection.getStage(
+                results = config.snowflake_connection.get_stage(
                     database=env_conf.get("database"),
                     schema=env_conf.get("schema"),
                     role=env_conf.get("role"),
@@ -134,13 +134,13 @@ def procedure_coverage_report(
             print(
                 f"Storing total coverage value of {str(coverage_percentage)} as a procedure comment."
             )
-            config.snowflake_connection.setProcedureComment(
+            config.snowflake_connection.set_procedure_comment(
                 env_conf["database"],
                 env_conf["schema"],
                 env_conf["role"],
                 env_conf["warehouse"],
                 name=name,
-                inputParameters=input_parameters,
+                input_parameters=input_parameters,
                 show_exceptions=True,
                 comment=str(coverage_percentage),
             )

--- a/src/snowcli/cli/snowpark_shared.py
+++ b/src/snowcli/cli/snowpark_shared.py
@@ -81,7 +81,7 @@ def snowpark_create(
                     temp_dir=temp_dir,
                     zip_file_path=temp_app_zip_path,
                 )
-            config.snowflake_connection.uploadFileToStage(
+            config.snowflake_connection.upload_file_to_stage(
                 file_path=temp_app_zip_path,
                 destination_stage=deploy_dict["stage"],
                 path=deploy_dict["directory"],
@@ -97,10 +97,10 @@ def snowpark_create(
                 packages.append("coverage")
         print(f"Creating {type}...")
         if type == "function":
-            results = config.snowflake_connection.createFunction(
+            results = config.snowflake_connection.create_function(
                 name=name,
-                inputParameters=input_parameters,
-                returnType=return_type,
+                input_parameters=input_parameters,
+                return_type=return_type,
                 handler=handler,
                 imports=deploy_dict["full_path"],
                 database=env_conf["database"],
@@ -111,10 +111,10 @@ def snowpark_create(
                 packages=packages,
             )
         elif type == "procedure":
-            results = config.snowflake_connection.createProcedure(
+            results = config.snowflake_connection.create_procedure(
                 name=name,
-                inputParameters=input_parameters,
-                returnType=return_type,
+                input_parameters=input_parameters,
+                return_type=return_type,
                 handler=handler,
                 imports=deploy_dict["full_path"],
                 database=env_conf["database"],
@@ -161,13 +161,13 @@ def snowpark_update(
         raise typer.Abort()
     if config.isAuth():
         config.connectToSnowflake()
-        updatedPackageList = []
+        updated_package_list = []
         try:
             print(f"Updating {type} {name}...")
             if type == "function":
-                resource_details = config.snowflake_connection.describeFunction(
+                resource_details = config.snowflake_connection.describe_function(
                     name=name,
-                    inputParameters=input_parameters,
+                    input_parameters=input_parameters,
                     database=env_conf["database"],
                     schema=env_conf["schema"],
                     role=env_conf["role"],
@@ -175,9 +175,9 @@ def snowpark_update(
                     show_exceptions=False,
                 )
             elif type == "procedure":
-                resource_details = config.snowflake_connection.describeProcedure(
+                resource_details = config.snowflake_connection.describe_procedure(
                     name=name,
-                    inputParameters=input_parameters,
+                    input_parameters=input_parameters,
                     database=env_conf["database"],
                     schema=env_conf["schema"],
                     role=env_conf["role"],
@@ -197,16 +197,16 @@ def snowpark_update(
                 "Checking if any packages defined or missing from "
                 "requirements.snowflake.txt...",
             )
-            updatedPackageList = utils.get_snowflake_packages_delta(
+            updated_package_list = utils.get_snowflake_packages_delta(
                 anaconda_packages,
             )
             if install_coverage_wrapper:
                 # if we're installing a coverage wrapper, ensure the coverage package included as a dependency
                 if (
                     "coverage" not in anaconda_packages
-                    and "coverage" not in updatedPackageList
+                    and "coverage" not in updated_package_list
                 ):
-                    updatedPackageList.append("coverage")
+                    updated_package_list.append("coverage")
             print(
                 "Checking if app configuration has changed...",
             )
@@ -242,7 +242,7 @@ def snowpark_update(
                         temp_dir=temp_dir,
                         zip_file_path=temp_app_zip_path,
                     )
-                deploy_response = config.snowflake_connection.uploadFileToStage(
+                deploy_response = config.snowflake_connection.upload_file_to_stage(
                     file_path=temp_app_zip_path,
                     destination_stage=deploy_dict["stage"],
                     path=deploy_dict["directory"],
@@ -256,13 +256,13 @@ def snowpark_update(
                 f'{deploy_dict["full_path"]}',
             )
 
-            if updatedPackageList or replace:
+            if updated_package_list or replace:
                 print(f"Replacing {type} with updated values...")
                 if type == "function":
-                    config.snowflake_connection.createFunction(
+                    config.snowflake_connection.create_function(
                         name=name,
-                        inputParameters=input_parameters,
-                        returnType=return_type,
+                        input_parameters=input_parameters,
+                        return_type=return_type,
                         handler=handler,
                         imports=deploy_dict["full_path"],
                         database=env_conf["database"],
@@ -273,10 +273,10 @@ def snowpark_update(
                         packages=utils.get_snowflake_packages(),
                     )
                 elif type == "procedure":
-                    config.snowflake_connection.createProcedure(
+                    config.snowflake_connection.create_procedure(
                         name=name,
-                        inputParameters=input_parameters,
-                        returnType=return_type,
+                        input_parameters=input_parameters,
+                        return_type=return_type,
                         handler=handler,
                         imports=deploy_dict["full_path"],
                         database=env_conf["database"],
@@ -338,13 +338,13 @@ def snowpark_package(
     pack_dir: str = None  # type: ignore
     if requirements:
         print("Comparing provided packages from Snowflake Anaconda...")
-        parsedRequirements = utils.parse_anaconda_packages(requirements)
-        if not parsedRequirements["other"]:
+        parsed_requirements = utils.parse_anaconda_packages(requirements)
+        if not parsed_requirements["other"]:
             print("No packages to manually resolve")
-        if parsedRequirements["other"]:
+        if parsed_requirements["other"]:
             print("Writing requirements.other.txt...")
             with open("requirements.other.txt", "w", encoding="utf-8") as f:
-                for package in parsedRequirements["other"]:
+                for package in parsed_requirements["other"]:
                     f.write(package + "\n")
         # if requirements.other.txt exists
         if os.path.isfile("requirements.other.txt"):
@@ -367,20 +367,20 @@ def snowpark_package(
                     pack_dir = ".packages"
                     # add the Anaconda packages discovered as dependancies
                     if second_chance_results is not None:
-                        parsedRequirements["snowflake"] = (
-                            parsedRequirements["snowflake"]
+                        parsed_requirements["snowflake"] = (
+                            parsed_requirements["snowflake"]
                             + second_chance_results["snowflake"]
                         )
 
         # write requirements.snowflake.txt file
-        if parsedRequirements["snowflake"]:
+        if parsed_requirements["snowflake"]:
             print("Writing requirements.snowflake.txt file...")
             with open(
                 "requirements.snowflake.txt",
                 "w",
                 encoding="utf-8",
             ) as f:
-                for package in sorted(list(set(parsedRequirements["snowflake"]))):
+                for package in sorted(list(set(parsed_requirements["snowflake"]))):
                     f.write(package + "\n")
         if pack_dir:
             utils.recursive_zip_packages_dir(pack_dir, "app.zip")
@@ -397,7 +397,7 @@ def snowpark_execute(type: str, environment: str, select: str):
     if config.isAuth():
         config.connectToSnowflake()
         if type == "function":
-            results = config.snowflake_connection.executeFunction(
+            results = config.snowflake_connection.execute_function(
                 function=select,
                 database=env_conf["database"],
                 schema=env_conf["schema"],
@@ -405,7 +405,7 @@ def snowpark_execute(type: str, environment: str, select: str):
                 warehouse=env_conf["warehouse"],
             )
         elif type == "procedure":
-            results = config.snowflake_connection.executeProcedure(
+            results = config.snowflake_connection.execute_procedure(
                 procedure=select,
                 database=env_conf["database"],
                 schema=env_conf["schema"],
@@ -442,7 +442,7 @@ def snowpark_describe(
                 )
             )
         if type == "function":
-            results = config.snowflake_connection.describeFunction(
+            results = config.snowflake_connection.describe_function(
                 signature=signature,
                 database=env_conf["database"],
                 schema=env_conf["schema"],
@@ -450,7 +450,7 @@ def snowpark_describe(
                 warehouse=env_conf["warehouse"],
             )
         elif type == "procedure":
-            results = config.snowflake_connection.describeProcedure(
+            results = config.snowflake_connection.describe_procedure(
                 signature=signature,
                 database=env_conf["database"],
                 schema=env_conf["schema"],
@@ -468,7 +468,7 @@ def snowpark_list(type, environment, like):
     if config.isAuth():
         config.connectToSnowflake()
         if type == "function":
-            results = config.snowflake_connection.listFunctions(
+            results = config.snowflake_connection.list_functions(
                 database=env_conf["database"],
                 schema=env_conf["schema"],
                 role=env_conf["role"],
@@ -476,7 +476,7 @@ def snowpark_list(type, environment, like):
                 like=like,
             )
         elif type == "procedure":
-            results = config.snowflake_connection.listProcedures(
+            results = config.snowflake_connection.list_procedures(
                 database=env_conf["database"],
                 schema=env_conf["schema"],
                 role=env_conf["role"],
@@ -513,7 +513,7 @@ def snowpark_drop(
                 )
             )
         if type == "function":
-            results = config.snowflake_connection.dropFunction(
+            results = config.snowflake_connection.drop_function(
                 signature=signature,
                 database=env_conf["database"],
                 schema=env_conf["schema"],
@@ -521,7 +521,7 @@ def snowpark_drop(
                 warehouse=env_conf["warehouse"],
             )
         elif type == "procedure":
-            results = config.snowflake_connection.dropProcedure(
+            results = config.snowflake_connection.drop_procedure(
                 signature=signature,
                 database=env_conf["database"],
                 schema=env_conf["schema"],

--- a/src/snowcli/cli/snowpark_shared.py
+++ b/src/snowcli/cli/snowpark_shared.py
@@ -57,8 +57,8 @@ def snowpark_create(
             """You cannot install a code coverage wrapper on a function, only a procedure."""
         )
         raise typer.Abort()
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         deploy_dict = utils.get_deploy_names(
             env_conf["database"],
             env_conf["schema"],
@@ -159,8 +159,8 @@ def snowpark_update(
             """You cannot install a code coverage wrapper on a function, only a procedure."""
         )
         raise typer.Abort()
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         updated_package_list = []
         try:
             print(f"Updating {type} {name}...")
@@ -394,8 +394,8 @@ def snowpark_package(
 def snowpark_execute(type: str, environment: str, select: str):
     env_conf = AppConfig().config.get(environment)
     validate_configuration(env_conf, environment)
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         if type == "function":
             results = config.snowflake_connection.execute_function(
                 function=select,
@@ -427,8 +427,8 @@ def snowpark_describe(
     env_conf = AppConfig().config.get(environment)
     validate_configuration(env_conf, environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         if signature == "":
             if name == "" and input_parameters == "":
                 typer.BadParameter(
@@ -465,8 +465,8 @@ def snowpark_describe(
 def snowpark_list(type, environment, like):
     env_conf = AppConfig().config.get(environment)
     validate_configuration(env_conf, environment)
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         if type == "function":
             results = config.snowflake_connection.list_functions(
                 database=env_conf["database"],
@@ -498,8 +498,8 @@ def snowpark_drop(
     env_conf = AppConfig().config.get(environment)
     validate_configuration(env_conf, environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         if signature == "":
             if name == "" and input_parameters == "":
                 typer.BadParameter(

--- a/src/snowcli/cli/sql.py
+++ b/src/snowcli/cli/sql.py
@@ -118,10 +118,10 @@ def execute_sql(
     else:
         sql = query if query else file.read_text()  # type: ignore
 
-    if not config.isAuth():
+    if not config.is_auth():
         raise ValueError("Not authorize")
 
-    config.connectToSnowflake(
+    config.connect_to_snowflake(
         connection,
         account=account,
         user=user,

--- a/src/snowcli/cli/stage.py
+++ b/src/snowcli/cli/stage.py
@@ -25,8 +25,8 @@ def stage_list(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         if name:
             results = config.snowflake_connection.list_stage(
                 database=env_conf.get("database"),
@@ -65,8 +65,8 @@ def stage_get(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.get_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
@@ -105,8 +105,8 @@ def stage_put(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         filepath = str(path)
         if path.is_dir():
             filepath = str(path) + "/*"
@@ -134,8 +134,8 @@ def stage_create(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.create_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
@@ -156,8 +156,8 @@ def stage_drop(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.drop_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),

--- a/src/snowcli/cli/stage.py
+++ b/src/snowcli/cli/stage.py
@@ -28,7 +28,7 @@ def stage_list(
     if config.isAuth():
         config.connectToSnowflake()
         if name:
-            results = config.snowflake_connection.listStage(
+            results = config.snowflake_connection.list_stage(
                 database=env_conf.get("database"),
                 schema=env_conf.get("schema"),
                 role=env_conf.get("role"),
@@ -37,7 +37,7 @@ def stage_list(
             )
             print_db_cursor(results)
         else:
-            results = config.snowflake_connection.listStages(
+            results = config.snowflake_connection.list_stages(
                 database=env_conf.get("database"),
                 schema=env_conf.get("schema"),
                 role=env_conf.get("role"),
@@ -67,7 +67,7 @@ def stage_get(
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.getStage(
+        results = config.snowflake_connection.get_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -111,7 +111,7 @@ def stage_put(
         if path.is_dir():
             filepath = str(path) + "/*"
 
-        results = config.snowflake_connection.putStage(
+        results = config.snowflake_connection.put_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -136,7 +136,7 @@ def stage_create(
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.createStage(
+        results = config.snowflake_connection.create_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -158,7 +158,7 @@ def stage_drop(
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.dropStage(
+        results = config.snowflake_connection.drop_stage(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),

--- a/src/snowcli/cli/streamlit.py
+++ b/src/snowcli/cli/streamlit.py
@@ -54,7 +54,7 @@ def streamlit_list(
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.listStreamlits(
+        results = config.snowflake_connection.list_streamlits(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -81,7 +81,7 @@ def streamlit_describe(
 
     if config.isAuth():
         config.connectToSnowflake()
-        description, url = config.snowflake_connection.describeStreamlit(
+        description, url = config.snowflake_connection.describe_streamlit(
             name,
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
@@ -132,7 +132,7 @@ def streamlit_create(
         else:
             from_stage_command = ""
 
-        results = config.snowflake_connection.createStreamlit(
+        results = config.snowflake_connection.create_streamlit(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -159,7 +159,7 @@ def streamlit_share(
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.shareStreamlit(
+        results = config.snowflake_connection.share_streamlit(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -182,7 +182,7 @@ def streamlit_drop(
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.dropStreamlit(
+        results = config.snowflake_connection.drop_streamlit(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),
@@ -248,7 +248,7 @@ def streamlit_deploy(
                 package_native_libraries,  # type: ignore[arg-type]
             )
             # upload the resulting app.zip file
-            config.snowflake_connection.uploadFileToStage(
+            config.snowflake_connection.upload_file_to_stage(
                 "app.zip",
                 f"{name}_stage",
                 "/",
@@ -264,7 +264,7 @@ def streamlit_deploy(
                 extract_zip=packaging_workaround_includes_content,
             )
             # upload the wrapper file
-            config.snowflake_connection.uploadFileToStage(
+            config.snowflake_connection.upload_file_to_stage(
                 str(file),
                 f"{name}_stage",
                 "/",
@@ -280,7 +280,7 @@ def streamlit_deploy(
                 excluded_anaconda_deps_list = excluded_anaconda_deps.split(",")
             env_file = generate_streamlit_environment_file(excluded_anaconda_deps_list)
             if env_file:
-                config.snowflake_connection.uploadFileToStage(
+                config.snowflake_connection.upload_file_to_stage(
                     str(env_file),
                     f"{name}_stage",
                     "/",
@@ -290,7 +290,7 @@ def streamlit_deploy(
                     overwrite=True,
                 )
 
-        base_url = config.snowflake_connection.deployStreamlit(
+        base_url = config.snowflake_connection.deploy_streamlit(
             name=name,
             file_path=str(file),
             stage_path="/",

--- a/src/snowcli/cli/streamlit.py
+++ b/src/snowcli/cli/streamlit.py
@@ -52,8 +52,8 @@ def streamlit_list(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.list_streamlits(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
@@ -79,8 +79,8 @@ def streamlit_describe(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         description, url = config.snowflake_connection.describe_streamlit(
             name,
             database=env_conf.get("database"),
@@ -118,8 +118,8 @@ def streamlit_create(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         if from_stage:
             if "." in from_stage:
                 full_stage_name = from_stage
@@ -157,8 +157,8 @@ def streamlit_share(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.share_streamlit(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
@@ -180,8 +180,8 @@ def streamlit_drop(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.drop_streamlit(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
@@ -235,8 +235,8 @@ def streamlit_deploy(
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         schema = env_conf.get("schema")
         role = env_conf.get("role")
         database = env_conf.get("database")

--- a/src/snowcli/cli/warehouse.py
+++ b/src/snowcli/cli/warehouse.py
@@ -22,7 +22,7 @@ def warehouse_status(environment: str = EnvironmentOption):
 
     if config.isAuth():
         config.connectToSnowflake()
-        results = config.snowflake_connection.showWarehouses(
+        results = config.snowflake_connection.show_warehouses(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),
             role=env_conf.get("role"),

--- a/src/snowcli/cli/warehouse.py
+++ b/src/snowcli/cli/warehouse.py
@@ -20,8 +20,8 @@ def warehouse_status(environment: str = EnvironmentOption):
     """
     env_conf = AppConfig().config.get(environment)
 
-    if config.isAuth():
-        config.connectToSnowflake()
+    if config.is_auth():
+        config.connect_to_snowflake()
         results = config.snowflake_connection.show_warehouses(
             database=env_conf.get("database"),
             schema=env_conf.get("schema"),

--- a/src/snowcli/config.py
+++ b/src/snowcli/config.py
@@ -37,7 +37,7 @@ class AppConfig:
             toml.dump(self.config, f)
 
 
-def connectToSnowflake(connection: Optional[str] = None, **overrides):  # type: ignore
+def connect_to_snowflake(connection: Optional[str] = None, **overrides):  # type: ignore
     global snowflake_connection
     cfg = AppConfig()
     snowsql_config = SnowsqlConfig(path=cfg.config.get("snowsql_config_path"))
@@ -51,7 +51,7 @@ def connectToSnowflake(connection: Optional[str] = None, **overrides):  # type: 
     )
 
 
-def isAuth():
+def is_auth():
     cfg = AppConfig()
     if "snowsql_config_path" not in cfg.config:
         click.echo("You must login first with `snow login`")

--- a/src/snowcli/snow_connector.py
+++ b/src/snowcli/snow_connector.py
@@ -51,15 +51,15 @@ class SnowflakeConnector:
         except (TypeError, AttributeError):
             pass
 
-    def getVersion(self):
+    def get_version(self):
         self.cs.execute("SELECT current_version()")
         return self.cs.fetchone()[0]
 
-    def createFunction(
+    def create_function(
         self,
         name: str,
-        inputParameters: str,
-        returnType: str,
+        input_parameters: str,
+        return_type: str,
         handler: str,
         imports: str,
         database: str,
@@ -69,7 +69,7 @@ class SnowflakeConnector:
         overwrite: bool,
         packages: list[str],
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "create_function",
             {
                 "database": database,
@@ -78,22 +78,22 @@ class SnowflakeConnector:
                 "warehouse": warehouse,
                 "name": name,
                 "overwrite": overwrite,
-                "input_parameters": inputParameters,
-                "return_type": returnType,
+                "input_parameters": input_parameters,
+                "return_type": return_type,
                 "handler": handler,
                 "imports": imports,
                 "packages": packages,
                 "signature": self.generate_signature_from_params(
-                    inputParameters,
+                    input_parameters,
                 ),
             },
         )
 
-    def createProcedure(
+    def create_procedure(
         self,
         name: str,
-        inputParameters: str,
-        returnType: str,
+        input_parameters: str,
+        return_type: str,
         handler: str,
         imports: str,
         database: str,
@@ -104,7 +104,7 @@ class SnowflakeConnector:
         packages: list[str],
         execute_as_caller: bool,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "create_procedure",
             {
                 "database": database,
@@ -113,19 +113,19 @@ class SnowflakeConnector:
                 "warehouse": warehouse,
                 "name": name,
                 "overwrite": overwrite,
-                "input_parameters": inputParameters,
-                "return_type": returnType,
+                "input_parameters": input_parameters,
+                "return_type": return_type,
                 "handler": handler,
                 "imports": imports,
                 "packages": packages,
                 "signature": self.generate_signature_from_params(
-                    inputParameters,
+                    input_parameters,
                 ),
                 "execute_as_caller": execute_as_caller,
             },
         )
 
-    def uploadFileToStage(
+    def upload_file_to_stage(
         self,
         file_path,
         destination_stage,
@@ -149,7 +149,7 @@ class SnowflakeConnector:
         )
         return self.cs.fetchone()
 
-    def executeFunction(
+    def execute_function(
         self,
         function,
         database,
@@ -157,7 +157,7 @@ class SnowflakeConnector:
         role,
         warehouse,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "execute_function",
             {
                 "database": database,
@@ -168,7 +168,7 @@ class SnowflakeConnector:
             },
         )
 
-    def executeProcedure(
+    def execute_procedure(
         self,
         procedure,
         database,
@@ -176,7 +176,7 @@ class SnowflakeConnector:
         role,
         warehouse,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "call_procedure",
             {
                 "database": database,
@@ -187,7 +187,7 @@ class SnowflakeConnector:
             },
         )
 
-    def describeFunction(
+    def describe_function(
         self,
         database,
         schema,
@@ -195,12 +195,12 @@ class SnowflakeConnector:
         warehouse,
         signature=None,
         name=None,
-        inputParameters=None,
+        input_parameters=None,
         show_exceptions=True,
     ) -> SnowflakeCursor:
-        if signature is None and name and inputParameters:
-            signature = name + self.generate_signature_from_params(inputParameters)
-        return self.runSql(
+        if signature is None and name and input_parameters:
+            signature = name + self.generate_signature_from_params(input_parameters)
+        return self.run_sql(
             "describe_function",
             {
                 "database": database,
@@ -212,7 +212,7 @@ class SnowflakeConnector:
             show_exceptions,
         )
 
-    def describeProcedure(
+    def describe_procedure(
         self,
         database,
         schema,
@@ -220,12 +220,12 @@ class SnowflakeConnector:
         warehouse,
         signature=None,
         name=None,
-        inputParameters=None,
+        input_parameters=None,
         show_exceptions=True,
     ) -> SnowflakeCursor:
-        if signature is None and name and inputParameters:
-            signature = name + self.generate_signature_from_params(inputParameters)
-        return self.runSql(
+        if signature is None and name and input_parameters:
+            signature = name + self.generate_signature_from_params(input_parameters)
+        return self.run_sql(
             "describe_procedure",
             {
                 "database": database,
@@ -237,7 +237,7 @@ class SnowflakeConnector:
             show_exceptions,
         )
 
-    def listFunctions(
+    def list_functions(
         self,
         database,
         schema,
@@ -245,7 +245,7 @@ class SnowflakeConnector:
         warehouse,
         like="%%",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "list_functions",
             {
                 "database": database,
@@ -256,7 +256,7 @@ class SnowflakeConnector:
             },
         )
 
-    def listStages(
+    def list_stages(
         self,
         database,
         schema,
@@ -264,7 +264,7 @@ class SnowflakeConnector:
         warehouse,
         like="%%",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "list_stages",
             {
                 "database": database,
@@ -275,7 +275,7 @@ class SnowflakeConnector:
             },
         )
 
-    def listStage(
+    def list_stage(
         self,
         database,
         schema,
@@ -286,7 +286,7 @@ class SnowflakeConnector:
     ) -> SnowflakeCursor:
         name = get_standard_stage_name(name)
 
-        return self.runSql(
+        return self.run_sql(
             "list_stage",
             {
                 "database": database,
@@ -298,7 +298,7 @@ class SnowflakeConnector:
             },
         )
 
-    def getStage(
+    def get_stage(
         self,
         database,
         schema,
@@ -309,7 +309,7 @@ class SnowflakeConnector:
     ) -> SnowflakeCursor:
         name = get_standard_stage_name(name)
 
-        return self.runSql(
+        return self.run_sql(
             "get_stage",
             {
                 "database": database,
@@ -321,7 +321,7 @@ class SnowflakeConnector:
             },
         )
 
-    def setProcedureComment(
+    def set_procedure_comment(
         self,
         database,
         schema,
@@ -329,13 +329,13 @@ class SnowflakeConnector:
         warehouse,
         signature=None,
         name=None,
-        inputParameters=None,
+        input_parameters=None,
         show_exceptions=True,
         comment="",
     ) -> SnowflakeCursor:
-        if signature is None and name and inputParameters:
-            signature = name + self.generate_signature_from_params(inputParameters)
-        return self.runSql(
+        if signature is None and name and input_parameters:
+            signature = name + self.generate_signature_from_params(input_parameters)
+        return self.run_sql(
             "set_procedure_comment",
             {
                 "database": database,
@@ -348,7 +348,7 @@ class SnowflakeConnector:
             show_exceptions,
         )
 
-    def putStage(
+    def put_stage(
         self,
         database,
         schema,
@@ -361,7 +361,7 @@ class SnowflakeConnector:
     ) -> SnowflakeCursor:
         name = get_standard_stage_name(name)
 
-        return self.runSql(
+        return self.run_sql(
             "put_stage",
             {
                 "database": database,
@@ -375,12 +375,12 @@ class SnowflakeConnector:
             },
         )
 
-    def removeFromStage(
+    def remove_from_stage(
         self, database, schema, role, warehouse, name, path
     ) -> SnowflakeCursor:
         name = get_standard_stage_name(name)
 
-        return self.runSql(
+        return self.run_sql(
             "remove_from_stage",
             {
                 "database": database,
@@ -392,7 +392,7 @@ class SnowflakeConnector:
             },
         )
 
-    def createStage(
+    def create_stage(
         self,
         database,
         schema,
@@ -400,7 +400,7 @@ class SnowflakeConnector:
         warehouse,
         name,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "create_stage",
             {
                 "database": database,
@@ -411,7 +411,7 @@ class SnowflakeConnector:
             },
         )
 
-    def dropStage(
+    def drop_stage(
         self,
         database,
         schema,
@@ -419,7 +419,7 @@ class SnowflakeConnector:
         warehouse,
         name,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "drop_stage",
             {
                 "database": database,
@@ -430,7 +430,7 @@ class SnowflakeConnector:
             },
         )
 
-    def listProcedures(
+    def list_procedures(
         self,
         database,
         schema,
@@ -438,7 +438,7 @@ class SnowflakeConnector:
         warehouse,
         like="%%",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "list_procedures",
             {
                 "database": database,
@@ -449,7 +449,7 @@ class SnowflakeConnector:
             },
         )
 
-    def dropFunction(
+    def drop_function(
         self,
         database,
         schema,
@@ -457,7 +457,7 @@ class SnowflakeConnector:
         warehouse,
         signature,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "drop_function",
             {
                 "database": database,
@@ -468,7 +468,7 @@ class SnowflakeConnector:
             },
         )
 
-    def dropProcedure(
+    def drop_procedure(
         self,
         database,
         schema,
@@ -476,7 +476,7 @@ class SnowflakeConnector:
         warehouse,
         signature,
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "drop_procedure",
             {
                 "database": database,
@@ -487,14 +487,14 @@ class SnowflakeConnector:
             },
         )
 
-    def listStreamlits(
+    def list_streamlits(
         self,
         database="",
         schema="",
         role="",
         warehouse="",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "list_streamlits",
             {
                 "database": database,
@@ -504,7 +504,7 @@ class SnowflakeConnector:
             },
         )
 
-    def showWarehouses(
+    def show_warehouses(
         self,
         database="",
         schema="",
@@ -512,7 +512,7 @@ class SnowflakeConnector:
         warehouse="",
         like="%%",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "show_warehouses",
             {
                 "database": database,
@@ -522,7 +522,7 @@ class SnowflakeConnector:
             },
         )
 
-    def createStreamlit(
+    def create_streamlit(
         self,
         database="",
         schema="",
@@ -532,7 +532,7 @@ class SnowflakeConnector:
         file="",
         from_stage_command="",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "create_streamlit",
             {
                 "database": database,
@@ -545,7 +545,7 @@ class SnowflakeConnector:
             },
         )
 
-    def shareStreamlit(
+    def share_streamlit(
         self,
         database="",
         schema="",
@@ -554,7 +554,7 @@ class SnowflakeConnector:
         name="",
         to_role="",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "share_streamlit",
             {
                 "database": database,
@@ -566,7 +566,7 @@ class SnowflakeConnector:
             },
         )
 
-    def dropStreamlit(
+    def drop_streamlit(
         self,
         database="",
         schema="",
@@ -574,7 +574,7 @@ class SnowflakeConnector:
         warehouse="",
         name="",
     ) -> SnowflakeCursor:
-        return self.runSql(
+        return self.run_sql(
             "drop_streamlit",
             {
                 "database": database,
@@ -585,7 +585,7 @@ class SnowflakeConnector:
             },
         )
 
-    def deployStreamlit(
+    def deploy_streamlit(
         self,
         name,
         file_path,
@@ -598,7 +598,7 @@ class SnowflakeConnector:
         stage_name = f"snow://streamlit/{database}.{schema}.{name}/default_checkout"
 
         """Upload main python file to stage and return url of streamlit"""
-        self.uploadFileToStage(
+        self.upload_file_to_stage(
             file_path,
             stage_name,
             stage_path,
@@ -608,7 +608,7 @@ class SnowflakeConnector:
             overwrite,
         )
 
-        result = self.runSql(
+        result = self.run_sql(
             "get_streamlit_url",
             {
                 "name": name,
@@ -620,8 +620,8 @@ class SnowflakeConnector:
 
         return result.fetchone()[0]
 
-    def describeStreamlit(self, name, database, schema, role, warehouse):
-        description = self.runSql(
+    def describe_streamlit(self, name, database, schema, role, warehouse):
+        description = self.run_sql(
             "describe_streamlit",
             {
                 "name": name,
@@ -631,7 +631,7 @@ class SnowflakeConnector:
                 "warehouse": warehouse,
             },
         )
-        url = self.runSql(
+        url = self.run_sql(
             "get_streamlit_url",
             {
                 "name": name,
@@ -642,7 +642,7 @@ class SnowflakeConnector:
         )
         return (description, url)
 
-    def runSql(
+    def run_sql(
         self,
         command,
         context,
@@ -665,7 +665,8 @@ class SnowflakeConnector:
                 print(e)
             raise (e)
 
-    def generate_signature_from_params(self, params: str) -> str:
+    @staticmethod
+    def generate_signature_from_params(params: str) -> str:
         if params == "()":
             return "()"
         return "(" + " ".join(params.split()[1::2])

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -97,27 +97,27 @@ def parse_requirements(requirements_file: str = "requirements.txt") -> list[str]
 def parse_anaconda_packages(packages: list[str]) -> dict:
     url = "https://repo.anaconda.com/pkgs/snowflake/channeldata.json"
     response = requests.get(url)
-    snowflakePackages = []
-    otherPackages = []
+    snowflake_packages = []
+    other_packages = []
     if response.status_code == 200:
         channel_data = response.json()
         for package in packages:
             # pip package names are case insensitive,
             # Anaconda package names are lowercased
             if package.lower() in channel_data["packages"]:
-                snowflakePackages.append(
+                snowflake_packages.append(
                     f"{package}",
                 )
             else:
                 click.echo(
                     f'"{package}" not found in Snowflake anaconda channel...',
                 )
-                otherPackages.append(package)
+                other_packages.append(package)
         # As at April 2023, streamlit appears unavailable in the Snowflake Anaconda channel
         # but actually works if specified in the environment
-        if "streamlit" in otherPackages:
-            otherPackages.remove("streamlit")
-        return {"snowflake": snowflakePackages, "other": otherPackages}
+        if "streamlit" in other_packages:
+            other_packages.remove("streamlit")
+        return {"snowflake": snowflake_packages, "other": other_packages}
     else:
         click.echo(f"Error: {response.status_code}")
         return {}
@@ -472,17 +472,17 @@ def get_snowflake_packages() -> list[str]:
 
 
 def get_snowflake_packages_delta(anaconda_packages) -> list[str]:
-    updatedPackageList = []
+    updated_package_list = []
     if os.path.exists("requirements.snowflake.txt"):
         with open("requirements.snowflake.txt", encoding="utf-8") as f:
             # for each line, check if it exists in anaconda_packages. If it
             # doesn't, add it to the return string
             for line in f:
                 if line.strip() not in anaconda_packages:
-                    updatedPackageList.append(line.strip())
-        return updatedPackageList
+                    updated_package_list.append(line.strip())
+        return updated_package_list
     else:
-        return updatedPackageList
+        return updated_package_list
 
 
 def convert_resource_details_to_dict(function_details: list[tuple]) -> dict:

--- a/tests/__snapshots__/test_snow_connector.ambr
+++ b/tests/__snapshots__/test_snow_connector.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_createFunction
+# name: test_create_function
   '''
   use database databaseValue;
   use schema schemaValue;
@@ -14,7 +14,7 @@
   describe function nameValue(a, b);
   '''
 # ---
-# name: test_createProcedure
+# name: test_create_procedure
   '''
   use database databaseValue;
   use schema schemaValue;
@@ -33,7 +33,7 @@
   describe PROCEDURE nameValue(a, b);
   '''
 # ---
-# name: test_createStage
+# name: test_create_stage
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -43,7 +43,7 @@
   create stage if not exists nameValue;
   '''
 # ---
-# name: test_createStreamlit
+# name: test_create_streamlit
   '''
   use role roleValue;
   use database databaseValue;
@@ -61,7 +61,7 @@
   alter streamlit nameValue checkout;
   '''
 # ---
-# name: test_createStreamlitFromStage
+# name: test_create_streamlit_from_stage
   '''
   use role roleValue;
   use database databaseValue;
@@ -79,7 +79,7 @@
   alter streamlit nameValue checkout;
   '''
 # ---
-# name: test_deployStreamlit
+# name: test_deploy_streamlit
   '''
   use database databaseValue;
   use schema schemaValue;
@@ -88,7 +88,7 @@
   CALL SYSTEM$GENERATE_STREAMLIT_URL_FROM_NAME('nameValue');
   '''
 # ---
-# name: test_describeFunction
+# name: test_describe_function
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -97,7 +97,7 @@
   desc FUNCTION signatureValue;
   '''
 # ---
-# name: test_describeProcedure
+# name: test_describe_procedure
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -106,7 +106,7 @@
   desc PROCEDURE signatureValue;
   '''
 # ---
-# name: test_describeStreamlit
+# name: test_describe_streamlit
   '''
   use database databaseValue;
   use schema schemaValue;
@@ -115,7 +115,7 @@
   CALL SYSTEM$GENERATE_STREAMLIT_URL_FROM_NAME('nameValue');
   '''
 # ---
-# name: test_dropFunction
+# name: test_drop_function
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -124,7 +124,7 @@
   drop function signatureValue;
   '''
 # ---
-# name: test_dropProcedure
+# name: test_drop_procedure
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -133,7 +133,7 @@
   drop procedure signatureValue;
   '''
 # ---
-# name: test_dropStage
+# name: test_drop_stage
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -143,7 +143,7 @@
   drop stage nameValue;
   '''
 # ---
-# name: test_dropStreamlit
+# name: test_drop_streamlit
   '''
   use role roleValue;
   use database databaseValue;
@@ -152,7 +152,7 @@
   drop streamlit "nameValue";
   '''
 # ---
-# name: test_executeFunction
+# name: test_execute_function
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -161,7 +161,7 @@
   select functionValue;
   '''
 # ---
-# name: test_executeProcedure
+# name: test_execute_procedure
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -170,7 +170,7 @@
   call procedureValue;
   '''
 # ---
-# name: test_getStage[namedStageValue]
+# name: test_get_stage[namedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -180,7 +180,7 @@
   get @namedStageValue file://pathValue/
   '''
 # ---
-# name: test_getStage[snow://embeddedStageValue]
+# name: test_get_stage[snow://embeddedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -190,7 +190,7 @@
   get snow://embeddedStageValue file://pathValue/
   '''
 # ---
-# name: test_listFunctions
+# name: test_list_functions
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -200,7 +200,7 @@
   select "name", "created_on", "arguments", "language" from table(result_scan(last_query_id()));
   '''
 # ---
-# name: test_listProcedures
+# name: test_list_procedures
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -210,7 +210,7 @@
   select "name", "created_on", "arguments" from table(result_scan(last_query_id()));
   '''
 # ---
-# name: test_listStage[namedStageValue]
+# name: test_list_stage[namedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -219,7 +219,7 @@
   ls @namedStageValue;
   '''
 # ---
-# name: test_listStage[snow://embeddedStageValue]
+# name: test_list_stage[snow://embeddedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -228,7 +228,7 @@
   ls snow://embeddedStageValue;
   '''
 # ---
-# name: test_listStages
+# name: test_list_stages
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -237,7 +237,7 @@
   show stages;
   '''
 # ---
-# name: test_listStreamlits
+# name: test_list_streamlits
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -246,7 +246,7 @@
   show streamlits;
   '''
 # ---
-# name: test_putStage[namedStageValue]
+# name: test_put_stage[namedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -256,7 +256,7 @@
   put file://pathValue @namedStageValue auto_compress=false parallel=parallelValue overwrite=True;
   '''
 # ---
-# name: test_putStage[snow://embeddedStageValue]
+# name: test_put_stage[snow://embeddedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -266,7 +266,7 @@
   put file://pathValue snow://embeddedStageValue auto_compress=false parallel=parallelValue overwrite=True;
   '''
 # ---
-# name: test_removeFromStage[namedStageValue]
+# name: test_remove_from_stage[namedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -276,7 +276,7 @@
   remove @namedStageValue/pathValue
   '''
 # ---
-# name: test_removeFromStage[snow://embeddedStageValue]
+# name: test_remove_from_stage[snow://embeddedStageValue]
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -286,7 +286,7 @@
   remove snow://embeddedStageValue/pathValue
   '''
 # ---
-# name: test_setProcedureComment
+# name: test_set_procedure_comment
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -295,7 +295,7 @@
   alter PROCEDURE signatureValue SET COMMENT = $$commentValue$$;
   '''
 # ---
-# name: test_shareStreamlit
+# name: test_share_streamlit
   '''
   use role roleValue;
   use warehouse warehouseValue;
@@ -305,7 +305,7 @@
   grant usage on streamlit nameValue to role to_roleValue;
   '''
 # ---
-# name: test_showWarehouses
+# name: test_show_warehouses
   '''
   use role roleValue;
   use warehouse warehouseValue;

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -6,22 +6,22 @@ from snowcli.snow_connector import SnowflakeConnector
 
 
 # Used as a solution to syrupy having some problems with comparing multilines string
-class custom_str(str):
+class CustomStr(str):
     def __repr__(self):
         return str(self)
 
 
 @mock.patch("snowflake.connector")
-def test_createFunction(_, snapshot):
+def test_create_function(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.createFunction(
+    connector.create_function(
         name="nameValue",
-        inputParameters="(string a, variant b)",
-        returnType="returnTypeValue",
+        input_parameters="(string a, variant b)",
+        return_type="returnTypeValue",
         handler="handlerValue",
         imports="import1, import2",
         database="databaseValue",
@@ -33,20 +33,20 @@ def test_createFunction(_, snapshot):
     )
     query_io, *_ = connector.ctx.execute_stream.call_args.args
     query_str = query_io.getvalue()
-    assert custom_str(query_str) == snapshot
+    assert CustomStr(query_str) == snapshot
 
 
 @mock.patch("snowflake.connector")
-def test_createProcedure(_, snapshot):
+def test_create_procedure(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.createProcedure(
+    connector.create_procedure(
         name="nameValue",
-        inputParameters="(string a, variant b)",
-        returnType="returnTypeValue",
+        input_parameters="(string a, variant b)",
+        return_type="returnTypeValue",
         handler="handlerValue",
         imports="import1, import2",
         database="databaseValue",
@@ -62,13 +62,13 @@ def test_createProcedure(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_executeFunction(_, snapshot):
+def test_execute_function(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.executeFunction(
+    connector.execute_function(
         function="functionValue",
         database="databaseValue",
         schema="schemaValue",
@@ -80,13 +80,13 @@ def test_executeFunction(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_executeProcedure(_, snapshot):
+def test_execute_procedure(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.executeProcedure(
+    connector.execute_procedure(
         procedure="procedureValue",
         database="databaseValue",
         schema="schemaValue",
@@ -98,20 +98,20 @@ def test_executeProcedure(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_describeFunction(_, snapshot):
+def test_describe_function(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.describeFunction(
+    connector.describe_function(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
         warehouse="warehouseValue",
         signature="signatureValue",
         name="nameValue",
-        inputParameters="(string a, variant b)",
+        input_parameters="(string a, variant b)",
         show_exceptions="show_exceptionsValue",
     )
     query, *_ = connector.ctx.execute_stream.call_args.args
@@ -119,20 +119,20 @@ def test_describeFunction(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_describeProcedure(_, snapshot):
+def test_describe_procedure(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.describeProcedure(
+    connector.describe_procedure(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
         warehouse="warehouseValue",
         signature="signatureValue",
         name="nameValue",
-        inputParameters="(string a, variant b)",
+        input_parameters="(string a, variant b)",
         show_exceptions="show_exceptionsValue",
     )
     query, *_ = connector.ctx.execute_stream.call_args.args
@@ -140,13 +140,13 @@ def test_describeProcedure(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_listFunctions(_, snapshot):
+def test_list_functions(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.listFunctions(
+    connector.list_functions(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -158,13 +158,13 @@ def test_listFunctions(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_listStages(_, snapshot):
+def test_list_stages(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.listStages(
+    connector.list_stages(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -179,13 +179,13 @@ def test_listStages(_, snapshot):
     "stage_name", [("namedStageValue"), ("snow://embeddedStageValue")]
 )
 @mock.patch("snowflake.connector")
-def test_listStage(_, snapshot, stage_name):
+def test_list_stage(_, snapshot, stage_name):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.listStage(
+    connector.list_stage(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -201,13 +201,13 @@ def test_listStage(_, snapshot, stage_name):
     "stage_name", [("namedStageValue"), ("snow://embeddedStageValue")]
 )
 @mock.patch("snowflake.connector")
-def test_getStage(_, snapshot, stage_name):
+def test_get_stage(_, snapshot, stage_name):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.getStage(
+    connector.get_stage(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -220,20 +220,20 @@ def test_getStage(_, snapshot, stage_name):
 
 
 @mock.patch("snowflake.connector")
-def test_setProcedureComment(_, snapshot):
+def test_set_procedure_comment(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.setProcedureComment(
+    connector.set_procedure_comment(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
         warehouse="warehouseValue",
         signature="signatureValue",
         name="nameValue",
-        inputParameters="(string a, variant b)",
+        input_parameters="(string a, variant b)",
         show_exceptions="show_exceptionsValue",
         comment="commentValue",
     )
@@ -245,13 +245,13 @@ def test_setProcedureComment(_, snapshot):
     "stage_name", [("namedStageValue"), ("snow://embeddedStageValue")]
 )
 @mock.patch("snowflake.connector")
-def test_putStage(_, snapshot, stage_name):
+def test_put_stage(_, snapshot, stage_name):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.putStage(
+    connector.put_stage(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -269,13 +269,13 @@ def test_putStage(_, snapshot, stage_name):
     "stage_name", [("namedStageValue"), ("snow://embeddedStageValue")]
 )
 @mock.patch("snowflake.connector")
-def test_removeFromStage(_, snapshot, stage_name):
+def test_remove_from_stage(_, snapshot, stage_name):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.removeFromStage(
+    connector.remove_from_stage(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -288,13 +288,13 @@ def test_removeFromStage(_, snapshot, stage_name):
 
 
 @mock.patch("snowflake.connector")
-def test_createStage(_, snapshot):
+def test_create_stage(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.createStage(
+    connector.create_stage(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -306,13 +306,13 @@ def test_createStage(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_dropStage(_, snapshot):
+def test_drop_stage(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.dropStage(
+    connector.drop_stage(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -324,13 +324,13 @@ def test_dropStage(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_listProcedures(_, snapshot):
+def test_list_procedures(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.listProcedures(
+    connector.list_procedures(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -342,13 +342,13 @@ def test_listProcedures(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_dropFunction(_, snapshot):
+def test_drop_function(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.dropFunction(
+    connector.drop_function(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -360,13 +360,13 @@ def test_dropFunction(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_dropProcedure(_, snapshot):
+def test_drop_procedure(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.dropProcedure(
+    connector.drop_procedure(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -378,13 +378,13 @@ def test_dropProcedure(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_listStreamlits(_, snapshot):
+def test_list_streamlits(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.listStreamlits(
+    connector.list_streamlits(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -395,13 +395,13 @@ def test_listStreamlits(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_showWarehouses(_, snapshot):
+def test_show_warehouses(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.showWarehouses(
+    connector.show_warehouses(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -413,13 +413,13 @@ def test_showWarehouses(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_createStreamlit(_, snapshot):
+def test_create_streamlit(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.createStreamlit(
+    connector.create_streamlit(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -432,13 +432,13 @@ def test_createStreamlit(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_createStreamlitFromStage(_, snapshot):
+def test_create_streamlit_from_stage(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.createStreamlit(
+    connector.create_streamlit(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -452,13 +452,13 @@ def test_createStreamlitFromStage(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_shareStreamlit(_, snapshot):
+def test_share_streamlit(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.shareStreamlit(
+    connector.share_streamlit(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -471,13 +471,13 @@ def test_shareStreamlit(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_dropStreamlit(_, snapshot):
+def test_drop_streamlit(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.dropStreamlit(
+    connector.drop_streamlit(
         database="databaseValue",
         schema="schemaValue",
         role="roleValue",
@@ -489,14 +489,14 @@ def test_dropStreamlit(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_deployStreamlit(_, snapshot):
+def test_deploy_streamlit(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (mock.MagicMock(),)
-    connector.uploadFileToStage = mock.MagicMock()
+    connector.upload_file_to_stage = mock.MagicMock()
 
-    connector.deployStreamlit(
+    connector.deploy_streamlit(
         name="nameValue",
         file_path="file_pathValue",
         stage_path="stage_pathValue",
@@ -510,13 +510,13 @@ def test_deployStreamlit(_, snapshot):
 
 
 @mock.patch("snowflake.connector")
-def test_describeStreamlit(_, snapshot):
+def test_describe_streamlit(_, snapshot):
     connector = SnowflakeConnector(
         connection_name="foo", snowsql_config=mock.MagicMock()
     )
     connector.ctx.execute_stream.return_value = (None, None)
 
-    connector.describeStreamlit(
+    connector.describe_streamlit(
         name="nameValue",
         database="databaseValue",
         schema="schemaValue",

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -64,7 +64,7 @@ def test_sql_fails_for_both_query_and_file(runner):
 
 @mock.patch("snowcli.config.AppConfig")
 @mock.patch("snowflake.connector.connect")
-@mock.patch("snowcli.cli.sql.config.isAuth")
+@mock.patch("snowcli.cli.sql.config.is_auth")
 def test_sql_overrides_connection_configuration(_, mock_conn, mock_app_config, runner):
     with NamedTemporaryFile() as tmp:
         Path(tmp.name).write_text("[connections.fooConn]")

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -8,7 +8,7 @@ APP_CONFIG = "snowcli.cli.stage.AppConfig"
 @mock.patch(APP_CONFIG)
 @mock.patch(SNOWCLI_CONFIG)
 def test_default_path_in_get_command(mock_config, mock_app_config, runner):
-    mock_config.isAuth.return_value = True
+    mock_config.is_auth.return_value = True
     mock_app_config.return_value.config.get.return_value = {
         "database": "some_database",
         "schema": "some_schema",
@@ -19,7 +19,7 @@ def test_default_path_in_get_command(mock_config, mock_app_config, runner):
     result = runner.invoke(["stage", "get", "some_name"])
 
     assert result.exit_code == 0
-    mock_config.connectToSnowflake.assert_called_once()
+    mock_config.connect_to_snowflake.assert_called_once()
     mock_config.snowflake_connection.get_stage.assert_called_once_with(
         database="some_database",
         schema="some_schema",

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -20,7 +20,7 @@ def test_default_path_in_get_command(mock_config, mock_app_config, runner):
 
     assert result.exit_code == 0
     mock_config.connectToSnowflake.assert_called_once()
-    mock_config.snowflake_connection.getStage.assert_called_once_with(
+    mock_config.snowflake_connection.get_stage.assert_called_once_with(
         database="some_database",
         schema="some_schema",
         role="some_role",


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've described my changes in the section below.

### Changes description
I changed names of functions, variables and classes to stick with PEP-8 naming conventions. This is necessary, as we introduced stricter naming checks in pre-commit stage.
