### PR TITLE
[NADE] Add Project Name Validation + Clarify Help Command

### DIFF
--- a/src/snowcli/cli/nativeapp/commands.py
+++ b/src/snowcli/cli/nativeapp/commands.py
@@ -45,7 +45,7 @@ def app_init(
     ),
     template: str = typer.Option(
         None,
-        help="A specific directory within the git URL to use as template for the Native Apps project. Example: native-app-basic within https://github.com/Snowflake-Labs/native-apps-templates.git.",
+        help="A specific directory within the git URL to use as template for the Native Apps project. Example: Default is native-app-basic if --git-url is https://github.com/Snowflake-Labs/native-apps-templates.git, and None if any other --git-url.",
     ),
     **options,
 ) -> CommandResult:

--- a/src/snowcli/cli/nativeapp/init.py
+++ b/src/snowcli/cli/nativeapp/init.py
@@ -265,7 +265,7 @@ def _init_with_url_and_template(
                 depth=1,
             )
 
-            # Move native-app-basic to current_working_directory and rename to name
+            # Move native-apps-basic to current_working_directory and rename to name
             move(
                 src=current_working_directory / temp_dir / template,
                 dst=current_working_directory / project_name,

--- a/tests/nativeapp/test_init.py
+++ b/tests/nativeapp/test_init.py
@@ -1,4 +1,5 @@
 from snowcli.cli.nativeapp.init import (
+    is_valid_project_name,
     render_snowflake_yml,
     render_nativeapp_readme,
     nativeapp_init,
@@ -9,16 +10,44 @@ from snowcli.cli.nativeapp.init import (
     CannotInitializeAnExistingProjectError,
     DirectoryAlreadyExistsError,
     InitError,
+    ProjectNameInvalidError,
 )
 from snowcli.exception import MissingConfiguration
 from tests.testing_utils.fixtures import *
 from textwrap import dedent
+from secrets import choice
+from string import ascii_letters, digits
 
 PROJECT_NAME = "demo_na_project"
+MAX_ALLOWED_NUM_CHARACTERS = 255
 
 # --------------------------------------
 # ----- Tests for Helper Methods -------
 # --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "project_name, expected",
+    [
+        ("_", True),  # Edge Case: Only One Character from the Allowed List
+        ("A", True),  # Edge Case: Only One Character from the Allowed List
+        ("9", False),  # Edge Case: Only One Character not from the Allowed List
+        ("_aB3_$", True),  # Test all allowed character types
+        ("__", True),  # Test all allowed character types
+        (
+            "".join(choice(ascii_letters) for i in range(MAX_ALLOWED_NUM_CHARACTERS)),
+            True,
+        ),
+        (
+            "".join(
+                choice(ascii_letters) for i in range(MAX_ALLOWED_NUM_CHARACTERS - 2)
+            ).join("*%"),
+            False,
+        ),
+    ],
+)
+def test_is_valid_project_name(project_name, expected):
+    assert is_valid_project_name(project_name) == expected
 
 
 def test_render_snowflake_yml(other_directory):
@@ -195,7 +224,7 @@ def test_init_with_url_and_no_template_w_native_app_url(mock_clone_from, temp_di
         _init_with_url_and_no_template(
             current_working_directory=Path.cwd(),
             project_name=fake_repo,
-            git_url="https://github.com/Snowflake-Labs/native-app-templates",
+            git_url="https://github.com/Snowflake-Labs/native-apps-templates",
         )
 
         dest = Path.cwd() / fake_repo
@@ -316,7 +345,7 @@ def test_init_with_url_and_template_w_native_app_url_and_template(
     _init_with_url_and_template(
         current_working_directory=Path.cwd(),
         project_name=fake_repo,
-        git_url="https://github.com/Snowflake-Labs/native-app-templates",
+        git_url="https://github.com/Snowflake-Labs/native-apps-templates",
         template="native-app-basic",
     )
 
@@ -385,3 +414,9 @@ def test_init_w_existing_yml(mock_path_is_file):
 def test_init_w_existing_directory(mock_path_exists):
     with pytest.raises(DirectoryAlreadyExistsError):
         nativeapp_init(name=PROJECT_NAME)
+
+
+@mock.patch("snowcli.cli.nativeapp.init.fullmatch", return_value=None)
+def test_init_w_invalid_project_name(mock_fullmatch):
+    with pytest.raises(ProjectNameInvalidError):
+        nativeapp_init(PROJECT_NAME)

--- a/tests/nativeapp/test_init.py
+++ b/tests/nativeapp/test_init.py
@@ -346,7 +346,7 @@ def test_init_with_url_and_template_w_native_app_url_and_template(
         current_working_directory=Path.cwd(),
         project_name=fake_repo,
         git_url="https://github.com/Snowflake-Labs/native-apps-templates",
-        template="native-app-basic",
+        template="native-apps-basic",
     )
 
     fake_repo_path = current_working_directory / fake_repo


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch. [As of Sept 18, 5:00PM EST]
   * [x] I've described my changes in the section below.

### Changes description
This PR adds a validation check to the project name for Native Apps Init command. 

1. This will minimize any conflicts between names used on different platforms, e.g. Windows v Linux/Mac. 
2. Since project name is used to populate default value of application package and application in snowflake.yml, we need to ensure that it is consistent with Snowflake's own identifier requirements, adapted to our use case (first two points in https://docs.snowflake.com/en/sql-reference/identifiers-syntax). This will prevent an experience where a developer creates a directory that may be a valid name on their OS but is not a valid object name in Snowflake, hence creating confusion. 
