### PR TITLE
[NADE] Create application / apply package scripts

### DIFF
--- a/src/snowcli/cli/common/sql_execution.py
+++ b/src/snowcli/cli/common/sql_execution.py
@@ -36,9 +36,11 @@ class SqlExecutionMixin:
         is_different_role = new_role.lower() != prev_role.lower()
         if is_different_role:
             self._execute_query(f"use role {new_role}")
-        yield
-        if is_different_role:
-            self._execute_query(f"use role {prev_role}")
+        try:
+            yield
+        finally:
+            if is_different_role:
+                self._execute_query(f"use role {prev_role}")
 
     def _execute_schema_query(self, query: str):
         self.check_database_and_schema()

--- a/src/snowcli/cli/nativeapp/artifacts.py
+++ b/src/snowcli/cli/nativeapp/artifacts.py
@@ -45,27 +45,32 @@ class TooManyFilesError(ClickException):
     dest_path: Path
 
     def __init__(self, dest_path: Path):
-        super().__init__(f"self.__doc__\ndest_path = {dest_path}")
+        super().__init__(f"{self.__doc__}\ndest_path = {dest_path}")
         self.dest_path = dest_path
 
 
-class OutsideDeployRootError(ClickException):
+class NotInDeployRootError(ClickException):
     """
-    The specified path is outside of the deploy root.
-    This can happen when a relative path with ".." is provided.
+    The specified destination path is outside of the deploy root, or
+    would entirely replace it. This can happen when a relative path
+    with ".." is provided, or when "." is used as the destination
+    (use "./" instead to copy into the deploy root).
     """
 
+    artifact_src: str
     dest_path: Path
     deploy_root: Path
 
-    def __init__(self, dest_path: Path, deploy_root: Path):
+    def __init__(self, artifact_src: str, dest_path: Path, deploy_root: Path):
         super().__init__(
             f"""
             {self.__doc__}
-            \ndest_path = {dest_path}
-            \ndeploy_root = {deploy_root}
+            artifact_src = {artifact_src}
+            dest_path = {dest_path}
+            deploy_root = {deploy_root}
             """
         )
+        self.artifact_src = artifact_src
         self.dest_path = dest_path
         self.deploy_root = deploy_root
 
@@ -89,16 +94,28 @@ def specifies_directory(s: str) -> bool:
     """
     Does the path (as seen from the project definition) refer to
     a directory? For destination paths, we enforce the usage of a
-    trailing slash (i.e. \ for windows; / for others).
+    trailing forward slash (/). Note that we use the forward slash
+    even on Windows so that snowflake.yml can be shared between OSes.
 
     This means that to put a file in the root of the stage, we need
     to specify "./" as its destination, or omit it (but only if the
     file already lives in the project root).
     """
-    return s.endswith(os.sep)
+    return s.endswith("/")
 
 
-def symlink_or_copy(src: Path, dst: Path, makedirs=True) -> None:
+def delete(path: Path) -> None:
+    """
+    Obliterates whatever is at the given path, or is a no-op if the
+    given path does not represent a file or directory that exists.
+    """
+    if os.path.isfile(path) or os.path.islink(path):
+        os.remove(path)  # remove the file
+    elif os.path.isdir(path):
+        shutil.rmtree(path)  # remove dir and all contains
+
+
+def symlink_or_copy(src: Path, dst: Path, makedirs=True, overwrite=True) -> None:
     """
     Tries to create a symlink to src at dst; failing that (i.e. in Windows
     without Administrator / Developer Mode) copies the file from src to dst instead.
@@ -107,15 +124,20 @@ def symlink_or_copy(src: Path, dst: Path, makedirs=True) -> None:
     """
     if makedirs:
         dst.parent.mkdir(parents=True, exist_ok=True)
+    if overwrite:
+        delete(dst)
     try:
-        if dst.is_file():
-            dst.unlink()
         os.symlink(src, dst)
     except OSError:
         shutil.copy(src, dst)
 
 
 def translate_artifact(item: Union[dict, str]) -> ArtifactMapping:
+    """
+    Builds an artifact mapping from a project definition value.
+    Validation is done later when we actually resolve files / folders.
+    """
+
     if isinstance(item, dict):
         return ArtifactMapping(item["src"], item.get("dest", item["src"]))
 
@@ -130,6 +152,8 @@ def get_source_paths(artifact: ArtifactMapping, project_root: Path) -> List[Path
     """
     Expands globs, ensuring at least one file exists that matches artifact.src.
     Returns a list of paths that resolve to actual files in the project root dir structure.
+    If a glob does not specify a directory (i.e. does not end with a path separator)
+
     """
     source_paths: List[Path]
 
@@ -166,18 +190,22 @@ def build_bundle(
         raise ValueError(f"Deploy root {resolved_root} exists, but is not a directory!")
 
     for artifact in artifacts:
-        # make sure we are only modifying files / directories inside the deploy root
         dest_path = resolve_without_follow(Path(resolved_root, artifact.dest))
-        if resolved_root != dest_path and resolved_root not in dest_path.parents:
-            raise OutsideDeployRootError(dest_path, resolved_root)
-
         source_paths = get_source_paths(artifact, project_root)
 
         if specifies_directory(artifact.dest):
+            # make sure we are only modifying files / directories inside the deploy root
+            if resolved_root != dest_path and resolved_root not in dest_path.parents:
+                raise NotInDeployRootError(artifact.src, dest_path, resolved_root)
+
             # copy all files as children of the given destination path
             for source_path in source_paths:
                 symlink_or_copy(source_path, dest_path / source_path.name)
         else:
+            # ensure we are copying into the deploy root, not replacing it!
+            if resolved_root not in dest_path.parents:
+                raise NotInDeployRootError(artifact.src, dest_path, resolved_root)
+
             if len(source_paths) == 1:
                 # copy a single file as the given destination path
                 symlink_or_copy(source_paths[0], dest_path)

--- a/src/snowcli/cli/nativeapp/commands.py
+++ b/src/snowcli/cli/nativeapp/commands.py
@@ -82,16 +82,15 @@ def app_run(
     **options,
 ) -> CommandResult:
     """
-    Creates an application package in your Snowflake account and uploads code files to its stage.
-    As a note, this command does not accept role or warehouse overrides to your config.toml file,
-    because your native app definition in snowflake.yml/snowflake.local.yml is used for any overrides.
+    Creates an application package in your Snowflake account, uploads code files to its stage,
+    then creates a development-mode instance of that application. As a note, this command does not
+    accept role or warehouse overrides to your config.toml file, because your native app definition
+    in snowflake.yml/snowflake.local.yml is used for any overrides.
     """
     manager = NativeAppManager(project_path)
     manager.build_bundle()
     manager.app_run()
-    return MessageResult(
-        f"Application Package is now active in your Snowflake account!"
-    )
+    return MessageResult(f'Your application ("{manager.app_name}") is now live!')
 
 
 @app.command("teardown")

--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -345,7 +345,7 @@ class NativeAppManager(SqlExecutionMixin):
                     raise ApplicationPackageAlreadyExistsError(self.package_name)
 
                 actual_owner = show_app_row[OWNER_COL]
-                if actual_owner != self.app_pkg_role:
+                if actual_owner != self.package_role:
                     raise UnexpectedOwnerError(
                         self.app_name, self.app_role, actual_owner
                     )

--- a/src/snowcli/cli/project/definition.py
+++ b/src/snowcli/cli/project/definition.py
@@ -91,6 +91,5 @@ def default_role():
 
 
 def default_application(project_name: str):
-    print(project_name)
     user = clean_identifier(get_env_username() or DEFAULT_USERNAME)
     return f"{project_name}_{user}"

--- a/src/snowcli/cli/project/schema.py
+++ b/src/snowcli/cli/project/schema.py
@@ -14,12 +14,9 @@ from strictyaml import (
     YAML,
 )
 
-IDENTIFIER = r'(?:("[^"]*(""[^"]*)*")|([A-Za-z_][\w$]{0,254}))'
-SCHEMA_AND_NAME = f"{IDENTIFIER}[.]{IDENTIFIER}"
-GLOB_REGEX = r"^[a-zA-Z0-9_\-./*?**\p{L}\p{N}]+$"
-RELATIVE_PATH = r"^[^/][\p{L}\p{N}_\-.][^/]*$"
+from .util import SCHEMA_AND_NAME, IDENTIFIER
 
-# TODO: use the above regexes to validate paths + globs
+# TODO: use the util regexes to validate paths + globs
 FilePath = Str
 Glob = Str
 
@@ -60,17 +57,15 @@ PathMapping = RelaxedMap(
     }
 )
 
-DEFAULT_PACKAGE_SCRIPTS = "package/*.sql"
 native_app_schema = RelaxedMap(
     {
         "name": Str(),
         "artifacts": Seq(FilePath() | PathMapping),
         Optional("deploy_root", default="output/deploy/"): FilePath(),
         Optional("source_stage", default="app_src.stage"): Regex(SCHEMA_AND_NAME),
-        Optional("package", default=dict(scripts=DEFAULT_PACKAGE_SCRIPTS)): RelaxedMap(
+        Optional("package"): RelaxedMap(
             {
-                Optional("scripts", default=DEFAULT_PACKAGE_SCRIPTS): Glob()
-                | UniqueSeq(Glob()),
+                Optional("scripts", default=None): UniqueSeq(FilePath()),
                 Optional("role"): Regex(IDENTIFIER),
                 Optional("name"): Regex(IDENTIFIER),
             }

--- a/src/snowcli/cli/project/util.py
+++ b/src/snowcli/cli/project/util.py
@@ -2,6 +2,12 @@ import re
 import os
 from typing import Optional
 
+IDENTIFIER = r'((?:"[^"]*(?:""[^"]*)*")|(?:[A-Za-z_][\w$]{0,254}))'
+DB_SCHEMA_AND_NAME = f"{IDENTIFIER}[.]{IDENTIFIER}[.]{IDENTIFIER}"
+SCHEMA_AND_NAME = f"{IDENTIFIER}[.]{IDENTIFIER}"
+GLOB_REGEX = r"^[a-zA-Z0-9_\-./*?**\p{L}\p{N}]+$"
+RELATIVE_PATH = r"^[^/][\p{L}\p{N}_\-.][^/]*$"
+
 
 def clean_identifier(input):
     """
@@ -9,6 +15,19 @@ def clean_identifier(input):
     converting to lowercase as well.
     """
     return re.sub(r"[^a-z0-9_$]", "", f"{input}".lower())
+
+
+def extract_schema(qualified_name: str):
+    """
+    Extracts the schema from either a two-part or three-part qualified name
+    (i.e. schema.object or database.schema.object). If qualified_name is not
+    qualified with a schema, returns None.
+    """
+    if match := re.fullmatch(DB_SCHEMA_AND_NAME, qualified_name):
+        return match.group(2)
+    elif match := re.fullmatch(SCHEMA_AND_NAME, qualified_name):
+        return match.group(1)
+    return None
 
 
 def generate_user_env(username: str) -> dict:

--- a/src/snowcli/cli/stage/diff.py
+++ b/src/snowcli/cli/stage/diff.py
@@ -34,6 +34,13 @@ class DiffResult:
     only_on_stage: List[str] = field(default_factory=list)
     "Files that only exist on the stage"
 
+    def has_changes(self) -> bool:
+        return (
+            len(self.different) > 0
+            or len(self.only_local) > 0
+            or len(self.only_on_stage) > 0
+        )
+
 
 def is_valid_md5sum(checksum: str) -> bool:
     """

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -11,7 +11,7 @@ from snowcli.cli.nativeapp.artifacts import (
     GlobMatchedNothingError,
     SourceNotFoundError,
     TooManyFilesError,
-    OutsideDeployRootError,
+    NotInDeployRootError,
 )
 from snowcli.cli.project.definition import load_project_definition
 
@@ -87,20 +87,27 @@ def test_glob_matched_nothing(project_definition_files):
 
 
 @pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
-def test_outside_deploy_root_two_ways(project_definition_files):
+def test_outside_deploy_root_three_ways(project_definition_files):
     project_root = project_definition_files[0].parent
-    with pytest.raises(OutsideDeployRootError):
+    with pytest.raises(NotInDeployRootError):
         build_bundle(
             project_root,
             deploy_root=Path(project_root, "deploy"),
             artifacts=[ArtifactMapping("setup.sql", "..")],
         )
 
-    with pytest.raises(OutsideDeployRootError):
+    with pytest.raises(NotInDeployRootError):
         build_bundle(
             project_root,
             deploy_root=Path(project_root, "deploy"),
             artifacts=[ArtifactMapping("setup.sql", "/")],
+        )
+
+    with pytest.raises(NotInDeployRootError):
+        build_bundle(
+            project_root,
+            deploy_root=Path(project_root, "deploy"),
+            artifacts=[ArtifactMapping("app", ".")],
         )
 
 

--- a/tests/nativeapp/test_artifacts.py
+++ b/tests/nativeapp/test_artifacts.py
@@ -43,11 +43,8 @@ def test_napp_project_1_artifacts(project_definition_files):
     native_app = load_project_definition(project_definition_files)["native_app"]
 
     deploy_root = Path(project_root, native_app["deploy_root"])
-    build_bundle(
-        project_root,
-        deploy_root,
-        artifacts=[translate_artifact(item) for item in native_app["artifacts"]],
-    )
+    artifacts = [translate_artifact(item) for item in native_app["artifacts"]]
+    build_bundle(project_root, deploy_root, artifacts)
 
     assert dir_structure(deploy_root) == [
         "app/README.md",
@@ -62,6 +59,9 @@ def test_napp_project_1_artifacts(project_definition_files):
     assert trimmed_contents(deploy_root / "app" / "README.md") == "app/README.md"
     assert trimmed_contents(deploy_root / "ui" / "main.py") == "# main.py"
     assert trimmed_contents(deploy_root / "ui" / "config.py") == "# config.py"
+
+    # we should be able to re-bundle without any errors happening
+    build_bundle(project_root, deploy_root, artifacts)
 
 
 @pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -41,7 +41,7 @@ mock_snowflake_yml_file = dedent(
                 warehouse: app_warehouse
                 debug: true
 
-             package:
+            package:
                 name: app_pkg
                 scripts:
                     - shared_content.sql

--- a/tests/nativeapp/test_package_scripts.py
+++ b/tests/nativeapp/test_package_scripts.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+import pytest
+from unittest import mock
+from textwrap import dedent
+
+from snowcli.cli.nativeapp.manager import (
+    NativeAppManager,
+    MissingPackageScriptError,
+    InvalidPackageScriptError,
+)
+
+from tests.project.fixtures import *
+from tests.testing_utils.fixtures import *
+
+NATIVEAPP_MODULE = "snowcli.cli.nativeapp.manager"
+NATIVEAPP_MANAGER_EXECUTE_QUERIES = (
+    f"{NATIVEAPP_MODULE}.NativeAppManager._execute_queries"
+)
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
+@pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
+def test_package_scripts(mock_execute, project_definition_files):
+    working_dir: Path = project_definition_files[0].parent
+    native_app_manager = NativeAppManager(str(working_dir))
+    native_app_manager._apply_package_scripts()
+    assert mock_execute.mock_calls == [
+        mock.call(
+            dedent(
+                f"""\
+                    -- package script (1/2)
+
+                    create schema if not exists myapp_pkg_polly.my_shared_content;
+                    grant usage on schema myapp_pkg_polly.my_shared_content
+                      to share in application package myapp_pkg_polly;
+                """
+            )
+        ),
+        mock.call(
+            dedent(
+                f"""\
+                    -- package script (2/2)
+
+                    create or replace table myapp_pkg_polly.my_shared_content.shared_table (
+                      col1 number,
+                      col2 varchar
+                    );
+                    grant select on table myapp_pkg_polly.my_shared_content.shared_table
+                      to share in application package myapp_pkg_polly;
+                """
+            )
+        ),
+    ]
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
+@pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
+def test_missing_package_script(mock_execute, project_definition_files):
+    working_dir: Path = project_definition_files[0].parent
+    native_app_manager = NativeAppManager(str(working_dir))
+    with pytest.raises(MissingPackageScriptError):
+        (working_dir / "002-shared.sql").unlink()
+        native_app_manager._apply_package_scripts()
+
+    # even though the second script was the one missing, nothing should be executed
+    assert mock_execute.mock_calls == []
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
+@pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
+def test_invalid_package_script(mock_execute, project_definition_files):
+    working_dir: Path = project_definition_files[0].parent
+    native_app_manager = NativeAppManager(str(working_dir))
+    with pytest.raises(InvalidPackageScriptError):
+        second_file = working_dir / "002-shared.sql"
+        second_file.unlink()
+        second_file.write_text("select * from {{ package_name")
+        native_app_manager._apply_package_scripts()
+
+    # even though the second script was the one missing, nothing should be executed
+    assert mock_execute.mock_calls == []
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
+@pytest.mark.parametrize("project_definition_files", ["napp_project_1"], indirect=True)
+def test_undefined_var_package_script(mock_execute, project_definition_files):
+    working_dir: Path = project_definition_files[0].parent
+    native_app_manager = NativeAppManager(str(working_dir))
+    with pytest.raises(InvalidPackageScriptError):
+        second_file = working_dir / "001-shared.sql"
+        second_file.unlink()
+        second_file.write_text("select * from {{ abc }}")
+        native_app_manager._apply_package_scripts()
+
+    assert mock_execute.mock_calls == []

--- a/tests/project/napp_project_1/001-shared.sql
+++ b/tests/project/napp_project_1/001-shared.sql
@@ -1,0 +1,5 @@
+-- package script (1/2)
+
+create schema if not exists {{ package_name }}.my_shared_content;
+grant usage on schema {{ package_name }}.my_shared_content
+  to share in application package {{ package_name }};

--- a/tests/project/napp_project_1/002-shared.sql
+++ b/tests/project/napp_project_1/002-shared.sql
@@ -1,0 +1,8 @@
+-- package script (2/2)
+
+create or replace table {{ package_name }}.my_shared_content.shared_table (
+  col1 number,
+  col2 varchar
+);
+grant select on table {{ package_name }}.my_shared_content.shared_table
+  to share in application package {{ package_name }};

--- a/tests/project/napp_project_1/snowflake.yml
+++ b/tests/project/napp_project_1/snowflake.yml
@@ -13,4 +13,6 @@ native_app:
       dest: ui/
 
   package:
-    scripts: package/*.sql
+    scripts:
+      - 001-shared.sql
+      - 002-shared.sql

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -27,7 +27,6 @@ def test_napp_project_1(project_definition_files):
 def test_na_minimal_project(project_definition_files: List[Path]):
     project = load_project_definition(project_definition_files)
     assert project["native_app"]["name"] == "minimal"
-    assert project["native_app"]["package"]["scripts"] == "package/*.sql"
     assert project["native_app"]["artifacts"] == ["setup.sql", "README.md"]
 
     from os import getenv as original_getenv


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Implements the "create application" and "apply package scripts" parts of snow app run.

Additional changes:
- `MockCursor` now has a correct `rowcount` property
- removes the ability to pass glob patterns in for package scripts, as well as the default value
- `SqlExecutionMixin.use_role` now correctly unsets the role upon exception
- fixed a bug that prevented single files with directory `dest`inations from working the second time around