### PR TITLE
[NADE] Add --git-url and --template option to "snow app init"

### DIFF
--- a/src/snowcli/cli/nativeapp/commands.py
+++ b/src/snowcli/cli/nativeapp/commands.py
@@ -39,16 +39,20 @@ def app_init(
     name: str = typer.Argument(
         ..., help="Name of the Native Apps project to be initiated."
     ),
+    git_url: str = typer.Option(
+        None,
+        help="A git URL to use as template for the Native Apps project. Example: https://github.com/Snowflake-Labs/native-apps-templates.git for all official Snowflake templates.",
+    ),
     template: str = typer.Option(
         None,
-        help="A git URL to use as template for the Native Apps project. Example: https://github.com/Snowflake-Labs/native-apps-templates.git",
+        help="A specific directory within the git URL to use as template for the Native Apps project. Example: native-app-basic within https://github.com/Snowflake-Labs/native-apps-templates.git.",
     ),
     **options,
 ) -> CommandResult:
     """
-    Initialize a Native Apps project, optionally with a --template.
+    Initialize a Native Apps project, optionally with a --git-url and a --template.
     """
-    nativeapp_init(name, template)
+    nativeapp_init(name, git_url, template)
     return MessageResult(
         f"Native Apps project {name} has been created in your local directory."
     )

--- a/src/snowcli/cli/nativeapp/init.py
+++ b/src/snowcli/cli/nativeapp/init.py
@@ -5,14 +5,16 @@ import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from click.exceptions import ClickException
-from shutil import move
+from shutil import move, rmtree
 from git import Repo
+from strictyaml import load, as_document
 
 
 from typing import Optional
 from snowcli.cli.project.definition import DEFAULT_USERNAME
 from snowcli.cli.project.util import clean_identifier, get_env_username
 from snowcli.cli.common.utils import generic_render_template
+from snowcli.cli.project.definition_manager import DefinitionManager
 
 
 log = logging.getLogger(__name__)
@@ -79,11 +81,11 @@ def render_snowflake_yml(parent_to_snowflake_yml: Path):
 
     try:
         generic_render_template(
-            template_path=parent_to_snowflake_yml.joinpath(snowflake_yml_jinja),
+            template_path=parent_to_snowflake_yml / snowflake_yml_jinja,
             data={"project_name": parent_to_snowflake_yml.name},
-            output_file_path=parent_to_snowflake_yml.joinpath("snowflake.yml"),
+            output_file_path=parent_to_snowflake_yml / "snowflake.yml",
         )
-        os.remove(parent_to_snowflake_yml.joinpath(snowflake_yml_jinja))
+        os.remove(parent_to_snowflake_yml / snowflake_yml_jinja)
     except Exception as err:
         log.error(err)
         raise RenderingFromJinjaError(snowflake_yml_jinja)
@@ -109,37 +111,138 @@ def render_nativeapp_readme(parent_to_readme: Path, project_name: str):
 
     try:
         generic_render_template(
-            template_path=parent_to_readme.joinpath(readme_jinja),
+            template_path=parent_to_readme / readme_jinja,
             data={
                 "application_name": f"{default_application_name_prefix}_{default_application_name_suffix}"
             },
-            output_file_path=parent_to_readme.joinpath("README.md"),
+            output_file_path=parent_to_readme / "README.md",
         )
-        os.remove(parent_to_readme.joinpath(readme_jinja))
+        os.remove(parent_to_readme / readme_jinja)
     except Exception as err:
         log.error(err)
         raise RenderingFromJinjaError(readme_jinja)
 
 
-def _init_without_user_provided_template(
-    current_working_directory: Path, project_name: str
-):
+def replace_snowflake_yml_name_with_project(target_directory: Path):
     """
-    Initialize a Native Apps project without any template specified by the user.
+    Replace the native_app schema's "name" field in a snowflake.yml file with its parent directory name, i.e. the native app project, as the default start.
+    This does not change the name in any other snowflake.*.yml as snowflake.yml is the base file and all others are overrides for the user to customize.
 
     Args:
-        current_working_directory (str): The current working directory of the user where the project will be added.
-        project_name (str): Name of the project to be created.
+        target_directory (str): The directory containing snowflake.yml at its root.
 
     Returns:
         None
     """
 
+    path_to_snowflake_yml = target_directory / "snowflake.yml"
+    contents = None
+
+    with open(path_to_snowflake_yml) as f:
+        contents = load(f.read()).data
+
+    if "native_app" in contents and "name" in contents["native_app"]:
+        contents["native_app"]["name"] = target_directory.name
+        with open(path_to_snowflake_yml, "w") as f:
+            f.write(as_document(contents).as_yaml())
+    # If there are no such keys, the Definition Manager will catch that during validation
+
+
+def validate_and_update_snowflake_yml(target_directory: Path):
+    """
+    Update the native_app name key in the snowflake.yml file and perform validation on the entire file.
+
+    Args:
+        target_directory (str): The directory containing snowflake.yml at its root.
+
+    Returns:
+        None
+    """
+    # 1. Determine if a snowflake.yml file exists, at the very least
+    definition_manager = DefinitionManager(target_directory)
+
+    # 2. Change the project name in snowflake.yml to project_name
+    replace_snowflake_yml_name_with_project(target_directory=target_directory)
+
+    # 3. Validate the Project Definition File(s)
+    # We do not need to use the result of the call below, we just want to validate the file
+    definition_manager.project_definition
+
+
+def _init_with_url_and_no_template(
+    current_working_directory: Path,
+    project_name: str,
+    git_url: str,
+):
+    """
+    Initialize a Native Apps project with a git url but without any specific template specified by the user.
+
+    Args:
+        current_working_directory (str): The current working directory of the user where the project will be added.
+        project_name (str): Name of the project to be created.
+        git_url (str): The git URL to perform a clone from.
+
+    Returns:
+        None
+    """
+
+    target_directory: Optional[Path] = None
+    try:
+        # with TemporaryDirectory(dir=current_working_directory) as temp_dir:
+        target_directory = current_working_directory / project_name
+        target_directory.mkdir(parents=True, exist_ok=False)
+
+        # Clone the repository with options.
+        Repo.clone_from(
+            url=git_url,
+            to_path=target_directory,
+            filter=["tree:0"],
+            depth=1,
+        )
+
+        # Remove all git history
+        rmtree(target_directory.joinpath(".git").resolve())
+
+        # Non-Snowflake git URLs should not have jinja files in their directory structure.
+        # If they do, snowCLI is not responsible for rendering them during init.
+        # If the SNOWFLAKELABS_GITHUB_URL is provided here, rendering is additionally skipped as there is no jinja file at the root.
+
+        # If not an official Snowflake Native App template
+        if git_url != SNOWFLAKELABS_GITHUB_URL:
+            validate_and_update_snowflake_yml(target_directory=target_directory)
+
+    except Exception as err:
+        # If there was any error, validation on Project Definition file or otherwise,
+        # there should not be any Native Apps Project left after this.
+        if target_directory:
+            rmtree(target_directory.resolve())
+
+        log.error(err)
+        raise InitError()
+
+
+def _init_with_url_and_template(
+    current_working_directory: Path, project_name: str, git_url: str, template: str
+):
+    """
+    Initialize a Native Apps project with a git URL and a specific template within the git URL.
+
+    Args:
+        current_working_directory (str): The current working directory of the user where the project will be added.
+        project_name (str): Name of the project to be created.
+        git_url (str): The git URL to perform a clone from.
+        template (str): A template within the git URL to use, all other directories and files outside the template will be discarded.
+
+    Returns:
+        None
+    """
+
+    path_to_project: Optional[Path] = None
     try:
         with TemporaryDirectory(dir=current_working_directory) as temp_dir:
             # Clone the repository in the temporary directory with options.
             Repo.clone_from(
-                url=SNOWFLAKELABS_GITHUB_URL,
+                url=git_url,
                 to_path=temp_dir,
                 filter=["tree:0"],
                 depth=1,
@@ -147,49 +250,77 @@ def _init_without_user_provided_template(
 
             # Move native-app-basic to current_working_directory and rename to name
             move(
-                src=current_working_directory.joinpath(temp_dir, BASIC_TEMPLATE),
-                dst=current_working_directory.joinpath(project_name),
+                src=current_working_directory / temp_dir / template,
+                dst=current_working_directory / project_name,
             )
 
-        # Render snowflake.yml file from its jinja template
-        render_snowflake_yml(
-            parent_to_snowflake_yml=current_working_directory.joinpath(project_name)
-        )
+        path_to_project = current_working_directory / project_name
+        # Rendering should be conditinal on the below combination,
+        # as right now, we only allow rendering of a jinja file within this combination
+        if (git_url == SNOWFLAKELABS_GITHUB_URL) and (template == BASIC_TEMPLATE):
+            # Render snowflake.yml file from its jinja template
+            render_snowflake_yml(parent_to_snowflake_yml=path_to_project)
 
-        # Render README.md file from its jinja template
-        render_nativeapp_readme(
-            parent_to_readme=current_working_directory.joinpath(project_name, "app"),
-            project_name=project_name,
-        )
+            # Render README.md file from its jinja template
+            render_nativeapp_readme(
+                parent_to_readme=path_to_project / "app",
+                project_name=project_name,
+            )
+
+        # If not an official Snowflake Native App template
+        if git_url != SNOWFLAKELABS_GITHUB_URL:
+            validate_and_update_snowflake_yml(target_directory=path_to_project)
 
     except Exception as err:
+        # If there was any error, validation on Project Definition file or otherwise,
+        # there should not be any Native Apps Project left after this.
+        if path_to_project:
+            rmtree(path_to_project.resolve())
+
         log.error(err)
         raise InitError()
 
 
-def nativeapp_init(name: str, template: Optional[str] = None):
+def nativeapp_init(
+    name: str, git_url: Optional[str] = None, template: Optional[str] = None
+):
     """
-    Initialize a Native Apps project in the user's local directory, with or without the use of a template.
+    Initialize a Native Apps project in the user's current working directory, with or without the use of a template.
+
+    Args:
+        name (str): Name of the project to be created.
+        git_url (str): The git URL to perform a clone from.
+        template (str): A template within the git URL to use, all other directories and files outside the template will be discarded.
+
+    Returns:
+        None
     """
 
     current_working_directory = Path.cwd()
 
     # If current directory is already contains a file named snowflake.yml, i.e. is a native apps project, fail init command.
     # We do not validate the yml here though.
-    path_to_snowflake_yml = current_working_directory.joinpath("snowflake.yml")
+    path_to_snowflake_yml = current_working_directory / "snowflake.yml"
     if path_to_snowflake_yml.is_file():
         raise CannotInitializeAnExistingProjectError()
 
     # If a subdirectory with the same name as name exists in the current directory, fail init command
-    path_to_project = current_working_directory.joinpath(name)
+    path_to_project = current_working_directory / name
     if path_to_project.exists():
         raise DirectoryAlreadyExistsError(name)
 
-    if template:  # If user provided a template, use the template
-        # Implementation to be added as part of https://snowflakecomputing.atlassian.net/browse/SNOW-896905
-        pass
-    else:  # No template provided, use Native Apps Basic Template
-        _init_without_user_provided_template(
+    if (
+        git_url and not template
+    ):  # If user provided a git url but no template, use the full clone
+        _init_with_url_and_no_template(
             current_working_directory=current_working_directory,
             project_name=name,
+            git_url=git_url,
+        )
+    else:  # If user provided some other combination of git url and template, only prioritize the template cloning
+        _init_with_url_and_template(
+            current_working_directory=current_working_directory,
+            project_name=name,
+            git_url=git_url if git_url else SNOWFLAKELABS_GITHUB_URL,
+            template=template if template else BASIC_TEMPLATE,
         )

--- a/tests/nativeapp/__snapshots__/test_init.ambr
+++ b/tests/nativeapp/__snapshots__/test_init.ambr
@@ -1,0 +1,12 @@
+# serializer version: 1
+# name: test_init_with_url_and_template_w_random_url_and_template
+  '''
+  definition_version: 1
+  native_app:
+    name: fake_repo
+    artifacts:
+    - setup.sql
+    - README.md
+  
+  '''
+# ---

--- a/tests/nativeapp/test_commands.py
+++ b/tests/nativeapp/test_commands.py
@@ -7,11 +7,11 @@ PROJECT_NAME = "demo_na_project"
 
 
 @mock.patch(
-    "snowcli.cli.nativeapp.init._init_without_user_provided_template",
+    "snowcli.cli.nativeapp.init._init_with_url_and_template",
     return_value=None,
 )
 def test_init_no_template_success(
-    mock_init_without_user_provided_template, runner, temp_dir, snapshot
+    mock_init_with_url_and_template, runner, temp_dir, snapshot
 ):
     # temp_dir will be cwd for the rest of this test
     result = runner.invoke(["app", "init", PROJECT_NAME])


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch. [As of Sept 12, 5:40PM EST]
   * [x] I've described my changes in the section below.

### Changes description
This PR introduces an extension on the `snow app init` command for native apps, by allowing `--template` and `--git-url` options to be specified in this command. 

As a heads up, some existing code had to be refactored as part of introducing the new options and re-using existing code as much as possible. Accordingly, tests have been added which cover the new and refactored behavior. 