### PR TITLE
Split global options into separate sections

### DIFF
--- a/src/snowcli/cli/common/flags.py
+++ b/src/snowcli/cli/common/flags.py
@@ -11,6 +11,10 @@ from snowcli.output.formats import OutputFormat
 DEFAULT_CONTEXT_SETTINGS = {"help_option_names": ["--help", "-h"]}
 
 
+_CONNECTION_SECTION = "Connection configuration"
+_CLI_BEHAVIOUR = "Global configuration"
+
+
 ConnectionOption = typer.Option(
     None,
     "-c",
@@ -19,6 +23,7 @@ ConnectionOption = typer.Option(
     help=f"Connection / environment name. If not provided then default connection will be used.",
     callback=ConnectionDetails.update_callback("connection_name"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 AccountOption = typer.Option(
@@ -28,6 +33,7 @@ AccountOption = typer.Option(
     help="Name assigned to your Snowflake account. Overrides value from connection.",
     callback=ConnectionDetails.update_callback("account"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 UserOption = typer.Option(
@@ -37,6 +43,7 @@ UserOption = typer.Option(
     help="Username to connect to Snowflake. Overrides value from connection.",
     callback=ConnectionDetails.update_callback("user"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 PasswordOption = typer.Option(
@@ -47,6 +54,7 @@ PasswordOption = typer.Option(
     hide_input=True,
     callback=ConnectionDetails.update_callback("password"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 DatabaseOption = typer.Option(
@@ -56,6 +64,7 @@ DatabaseOption = typer.Option(
     help="Database to use. Overrides value from connection.",
     callback=ConnectionDetails.update_callback("database"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 SchemaOption = typer.Option(
@@ -65,6 +74,7 @@ SchemaOption = typer.Option(
     help=" Schema in the database to use. Overrides value from connection.",
     callback=ConnectionDetails.update_callback("schema"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 RoleOption = typer.Option(
@@ -74,6 +84,7 @@ RoleOption = typer.Option(
     help="Role to be used. Overrides value from connection.",
     callback=ConnectionDetails.update_callback("role"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 WarehouseOption = typer.Option(
@@ -82,6 +93,7 @@ WarehouseOption = typer.Option(
     help="Warehouse to use. Overrides value from connection.",
     callback=ConnectionDetails.update_callback("warehouse"),
     show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
 )
 
 OutputFormatOption = typer.Option(
@@ -90,6 +102,7 @@ OutputFormatOption = typer.Option(
     help="Specifies output format",
     case_sensitive=False,
     callback=update_callback("output_format"),
+    rich_help_panel=_CLI_BEHAVIOUR,
 )
 
 VerboseOption = typer.Option(
@@ -99,6 +112,7 @@ VerboseOption = typer.Option(
     help="Print logs from level info and higher",
     callback=update_callback("verbose"),
     is_flag=True,
+    rich_help_panel=_CLI_BEHAVIOUR,
 )
 
 DebugOption = typer.Option(
@@ -107,4 +121,5 @@ DebugOption = typer.Option(
     help="Print logs from level debug and higher, logs contains additional information",
     callback=update_callback("enable_tracebacks"),
     is_flag=True,
+    rich_help_panel=_CLI_BEHAVIOUR,
 )


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the section below.

### Changes description
```
➜ snow snowpark procedure describe --help                  
                                                                                                                                                                                                                        
 Usage: snow snowpark procedure describe [OPTIONS]                                                                                                                                                                      
                                                                                                                                                                                                                        
 Describes a Snowflake procedure.                                                                                                                                                                                       
                                                                                                                                                                                                                        
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --name              -n      TEXT  Name of the procedure                                                                                                                                                              │
│ --input-parameters  -i      TEXT  Input parameters - such as (message string, count int)                                                                                                                             │
│ --procedure         -p      TEXT  Procedure signature with inputs. E.g. 'hello(int, string)'                                                                                                                         │
│ --help              -h            Show this message and exit.                                                                                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Connection configuration ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --connection,--environment  -c         TEXT  Connection / environment name. If not provided then default connection will be used.                                                                                    │
│ --account,--accountname                TEXT  Name assigned to your Snowflake account. Overrides value from connection.                                                                                               │
│ --username                  -user      TEXT  Username to connect to Snowflake. Overrides value from connection.                                                                                                      │
│ --password                  -p         TEXT  Snowflake password. Overrides value from connection.                                                                                                                    │
│ --database,--dbname                    TEXT  Database to use. Overrides value from connection.                                                                                                                       │
│ --schema,--schemaname                  TEXT  Schema in the database to use. Overrides value from connection.                                                                                                         │
│ --role,--rolename                      TEXT  Role to be used. Overrides value from connection.                                                                                                                       │
│ --warehouse                            TEXT  Warehouse to use. Overrides value from connection.                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Global configuration ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --format           [TABLE|JSON]  Specifies output format [default: TABLE]                                                                                                                                            │
│ --verbose  -v                    Print logs from level info and higher                                                                                                                                               │
│ --debug                          Print logs from level debug and higher, logs contains additional information                                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


```
