### PR TITLE
[v1.1.1] Removing option duplicates (backward incompatible way)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,17 +1,7 @@
-# v2.0.0
+# v1.1.1
 
 ## Backward incompatibility
-* In `snowpark function` command:
-  * Combined options `--function` and `--input-parameters` to `identifier` argument
-  * Changed name of option from `--return-type` to `returns`
-* In `snowpark procedure` command:
-  * Combined options `--procedure` and `--input-parameters` to `identifier` argument
-  * Changed name of option from `--return-type` to `--returns`
-* In `snowpark procedure coverage` command:
-  * Combined options `--name` and `--input-parameters` to `identifier` argument
-* Changed path to coverage reports on stage, previously created procedures with coverage will not work, have to be recreated
-* Snowpark command `compute-pool` and its alias `cp` were replaced by `pool` command.
-* `snow snowpark registry` was replaced with `snow registry` command.
+* Removed short version `-p` of `--password` option.
 
 ## New additions
 
@@ -23,3 +13,6 @@
 * Updated help messages
 * Fixed problem with Windows shortened paths
 * If only one connection is configured, will be used as default
+* Fixed registry token connection issues
+* Fixes in commands belonging to `snow snowpark compute-pool` and `snow snowpark services` groups
+* Removed duplicated short option names in a few commands

--- a/src/snowcli/app/commands_registration/commands_registration_with_callbacks.py
+++ b/src/snowcli/app/commands_registration/commands_registration_with_callbacks.py
@@ -76,4 +76,5 @@ class CommandsRegistrationWithCallbacks:
     def reset_running_instance_registration_state(self):
         self._commands_already_registered = False
         self._counter_of_callbacks_invoked_before_registration.set(0)
+        self._callbacks_after_registration.clear()
         self._commands_registration_config.enable_external_command_plugins = True

--- a/src/snowcli/app/dev/commands_structure.py
+++ b/src/snowcli/app/dev/commands_structure.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional, List
 
 from click import Command
 
@@ -11,11 +12,26 @@ class _Node:
     name: str
     children: Dict[str, _Node] = field(default_factory=dict)
     level: int = 0
+    options: Dict[str, List[str]] = field(default_factory=dict)
 
     def print(self):
         print("    " * self.level, self.name)
         for ch in self.children.values():
             ch.print()
+
+    def print_with_options(self):
+        options = self._prepare_options_dict()
+        pretty = json.dumps(options, indent=4)
+        print(pretty)
+
+    def _prepare_options_dict(self, options_dict={}):
+        options_dict["options"] = self.options
+
+        for ch in self.children.values():
+            options_dict[ch.name] = ch._prepare_options_dict(
+                options_dict.get(ch.name, {})
+            )
+        return options_dict
 
 
 def generate_commands_structure(command: Command, root: _Node | None = None):
@@ -25,6 +41,11 @@ def generate_commands_structure(command: Command, root: _Node | None = None):
     """
     if not root:
         root = _Node(name="snow")
+
+    if command.params:
+        root.options = {
+            param.human_readable_name: param.opts for param in command.params
+        }
 
     if hasattr(command, "commands"):
         for command_name, command_info in command.commands.items():

--- a/src/snowcli/cli/common/flags.py
+++ b/src/snowcli/cli/common/flags.py
@@ -49,7 +49,6 @@ UserOption = typer.Option(
 PasswordOption = typer.Option(
     None,
     "--password",
-    "-p",
     help="Snowflake password. Overrides the value specified for the connection.",
     hide_input=True,
     callback=ConnectionDetails.update_callback("password"),

--- a/src/snowcli/cli/snowpark/function/commands.py
+++ b/src/snowcli/cli/snowpark/function/commands.py
@@ -183,7 +183,6 @@ def function_update(
     replace: bool = typer.Option(
         False,
         "--replace-always",
-        "-a",
         help="Whether to replace the function even in no changes to the metadata are detected.",
     ),
     **options,

--- a/src/snowcli/cli/snowpark/jobs/commands.py
+++ b/src/snowcli/cli/snowpark/jobs/commands.py
@@ -22,7 +22,7 @@ app = typer.Typer(
 @global_options_with_connection
 def create(
     compute_pool: str = typer.Option(
-        ..., "--compute-pool", "-c", help="Name of the pool in which to run the job."
+        ..., "--compute-pool", help="Name of the pool in which to run the job."
     ),
     spec_path: Path = typer.Option(
         ...,
@@ -70,7 +70,7 @@ def desc(id: str = typer.Argument(..., help="Job id"), **options) -> CommandResu
 def logs(
     id: str = typer.Argument(..., help="Job id"),
     container_name: str = typer.Option(
-        ..., "--container-name", "-c", help="Name of the container."
+        ..., "--container-name", help="Name of the container."
     ),
     **options,
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+import json
+from typing import Dict, Any, List, Set
+
 import pytest
 
 from tests.testing_utils.fixtures import *
@@ -25,3 +28,39 @@ def test_namespace(namespace, expected, runner):
     assert result.exit_code == 0
 
     assert expected in result.output
+
+
+@pytest.mark.skip  # skipped until we solve all conflicts
+def test_options_structure(runner):
+    result = runner.invoke(["--options-structure"])
+    assert result.exit_code == 0
+
+    options_json = json.loads(result.output)
+    assert find_conflicts_in_options_dict("snow", options_json) is None
+
+
+def find_conflicts_in_options_dict(path: str, options_dict: Dict[str, Any]):
+
+    keys = list(options_dict.keys())
+    duplicates = {}
+    if "options" in keys:
+        if opts_duplicates := check_options_for_duplicates(options_dict["options"]):
+            duplicates[path] = opts_duplicates
+        keys.remove("options")
+
+    for key in keys:
+        if key_duplicates := find_conflicts_in_options_dict(key, options_dict[key]):
+            duplicates[key] = key_duplicates
+
+    if duplicates:
+        return duplicates
+
+    return None
+
+
+def check_options_for_duplicates(options: Dict[str, List[str]]) -> Set[str]:
+    RESERVED_FLAGS = ["-h", "--help"]  # noqa: N806
+    flags = [flag for option in options.values() for flag in option]
+    return set(
+        [flag for flag in flags if (flags.count(flag) > 1 or flag in RESERVED_FLAGS)]
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,5 @@
 import json
-from typing import Dict, Any, List, Set
-
-import pytest
+from typing import Dict, Any, Set
 
 from tests.testing_utils.fixtures import *
 
@@ -30,7 +28,6 @@ def test_namespace(namespace, expected, runner):
     assert expected in result.output
 
 
-@pytest.mark.skip  # skipped until we solve all conflicts
 def test_options_structure(runner):
     result = runner.invoke(["--options-structure"])
     assert result.exit_code == 0
@@ -49,8 +46,10 @@ def find_conflicts_in_options_dict(path: str, options_dict: Dict[str, Any]):
         keys.remove("options")
 
     for key in keys:
-        if key_duplicates := find_conflicts_in_options_dict(key, options_dict[key]):
-            duplicates[key] = key_duplicates
+        if key_duplicates := find_conflicts_in_options_dict(
+            f"{path} {key}", options_dict[key]
+        ):
+            duplicates.update(key_duplicates)
 
     if duplicates:
         return duplicates
@@ -59,7 +58,7 @@ def find_conflicts_in_options_dict(path: str, options_dict: Dict[str, Any]):
 
 
 def check_options_for_duplicates(options: Dict[str, List[str]]) -> Set[str]:
-    RESERVED_FLAGS = ["-h", "--help"]  # noqa: N806
+    RESERVED_FLAGS = ["--help"]  # noqa: N806
     flags = [flag for option in options.values() for flag in option]
     return set(
         [flag for flag in flags if (flags.count(flag) > 1 or flag in RESERVED_FLAGS)]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Alternative approach to #441
* Removed option duplicates by:
  * Removing `-p` short option for `--password` option for all commands (backward incompatibility affecting all the commands using a connection) (it was conflicting with various options in a few commands)
  * Removing `-a` short option for `--replace-always` in `snow snowpark function update` command (it was conflicting with short version of `--check-anaconda-for-pypi-deps`) 
  * Removing `-c` short option for `--compute-pool` in `snow snowpark jobs create` (it was conflicting with short version of global `--connection` option)
  * Removing `-c` short option for `--container-name` in `snow snowpark jobs logs` (it was conflicting with short version of global `--connection` option)
* Cherry-picked a test checking that there are no option duplicates from #416 
* Fixed a few bugs in commands registration which are (or will be) also fixed on the main branch
* Updated release notes for v1.1.1
