### PR TITLE
Cache connections to allow for multiple snow commands with browser authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "requests==2.31.0",
   "requirements-parser==0.5.0",
 #  "snowflake-connector-python==3.0.4",
-  "snowflake-connector-python-nightly==2023.6.24",
+  "snowflake-connector-python-nightly[secure-local-storage]==2023.6.24",
   "tomlkit==0.11.8",
   "typer==0.9.0",
 ]


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the section below.

### Changes description

Without this version of the snowflake connector, every separate snow command requires a new browser tab to be created. This version enables the credentials to be cached for a time after they are first created.

<img width="964" alt="image" src="https://github.com/Snowflake-Labs/snowcli/assets/102999810/52a45067-c95d-4382-bbf9-cf32c569ef6d">

See https://github.com/Snowflake-Labs/snowcli/pull/66 for a previous version of this.
