### PR TITLE
Allow glob-style paths for snow stage put

### DIFF
--- a/src/snowcli/cli/stage/commands.py
+++ b/src/snowcli/cli/stage/commands.py
@@ -90,7 +90,7 @@ def stage_put(
     Upload files to a stage from a local client
     """
     manager = StageManager()
-    local_path = str(path) + "/*" if Path(path).is_dir() else str(path)
+    local_path = str(path) + "/*" if path.is_dir() else str(path)
 
     cursor = manager.put(
         local_path=local_path, stage_path=name, overwrite=overwrite, parallel=parallel

--- a/src/snowcli/cli/stage/commands.py
+++ b/src/snowcli/cli/stage/commands.py
@@ -66,6 +66,10 @@ def stage_put(
     path: Path = typer.Argument(
         ...,
         exists=False,
+        file_okay=True,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
         help=(
             "File or directory to upload to stage, can include a * in the path, "
             "like folder/*.csv"

--- a/src/snowcli/cli/stage/commands.py
+++ b/src/snowcli/cli/stage/commands.py
@@ -72,7 +72,8 @@ def stage_put(
         resolve_path=True,
         help=(
             "File or directory to upload to stage, can include a * in the path, "
-            "like folder/*.csv"
+            'like "folder/*.csv". Make sure you put quotes around the path if it'
+            " includes a *. "
         ),
     ),
     name: str = StageNameOption,

--- a/src/snowcli/cli/stage/commands.py
+++ b/src/snowcli/cli/stage/commands.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import typer
-
 from snowcli.cli.common.decorators import global_options_with_connection
 from snowcli.cli.common.flags import DEFAULT_CONTEXT_SETTINGS
 from snowcli.cli.stage.manager import StageManager
@@ -66,12 +65,11 @@ def stage_get(
 def stage_put(
     path: Path = typer.Argument(
         ...,
-        exists=True,
-        file_okay=True,
-        dir_okay=True,
-        writable=True,
-        resolve_path=True,
-        help="File or directory to upload to stage",
+        exists=False,
+        help=(
+            "File or directory to upload to stage, can include a * in the path, "
+            "like folder/*.csv"
+        ),
     ),
     name: str = StageNameOption,
     overwrite: bool = typer.Option(
@@ -88,7 +86,7 @@ def stage_put(
     Upload files to a stage from a local client
     """
     manager = StageManager()
-    local_path = str(path) + "/*" if path.is_dir() else str(path)
+    local_path = str(path) + "/*" if Path(path).is_dir() else str(path)
 
     cursor = manager.put(
         local_path=local_path, stage_path=name, overwrite=overwrite, parallel=parallel

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -85,3 +85,26 @@ def test_stage_remove(mock_execute, runner, mock_cursor):
     )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with("remove @stageName/my/file/foo.csv")
+
+
+@mock.patch(f"{STAGE_MANAGER}._execute_query")
+def test_stage_put_star(mock_execute, runner, mock_cursor):
+    mock_execute.return_value = mock_cursor(["row"], [])
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke_with_config(
+            [
+                "stage",
+                "put",
+                "-c",
+                "empty",
+                "--overwrite",
+                "--parallel",
+                42,
+                str(tmp_dir) + "/*.py",
+                "stageName",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+    mock_execute.assert_called_once_with(
+        f"put file://{Path(tmp_dir).resolve()}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
+    )

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -38,6 +38,13 @@ def test_stage_get_default_path(mock_execute, runner, mock_cursor):
     )
 
 
+def _resolve_tmp_dir(tmp_dir):
+    raw_path = str(Path(tmp_dir).resolve())
+    if raw_path.startswith("/private/"):
+        return raw_path.replace("/private/", "/")
+    return raw_path
+
+
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_put(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
@@ -57,7 +64,30 @@ def test_stage_put(mock_execute, runner, mock_cursor):
         )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with(
-        f"put file://{Path(tmp_dir).resolve()}/* @stageName auto_compress=false parallel=42 overwrite=True"
+        f"put file://{_resolve_tmp_dir(tmp_dir)}/* @stageName auto_compress=false parallel=42 overwrite=True"
+    )
+
+
+@mock.patch(f"{STAGE_MANAGER}._execute_query")
+def test_stage_put_star(mock_execute, runner, mock_cursor):
+    mock_execute.return_value = mock_cursor(["row"], [])
+    with TemporaryDirectory() as tmp_dir:
+        result = runner.invoke_with_config(
+            [
+                "stage",
+                "put",
+                "-c",
+                "empty",
+                "--overwrite",
+                "--parallel",
+                42,
+                str(tmp_dir) + "/*.py",
+                "stageName",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+    mock_execute.assert_called_once_with(
+        f"put file://{_resolve_tmp_dir(tmp_dir)}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
     )
 
 
@@ -85,26 +115,3 @@ def test_stage_remove(mock_execute, runner, mock_cursor):
     )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with("remove @stageName/my/file/foo.csv")
-
-
-@mock.patch(f"{STAGE_MANAGER}._execute_query")
-def test_stage_put_star(mock_execute, runner, mock_cursor):
-    mock_execute.return_value = mock_cursor(["row"], [])
-    with TemporaryDirectory() as tmp_dir:
-        result = runner.invoke_with_config(
-            [
-                "stage",
-                "put",
-                "-c",
-                "empty",
-                "--overwrite",
-                "--parallel",
-                42,
-                str(tmp_dir) + "/*.py",
-                "stageName",
-            ]
-        )
-    assert result.exit_code == 0, result.output
-    mock_execute.assert_called_once_with(
-        f"put file://{Path(tmp_dir).resolve()}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
-    )

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -38,13 +38,6 @@ def test_stage_get_default_path(mock_execute, runner, mock_cursor):
     )
 
 
-def _resolve_tmp_dir(tmp_dir):
-    raw_path = str(Path(tmp_dir).resolve())
-    if raw_path.startswith("/private/"):
-        return raw_path.replace("/private/", "/")
-    return raw_path
-
-
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_put(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
@@ -64,7 +57,7 @@ def test_stage_put(mock_execute, runner, mock_cursor):
         )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with(
-        f"put file://{_resolve_tmp_dir(tmp_dir)}/* @stageName auto_compress=false parallel=42 overwrite=True"
+        f"put file://{Path(tmp_dir)}/* @stageName auto_compress=false parallel=42 overwrite=True"
     )
 
 
@@ -87,7 +80,7 @@ def test_stage_put_star(mock_execute, runner, mock_cursor):
         )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with(
-        f"put file://{_resolve_tmp_dir(tmp_dir)}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
+        f"put file://{Path(tmp_dir)}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
     )
 
 

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -57,7 +57,7 @@ def test_stage_put(mock_execute, runner, mock_cursor):
         )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with(
-        f"put file://{Path(tmp_dir)}/* @stageName auto_compress=false parallel=42 overwrite=True"
+        f"put file://{Path(tmp_dir).resolve()}/* @stageName auto_compress=false parallel=42 overwrite=True"
     )
 
 
@@ -80,7 +80,7 @@ def test_stage_put_star(mock_execute, runner, mock_cursor):
         )
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with(
-        f"put file://{Path(tmp_dir)}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
+        f"put file://{Path(tmp_dir).resolve()}/*.py @stageName auto_compress=false parallel=42 overwrite=True"
     )
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the section below.

### Changes description

Fixes #331 by not requiring Typer to enforce that the path that is passed actually resolves to a valid local path, and allow glob-style paths to be passed directly.