### PR TITLE
Show --help as suggestion rather than -h

### DIFF
--- a/src/snowcli/cli/common/flags.py
+++ b/src/snowcli/cli/common/flags.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typer
 from snowcli.utils import check_for_connection
 
-DEFAULT_CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+DEFAULT_CONTEXT_SETTINGS = {"help_option_names": ["--help", "-h"]}
 
 
 ConnectionOption = typer.Option(


### PR DESCRIPTION
This helps because -h is sometimes overridden (e.g. `snow snowpark function create -h` uses -h for handler). It's still usable in some cases (though perhaps should be removed altogether), but this means that if you have an incomplete command, it will say 
```
Try 'snow <commands> --help' for help.
```

Rather than this (which doesn't always work)
```
Try 'snow <commands> --h' for help.
```

### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the section below.

### Changes description
...
