### PR TITLE
Access to context in tests

### DIFF
--- a/src/snowcli/app/cli_app.py
+++ b/src/snowcli/app/cli_app.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 import click
 import typer
+from click import Context
 
 from snowcli import __about__
 from snowcli.api import api_provider, Api
@@ -35,6 +37,15 @@ api_provider.register_api(_api)
 _commands_registration = CommandsRegistrationWithCallbacks(_api.plugin_config_provider)
 
 
+@dataclass
+class AppContextHolder:
+    # needed to access the context from tests
+    app_context: Optional[Context] = None
+
+
+app_context_holder = AppContextHolder()
+
+
 def _do_not_execute_on_completion(callback):
     def enriched_callback(value):
         if click.get_current_context().resilient_parsing:
@@ -50,6 +61,7 @@ def _commands_registration_callback(value: bool):
     # required to make the tests working
     # because a single test can execute multiple commands using always the same "app" instance
     _commands_registration.reset_running_instance_registration_state()
+    app_context_holder.app_context = click.get_current_context()
 
 
 @_commands_registration.before

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 import json
 import typing as t
 
-import click
 from click import Command
 from typer.core import TyperArgument
-from typer.main import get_command
 
 from snowcli.__about__ import VERSION
+from snowcli.app.cli_app import app_context_holder
 from snowcli.config import cli_config
 from tests.testing_utils.fixtures import *
 
@@ -57,10 +56,11 @@ def test_info_callback(runner):
     ]
 
 
-def test_all_commands_has_proper_documentation():
-    from snowcli.app.cli_app import app
+def test_all_commands_has_proper_documentation(runner):
+    # invoke any command to populate app context (plugins registration)
+    runner.invoke("--help")
 
-    ctx = click.Context(get_command(app))
+    ctx = app_context_holder.app_context
     errors = []
 
     def _check(command: Command, path: t.Optional[t.List] = None):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Added a handle to app context to have access to it in tests. We can't create a separate new context in tests, because plugin command registration is done only in the context of the running command.
