### PR TITLE
Remove completion options from plugin commands

### DIFF
--- a/src/snowcli/api/plugin/command/__init__.py
+++ b/src/snowcli/api/plugin/command/__init__.py
@@ -48,6 +48,7 @@ class CommandSpec:
 
     @cached_property
     def command(self) -> click.Command:
+        self.typer_instance._add_completion = False
         return get_command(self.typer_instance)
 
     @cached_property


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
  * Plugins mechanism accidentally added `--install-completion` and `--show-completion` options to all command / command groups registered as plugins. This change fixes it and removes these options, as they should be visible on only top-level `--help`.
