### PR TITLE
Hide --disable-external-command-plugins option for v1.1.1

### DIFF
--- a/src/snowcli/app/cli_app.py
+++ b/src/snowcli/app/cli_app.py
@@ -174,6 +174,7 @@ def default(
     disable_external_command_plugins: bool = typer.Option(
         None,
         "--disable-external-command-plugins",
+        hidden=True,
         help="Disable external command plugins",
         callback=_disable_external_command_plugins_callback,
         is_eager=True,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
* External plugins are not part of 1.1.1 release so `--disable-external-command-plugins` shouldn't be visible in the help text.