### PR TITLE
[v1.1.1] Removing option duplicates (backward compatible way)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,17 +1,6 @@
-# v2.0.0
+# v1.1.1
 
 ## Backward incompatibility
-* In `snowpark function` command:
-  * Combined options `--function` and `--input-parameters` to `identifier` argument
-  * Changed name of option from `--return-type` to `returns`
-* In `snowpark procedure` command:
-  * Combined options `--procedure` and `--input-parameters` to `identifier` argument
-  * Changed name of option from `--return-type` to `--returns`
-* In `snowpark procedure coverage` command:
-  * Combined options `--name` and `--input-parameters` to `identifier` argument
-* Changed path to coverage reports on stage, previously created procedures with coverage will not work, have to be recreated
-* Snowpark command `compute-pool` and its alias `cp` were replaced by `pool` command.
-* `snow snowpark registry` was replaced with `snow registry` command.
 
 ## New additions
 
@@ -23,3 +12,6 @@
 * Updated help messages
 * Fixed problem with Windows shortened paths
 * If only one connection is configured, will be used as default
+* Fixed registry token connection issues
+* Fixes in commands belonging to `snow snowpark compute-pool` and `snow snowpark services` groups
+* Removed duplicated short option names in a few commands

--- a/src/snowcli/app/commands_registration/commands_registration_with_callbacks.py
+++ b/src/snowcli/app/commands_registration/commands_registration_with_callbacks.py
@@ -4,6 +4,9 @@ from typing import Callable, List
 from snowcli.app.commands_registration.command_plugins_loader import (
     load_only_builtin_command_plugins,
 )
+from snowcli.app.commands_registration.duplicated_options_exclusion import (
+    exclude_duplicated_secondary_option_names,
+)
 from snowcli.app.commands_registration.typer_registration import (
     register_commands_from_plugins,
 )
@@ -43,6 +46,9 @@ class CommandsRegistrationWithCallbacks:
         if self._commands_registration_config.enable_external_command_plugins:
             self._register_external_plugin_commands()
 
+        # temporary workaround of issues with duplicated options only for v1.1.1
+        exclude_duplicated_secondary_option_names()
+
         self._commands_already_registered = True
         for callback in self._callbacks_after_registration:
             callback()
@@ -76,4 +82,5 @@ class CommandsRegistrationWithCallbacks:
     def reset_running_instance_registration_state(self):
         self._commands_already_registered = False
         self._counter_of_callbacks_invoked_before_registration.set(0)
+        self._callbacks_after_registration.clear()
         self._commands_registration_config.enable_external_command_plugins = True

--- a/src/snowcli/app/commands_registration/duplicated_options_exclusion.py
+++ b/src/snowcli/app/commands_registration/duplicated_options_exclusion.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Union
+
+import click
+from click import Command, Parameter
+from typer.core import TyperGroup, TyperCommand
+
+
+@dataclass
+class SecondaryOptionNameExclusion:
+    command_path: str
+    primary_option_name: str
+    excluded_secondary_option_name: str
+
+
+_secondary_option_names_duplicates = [
+    SecondaryOptionNameExclusion("snowpark procedure describe", "--password", "-p"),
+    SecondaryOptionNameExclusion("snowpark procedure drop", "--password", "-p"),
+    SecondaryOptionNameExclusion("snowpark procedure execute", "--password", "-p"),
+    SecondaryOptionNameExclusion("snowpark services create", "--password", "-p"),
+]
+
+
+def exclude_duplicated_secondary_option_names():
+    _exclude_secondary_option_names(_secondary_option_names_duplicates)
+
+
+def _exclude_secondary_option_names(exclusions: List[SecondaryOptionNameExclusion]):
+    main_command_group = _get_main_typer_command_group_from_click_context()
+    for exclusion in exclusions:
+        command = _find_command(
+            command_group=main_command_group,
+            remaining_path=exclusion.command_path.split(" "),
+            full_path=exclusion.command_path,
+        )
+        param = _find_param(
+            command=command,
+            primary_option_name=exclusion.primary_option_name,
+            command_path=exclusion.command_path,
+        )
+        _remove_option_name_from_param(exclusion.excluded_secondary_option_name, param)
+
+
+def _get_main_typer_command_group_from_click_context() -> TyperGroup:
+    main_typer_command_group = click.get_current_context().command
+    if isinstance(main_typer_command_group, TyperGroup):
+        return main_typer_command_group
+    else:
+        raise RuntimeError(
+            "Invalid main top-level command type. It should be a TyperGroup but it is not."
+        )
+
+
+def _find_command(
+    command_group: TyperGroup,
+    remaining_path: List[str],
+    full_path: str,
+) -> Union[TyperCommand, TyperGroup]:
+    if remaining_path:
+        new_remaining_path = remaining_path[1:]
+        found_command = command_group.commands.get(remaining_path[0])
+        if isinstance(found_command, TyperGroup):
+            return _find_command(found_command, new_remaining_path, full_path)
+        elif isinstance(found_command, TyperCommand) and not new_remaining_path:
+            return found_command
+        else:
+            raise RuntimeError(f"Cannot find command [{full_path}].")
+    else:
+        return command_group
+
+
+def _find_param(
+    command: Command, primary_option_name: str, command_path: str
+) -> Parameter:
+    for param in command.params:
+        if primary_option_name in param.opts:
+            return param
+    raise RuntimeError(
+        f"Cannot find param [{primary_option_name}] for command [{command_path}]."
+    )
+
+
+def _remove_option_name_from_param(excluded_name: str, param: Parameter):
+    if excluded_name in param.opts:
+        param.opts.remove(excluded_name)
+    if excluded_name in param.secondary_opts:
+        param.secondary_opts.remove(excluded_name)

--- a/src/snowcli/app/dev/commands_structure.py
+++ b/src/snowcli/app/dev/commands_structure.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional, List
 
 from click import Command
 
@@ -11,11 +12,26 @@ class _Node:
     name: str
     children: Dict[str, _Node] = field(default_factory=dict)
     level: int = 0
+    options: Dict[str, List[str]] = field(default_factory=dict)
 
     def print(self):
         print("    " * self.level, self.name)
         for ch in self.children.values():
             ch.print()
+
+    def print_with_options(self):
+        options = self._prepare_options_dict()
+        pretty = json.dumps(options, indent=4)
+        print(pretty)
+
+    def _prepare_options_dict(self, options_dict={}):
+        options_dict["options"] = self.options
+
+        for ch in self.children.values():
+            options_dict[ch.name] = ch._prepare_options_dict(
+                options_dict.get(ch.name, {})
+            )
+        return options_dict
 
 
 def generate_commands_structure(command: Command, root: _Node | None = None):
@@ -25,6 +41,11 @@ def generate_commands_structure(command: Command, root: _Node | None = None):
     """
     if not root:
         root = _Node(name="snow")
+
+    if command.params:
+        root.options = {
+            param.human_readable_name: param.opts for param in command.params
+        }
 
     if hasattr(command, "commands"):
         for command_name, command_info in command.commands.items():

--- a/src/snowcli/cli/snowpark/function/commands.py
+++ b/src/snowcli/cli/snowpark/function/commands.py
@@ -183,7 +183,6 @@ def function_update(
     replace: bool = typer.Option(
         False,
         "--replace-always",
-        "-a",
         help="Whether to replace the function even in no changes to the metadata are detected.",
     ),
     **options,

--- a/src/snowcli/cli/snowpark/jobs/commands.py
+++ b/src/snowcli/cli/snowpark/jobs/commands.py
@@ -22,7 +22,7 @@ app = typer.Typer(
 @global_options_with_connection
 def create(
     compute_pool: str = typer.Option(
-        ..., "--compute-pool", "-c", help="Name of the pool in which to run the job."
+        ..., "--compute-pool", help="Name of the pool in which to run the job."
     ),
     spec_path: Path = typer.Option(
         ...,
@@ -70,7 +70,7 @@ def desc(id: str = typer.Argument(..., help="Job id"), **options) -> CommandResu
 def logs(
     id: str = typer.Argument(..., help="Job id"),
     container_name: str = typer.Option(
-        ..., "--container-name", "-c", help="Name of the container."
+        ..., "--container-name", help="Name of the container."
     ),
     **options,
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+import json
+from typing import Dict, Any, List, Set
+
 import pytest
 
 from tests.testing_utils.fixtures import *
@@ -25,3 +28,39 @@ def test_namespace(namespace, expected, runner):
     assert result.exit_code == 0
 
     assert expected in result.output
+
+
+@pytest.mark.skip  # skipped until we solve all conflicts
+def test_options_structure(runner):
+    result = runner.invoke(["--options-structure"])
+    assert result.exit_code == 0
+
+    options_json = json.loads(result.output)
+    assert find_conflicts_in_options_dict("snow", options_json) is None
+
+
+def find_conflicts_in_options_dict(path: str, options_dict: Dict[str, Any]):
+
+    keys = list(options_dict.keys())
+    duplicates = {}
+    if "options" in keys:
+        if opts_duplicates := check_options_for_duplicates(options_dict["options"]):
+            duplicates[path] = opts_duplicates
+        keys.remove("options")
+
+    for key in keys:
+        if key_duplicates := find_conflicts_in_options_dict(key, options_dict[key]):
+            duplicates[key] = key_duplicates
+
+    if duplicates:
+        return duplicates
+
+    return None
+
+
+def check_options_for_duplicates(options: Dict[str, List[str]]) -> Set[str]:
+    RESERVED_FLAGS = ["-h", "--help"]  # noqa: N806
+    flags = [flag for option in options.values() for flag in option]
+    return set(
+        [flag for flag in flags if (flags.count(flag) > 1 or flag in RESERVED_FLAGS)]
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,5 @@
 import json
-from typing import Dict, Any, List, Set
-
-import pytest
+from typing import Dict, Any, Set
 
 from tests.testing_utils.fixtures import *
 
@@ -30,7 +28,6 @@ def test_namespace(namespace, expected, runner):
     assert expected in result.output
 
 
-@pytest.mark.skip  # skipped until we solve all conflicts
 def test_options_structure(runner):
     result = runner.invoke(["--options-structure"])
     assert result.exit_code == 0
@@ -49,8 +46,10 @@ def find_conflicts_in_options_dict(path: str, options_dict: Dict[str, Any]):
         keys.remove("options")
 
     for key in keys:
-        if key_duplicates := find_conflicts_in_options_dict(key, options_dict[key]):
-            duplicates[key] = key_duplicates
+        if key_duplicates := find_conflicts_in_options_dict(
+            f"{path} {key}", options_dict[key]
+        ):
+            duplicates.update(key_duplicates)
 
     if duplicates:
         return duplicates
@@ -59,7 +58,7 @@ def find_conflicts_in_options_dict(path: str, options_dict: Dict[str, Any]):
 
 
 def check_options_for_duplicates(options: Dict[str, List[str]]) -> Set[str]:
-    RESERVED_FLAGS = ["-h", "--help"]  # noqa: N806
+    RESERVED_FLAGS = ["--help"]  # noqa: N806
     flags = [flag for option in options.values() for flag in option]
     return set(
         [flag for flag in flags if (flags.count(flag) > 1 or flag in RESERVED_FLAGS)]

--- a/tests/test_command_registration.py
+++ b/tests/test_command_registration.py
@@ -90,6 +90,10 @@ def test_exception_handling_if_single_command_has_multiple_commands(
         "connection2": connection_plugin_spec,
     },
 )
+@mock.patch(
+    "snowcli.app.commands_registration.duplicated_options_exclusion._secondary_option_names_duplicates",
+    [],
+)
 def test_duplicated_plugin_handling(runner):
     result = runner.invoke(["-h"])
     assert result.exit_code == 0


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* Alternative approach to #438
* Removed option duplicates by:
  * Removing `-p` short option for `--password` option for the following commands:
    * `snowpark procedure describe`
    * `snowpark procedure drop`
    * `snowpark procedure execute`
    * `snowpark services create`
  * Removing `-a` short option for `--replace-always` in `snow snowpark function update` command (it was conflicting with short version of `--check-anaconda-for-pypi-deps`) 
  * Removing `-c` short option for `--compute-pool` in `snow snowpark jobs create` (it was conflicting with short version of global `--connection` option)
  * Removing `-c` short option for `--container-name` in `snow snowpark jobs logs` (it was conflicting with short version of global `--connection` option)
* Cherry-picked a test checking that there are no option duplicates from #416 
* Fixed a few bugs in commands registration which are (or will be) also fixed on the main branch
* Updated release notes for v1.1.1
