### PR TITLE
Fixed regex in get_package_name_from_metadata

### DIFF
--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -237,10 +237,10 @@ def get_package_name_from_metadata(metadata_file_path: str) -> str | None:
     """
     with open(metadata_file_path, encoding="utf-8") as metadata_file:
         contents = metadata_file.read()
-        results = re.search("^Name: (.*)$", contents, flags=re.MULTILINE)
+        results = re.search("^( *)name: (.*)$", contents, flags=re.MULTILINE | re.IGNORECASE)
         if results is None:
             return None
-        return results.group(1)
+        return results.group(2)
 
 
 def generate_snowpark_coverage_wrapper(

--- a/src/snowcli/utils.py
+++ b/src/snowcli/utils.py
@@ -237,7 +237,9 @@ def get_package_name_from_metadata(metadata_file_path: str) -> str | None:
     """
     with open(metadata_file_path, encoding="utf-8") as metadata_file:
         contents = metadata_file.read()
-        results = re.search("^( *)name: (.*)$", contents, flags=re.MULTILINE | re.IGNORECASE)
+        results = re.search(
+            "^( *)name: (.*)$", contents, flags=re.MULTILINE | re.IGNORECASE
+        )
         if results is None:
             return None
         return results.group(2)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've described my changes in the section below.

### Changes description
Tests for this change are part of SNOW-821329_add_missing_unit_tests

So far, function get_package_name_from_metadata in utils module, was using a regex:
`re.search("^Name: (.*)$", contents, flags=re.MULTILINE)`

When checked with example files:
https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
https://gist.github.com/bbengfort/a77dd0ff610fd10f40926f7426a89486

it appeared, the code has two flaws:
1. It searches only for the occurence at the beginning of a line, while in example files, "name" is indented with two spaces
2. It looks for uppercase "Name", while example files use lowercase "name"

To fix it, i added IGNORECASE flag, and allowed 0+ spaces at the beggining of the line. 
