### PR TITLE
Fixed get_service_status query for snow snowpark services status.  Th…

### DIFF
--- a/src/snowcli/cli/snowpark/services/manager.py
+++ b/src/snowcli/cli/snowpark/services/manager.py
@@ -36,7 +36,7 @@ class ServiceManager(SqlExecutionMixin):
         return self._execute_query("show services")
 
     def status(self, service_name: str) -> SnowflakeCursor:
-        return self._execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS(('{service_name}')")
+        return self._execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")
 
     def drop(self, service_name: str) -> SnowflakeCursor:
         return self._execute_query(f"drop service {service_name}")

--- a/tests/snowpark/test_services.py
+++ b/tests/snowpark/test_services.py
@@ -85,7 +85,7 @@ def test_service_status(mock_connector, runner, mock_ctx):
     result = runner.invoke(["snowpark", "services", "status", "serviceName"])
 
     assert result.exit_code == 0, result.output
-    assert ctx.get_query() == "CALL SYSTEM$GET_SERVICE_STATUS(('serviceName')"
+    assert ctx.get_query() == "CALL SYSTEM$GET_SERVICE_STATUS('serviceName')"
 
 
 @mock.patch("snowflake.connector.connect")


### PR DESCRIPTION
…e query had an extra (, IE: GET_SERVICE_STATUS(('service').

### Pre-review checklist
   * [ *] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [ *] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ *] I've described my changes in the section below.

### Changes description
Fixed a bad query for GET_SERVICE_STATUS that had an extra ( 
