### PR TITLE
Proper identifier unquoting

### DIFF
--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -108,9 +108,7 @@ class MissingSchemaError(ClickException):
         super().__init__(f'Identifier missing a schema qualifier: "{identifier}"')
 
 
-def find_row(
-    cursor: SnowflakeCursor, predicate: Callable[[Union[dict, tuple]], bool]
-) -> Optional[Union[dict, tuple]]:
+def find_row(cursor: DictCursor, predicate: Callable[[dict], bool]) -> Optional[dict]:
     """Returns the first row that matches the predicate, or None."""
     return next(
         (row for row in cursor.fetchall() if predicate(row)),

--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from functools import cached_property
-from typing import List, Optional, Literal
+from typing import List, Optional, Literal, Union, Callable
 from click.exceptions import ClickException
 from snowcli.exception import SnowflakeSQLExecutionError
 
-from snowflake.connector.cursor import DictCursor
+from snowflake.connector.cursor import DictCursor, SnowflakeCursor
 
 import jinja2
 
 from snowcli.cli.project.util import (
     clean_identifier,
-    identifier_as_part,
+    unquote_identifier,
     extract_schema,
 )
 from snowcli.cli.common.sql_execution import SqlExecutionMixin
@@ -42,6 +42,7 @@ from snowflake.connector.cursor import DictCursor
 SPECIAL_COMMENT = "GENERATED_BY_SNOWCLI"
 LOOSE_FILES_MAGIC_VERSION = "dev_stage"
 
+NAME_COL = "name"
 COMMENT_COL = "comment"
 OWNER_COL = "owner"
 VERSION_COL = "version"
@@ -105,6 +106,16 @@ class MissingSchemaError(ClickException):
 
     def __init__(self, identifier: str):
         super().__init__(f'Identifier missing a schema qualifier: "{identifier}"')
+
+
+def find_row(
+    cursor: SnowflakeCursor, predicate: Callable[[Union[dict, tuple], bool]]
+) -> Union[dict, tuple]:
+    """Returns the first row that matches the predicate, or None."""
+    return next(
+        (row for row in cursor.fetchall() if predicate(row)),
+        None,
+    )
 
 
 class NativeAppManager(SqlExecutionMixin):
@@ -274,13 +285,17 @@ class NativeAppManager(SqlExecutionMixin):
                 self._execute_query(f"use warehouse {self.warehouse}")
 
             show_app_cursor = self._execute_query(
-                f"show applications like '{identifier_as_part(self.app_name)}'",
+                f"show applications like '{unquote_identifier(self.app_name)}'",
                 cursor_class=DictCursor,
             )
 
-            if show_app_cursor.rowcount != 0:
-                # There can only be one possible pre-existing app with the same name
-                show_app_row: dict = show_app_cursor.fetchone()
+            # There can only be one possible pre-existing app with the same name
+            show_app_row: dict = find_row(
+                show_app_cursor,
+                lambda row: row[NAME_COL] == unquote_identifier(self.app_name),
+            )
+
+            if show_app_row is not None:
                 if (
                     show_app_row[COMMENT_COL] != SPECIAL_COMMENT
                     or show_app_row[VERSION_COL] != LOOSE_FILES_MAGIC_VERSION
@@ -288,7 +303,7 @@ class NativeAppManager(SqlExecutionMixin):
                     raise ApplicationAlreadyExistsError(self.app_name)
 
                 actual_owner = show_app_row[OWNER_COL]
-                if actual_owner != self.app_role:
+                if actual_owner != unquote_identifier(self.app_role):
                     raise UnexpectedOwnerError(
                         self.app_name, self.app_role, actual_owner
                     )
@@ -320,10 +335,16 @@ class NativeAppManager(SqlExecutionMixin):
         """Returns True iff the application exists on Snowflake."""
         with self.use_role(self.app_role):
             show_app_cursor = self._execute_query(
-                f"show applications like '{identifier_as_part(self.app_name)}'",
+                f"show applications like '{unquote_identifier(self.app_name)}'",
                 cursor_class=DictCursor,
             )
-            return show_app_cursor.rowcount != 0
+            return (
+                find_row(
+                    show_app_cursor,
+                    lambda row: row[NAME_COL] == unquote_identifier(self.app_name),
+                )
+                is not None
+            )
 
     def app_run(self) -> None:
         """
@@ -331,13 +352,19 @@ class NativeAppManager(SqlExecutionMixin):
         """
         with self.use_role(self.package_role):
             show_cursor = self._execute_query(
-                f"show application packages like '{identifier_as_part(self.package_name)}'",
+                f"show application packages like '{unquote_identifier(self.package_name)}'",
                 cursor_class=DictCursor,
             )
 
             if show_cursor.rowcount is None:
                 raise SnowflakeSQLExecutionError()
-            elif show_cursor.rowcount == 0:
+
+            # There can be maximum one possible pre-existing app pkg with the same name
+            show_app_row = find_row(
+                show_cursor,
+                lambda row: row[NAME_COL] == unquote_identifier(self.package_name),
+            )
+            if show_app_row is None:
                 # Create an app pkg, with distribution = internal to avoid triggering security scan
                 log.info(
                     f"Creating new application package {self.package_name} in account."
@@ -350,8 +377,6 @@ class NativeAppManager(SqlExecutionMixin):
                     """
                 )
             else:
-                # There can only be one possible pre-existing app pkg with the same name
-                show_app_row = show_cursor.fetchone()
                 row_comment = show_app_row[
                     COMMENT_COL
                 ]  # Because we use a DictCursor, we are guaranteed a dictionary instead of indexing through a list.
@@ -360,7 +385,7 @@ class NativeAppManager(SqlExecutionMixin):
                     raise ApplicationPackageAlreadyExistsError(self.package_name)
 
                 actual_owner = show_app_row[OWNER_COL]
-                if actual_owner != self.package_role:
+                if actual_owner != unquote_identifier(self.package_role):
                     raise UnexpectedOwnerError(
                         self.app_name, self.app_role, actual_owner
                     )
@@ -375,7 +400,7 @@ class NativeAppManager(SqlExecutionMixin):
 
     def get_snowsight_url(self) -> str:
         """Returns the URL that can be used to visit this app via Snowsight."""
-        name = identifier_as_part(self.app_name)
+        name = unquote_identifier(self.app_name)
         return make_snowsight_url(self._conn, f"/#/apps/application/{name}")
 
     def drop_object(
@@ -393,28 +418,32 @@ class NativeAppManager(SqlExecutionMixin):
         )
 
         with self.use_role(object_role):
-            show_obj_query = f"{query_dict['show']} '{identifier_as_part(object_name)}'"
+            show_obj_query = f"{query_dict['show']} '{unquote_identifier(object_name)}'"
             show_obj_cursor = self._execute_query(
                 show_obj_query, cursor_class=DictCursor
             )
 
             if show_obj_cursor.rowcount is None:
                 raise SnowflakeSQLExecutionError(show_obj_query)
-            elif show_obj_cursor.rowcount == 0:
+
+            show_obj_row = find_row(
+                show_obj_cursor,
+                lambda row: row[NAME_COL] == unquote_identifier(object_name),
+            )
+            if show_obj_row is None:
                 raise CouldNotDropObjectError(
                     f"Role {object_role} does not own any {log_object_type.lower()} with the name {object_name}!"
                 )
-            elif show_obj_cursor.rowcount > 0:
-                # There can only be one possible pre-existing object with the same name
-                show_obj_row = show_obj_cursor.fetchone()
-                row_comment = show_obj_row[
-                    COMMENT_COL
-                ]  # Because we use a DictCursor, we are guaranteed a dictionary instead of indexing through a list.
 
-                if row_comment != SPECIAL_COMMENT:
-                    raise CouldNotDropObjectError(
-                        f"{log_object_type} {object_name} was not created by SnowCLI. Cannot drop the {log_object_type.lower()}."
-                    )
+            # There can only be one possible pre-existing object with the same name
+            row_comment = show_obj_row[
+                COMMENT_COL
+            ]  # Because we use a DictCursor, we are guaranteed a dictionary instead of indexing through a list.
+
+            if row_comment != SPECIAL_COMMENT:
+                raise CouldNotDropObjectError(
+                    f"{log_object_type} {object_name} was not created by SnowCLI. Cannot drop the {log_object_type.lower()}."
+                )
 
             log.info(f"Dropping {log_object_type.lower()} {object_name} now.")
             drop_query = f"{query_dict['drop']} {object_name}"

--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from functools import cached_property
-from typing import List, Optional, Literal, Union, Callable
+from typing import List, Optional, Literal, Callable
 from click.exceptions import ClickException
 from snowcli.exception import SnowflakeSQLExecutionError
 
-from snowflake.connector.cursor import DictCursor, SnowflakeCursor
+from snowflake.connector.cursor import DictCursor
 
 import jinja2
 
@@ -22,8 +22,6 @@ from snowcli.cli.project.definition import (
     default_application,
     default_role,
 )
-from snowcli.output.printing import print_result
-from snowcli.output.types import ObjectResult
 from snowcli.cli.stage.diff import (
     DiffResult,
     stage_diff,

--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -109,8 +109,8 @@ class MissingSchemaError(ClickException):
 
 
 def find_row(
-    cursor: SnowflakeCursor, predicate: Callable[[Union[dict, tuple], bool]]
-) -> Union[dict, tuple]:
+    cursor: SnowflakeCursor, predicate: Callable[[Union[dict, tuple]], bool]
+) -> Optional[Union[dict, tuple]]:
     """Returns the first row that matches the predicate, or None."""
     return next(
         (row for row in cursor.fetchall() if predicate(row)),

--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -286,7 +286,7 @@ class NativeAppManager(SqlExecutionMixin):
             )
 
             # There can only be one possible pre-existing app with the same name
-            show_app_row: dict = find_row(
+            show_app_row = find_row(
                 show_app_cursor,
                 lambda row: row[NAME_COL] == unquote_identifier(self.app_name),
             )

--- a/src/snowcli/cli/project/definition.py
+++ b/src/snowcli/cli/project/definition.py
@@ -23,7 +23,9 @@ def merge_left(target: Union[Dict, YAML], source: Union[Dict, YAML]) -> None:
     Modifies the original dict-like "target".
     """
     for k, v in source.items():
-        if k in target and (isinstance(v, dict) or isinstance(v, YAML)):
+        if k in target and (
+            isinstance(v, dict) or (isinstance(v, YAML) and not v.is_scalar())
+        ):
             # assumption: all inputs have been validated.
             assert isinstance(target[k], dict) or isinstance(target[k], YAML)
             merge_left(target[k], v)

--- a/src/snowcli/cli/project/util.py
+++ b/src/snowcli/cli/project/util.py
@@ -18,13 +18,15 @@ def clean_identifier(input):
     return re.sub(r"[^a-z0-9_$]", "", f"{input}".lower())
 
 
-def identifier_as_part(identifier: str) -> str:
+def unquote_identifier(identifier: str) -> str:
     """
-    Returns a version of this identifier that can be used inside of a URL
-    or inside of a string for a LIKE clause.
+    Returns a version of this identifier that can be used inside of a URL,
+    inside of a string for a LIKE clause, or to match an identifier passed
+    back as a value from a SQL statement.
     """
     if match := re.fullmatch(QUOTED, identifier):
         return match.group(1)
+    # unquoted identifiers are internally represented as uppercase
     return identifier.upper()
 
 

--- a/src/snowcli/cli/streamlit/manager.py
+++ b/src/snowcli/cli/streamlit/manager.py
@@ -14,7 +14,7 @@ from snowcli.utils import (
     generate_streamlit_package_wrapper,
 )
 from snowcli.cli.connection.util import make_snowsight_url, MissingConnectionHostError
-from snowcli.cli.project.util import identifier_as_part
+from snowcli.cli.project.util import unquote_identifier
 
 log = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class StreamlitManager(SqlExecutionMixin):
 
     def qualified_name_for_url(self, object_name: str):
         return (
-            f"{identifier_as_part(self._conn.database)}."
-            f"{identifier_as_part(self._conn.schema)}."
-            f"{identifier_as_part(object_name)}"
+            f"{unquote_identifier(self._conn.database)}."
+            f"{unquote_identifier(self._conn.schema)}."
+            f"{unquote_identifier(object_name)}"
         )

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -127,8 +127,8 @@ def test_drop_object(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
-                    "name": "sample_package_name",
-                    "owner": "sample_package_role",
+                    "name": "SAMPLE_PACKAGE_NAME",
+                    "owner": "SAMPLE_PACKAGE_ROLE",
                     "blank": "blank",
                     "comment": "GENERATED_BY_SNOWCLI",
                 }
@@ -208,8 +208,8 @@ def test_drop_object_no_special_comment(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
-                    "name": "sample_package_name",
-                    "owner": "sample_package_role",
+                    "name": "SAMPLE_PACKAGE_NAME",
+                    "owner": "SAMPLE_PACKAGE_ROLE",
                     "blank": "blank",
                     "comment": "NOT_GENERATED_BY_SNOWCLI",
                 }
@@ -265,9 +265,10 @@ def test_create_dev_app_noop(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "MYAPP",
                     "comment": SPECIAL_COMMENT,
                     "version": LOOSE_FILES_MAGIC_VERSION,
-                    "owner": "app_role",
+                    "owner": "APP_ROLE",
                 }
             ],
             [],
@@ -317,9 +318,10 @@ def test_create_dev_app_recreate(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "MYAPP",
                     "comment": SPECIAL_COMMENT,
                     "version": LOOSE_FILES_MAGIC_VERSION,
-                    "owner": "app_role",
+                    "owner": "APP_ROLE",
                 }
             ],
             [],
@@ -402,9 +404,10 @@ def test_create_dev_app_bad_comment(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "MYAPP",
                     "comment": "bad comment",
                     "version": LOOSE_FILES_MAGIC_VERSION,
-                    "owner": "app_role",
+                    "owner": "APP_ROLE",
                 }
             ],
             [],
@@ -445,6 +448,7 @@ def test_create_dev_app_bad_version(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "MYAPP",
                     "comment": SPECIAL_COMMENT,
                     "version": "v1",
                     "owner": "app_role",
@@ -488,6 +492,7 @@ def test_create_dev_app_bad_owner(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "MYAPP",
                     "comment": SPECIAL_COMMENT,
                     "version": LOOSE_FILES_MAGIC_VERSION,
                     "owner": "accountadmin_or_something",
@@ -529,6 +534,7 @@ def test_app_exists(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "MYAPP",
                     "comment": SPECIAL_COMMENT,
                     "version": LOOSE_FILES_MAGIC_VERSION,
                     "owner": "app_role",
@@ -631,9 +637,10 @@ def test_quoting_app_teardown(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "My Application",
                     "comment": SPECIAL_COMMENT,
                     "version": LOOSE_FILES_MAGIC_VERSION,
-                    "owner": "app_role",
+                    "owner": "APP_ROLE",
                 }
             ],
             [],
@@ -646,8 +653,9 @@ def test_quoting_app_teardown(mock_execute, temp_dir, mock_cursor):
         mock_cursor(
             [
                 {
+                    "name": "My Package",
                     "comment": SPECIAL_COMMENT,
-                    "owner": "package_role",
+                    "owner": "PACKAGE_ROLE",
                 }
             ],
             [],

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -43,6 +43,7 @@ mock_snowflake_yml_file = dedent(
 
             package:
                 name: app_pkg
+                role: package_role
                 scripts:
                     - shared_content.sql
     """
@@ -60,6 +61,18 @@ mock_project_definition_override = {
         },
     }
 }
+
+quoted_override_yml_file = dedent(
+    """\
+        native_app:
+            application:
+                name: >-
+                    "My Application"
+            package:
+                name: >-
+                    "My Package"
+    """
+)
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
@@ -147,7 +160,7 @@ def test_drop_object(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role sample_package_role"),
         mock.call("show application packages like 'sample_package_name'"),
-        mock.call("drop applicatin package sample_package_name"),
+        mock.call("drop application package sample_package_name"),
         mock.call("use role old_role"),
     ]
     mock_execute.mock_calls == expected
@@ -240,7 +253,7 @@ def test_create_dev_app_noop(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
         mock.call("use warehouse app_warehouse"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("alter application myapp set debug_mode = True"),
         mock.call("use role old_role"),
     ]
@@ -283,7 +296,7 @@ def test_create_dev_app_recreate(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
         mock.call("use warehouse app_warehouse"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("drop application myapp"),
         mock.call(
             f"""
@@ -336,7 +349,7 @@ def test_create_dev_app_create_new(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
         mock.call("use warehouse app_warehouse"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call(
             f"""
                 create application myapp
@@ -378,7 +391,7 @@ def test_create_dev_app_bad_comment(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
         mock.call("use warehouse app_warehouse"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("use role old_role"),
     ]
     # 1:1 with expected calls; these are return values
@@ -421,7 +434,7 @@ def test_create_dev_app_bad_version(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
         mock.call("use warehouse app_warehouse"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("use role old_role"),
     ]
     # 1:1 with expected calls; these are return values
@@ -464,7 +477,7 @@ def test_create_dev_app_bad_owner(mock_execute, temp_dir, mock_cursor):
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
         mock.call("use warehouse app_warehouse"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("use role old_role"),
     ]
     # 1:1 with expected calls; these are return values
@@ -506,7 +519,7 @@ def test_app_exists(mock_execute, temp_dir, mock_cursor):
     expected = [
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("use role old_role"),
     ]
     # 1:1 with expected calls; these are return values
@@ -543,7 +556,7 @@ def test_app_does_not_exist(mock_execute, temp_dir, mock_cursor):
     expected = [
         mock.call("select current_role()", cursor_class=DictCursor),
         mock.call("use role app_role"),
-        mock.call("show applications like 'myapp'", cursor_class=DictCursor),
+        mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
         mock.call("use role old_role"),
     ]
     # 1:1 with expected calls; these are return values
@@ -590,3 +603,71 @@ def test_get_snowsight_url(
         native_app_manager.get_snowsight_url()
         == "https://host/deployment/account/#/apps/application/MYAPP"
     )
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+def test_quoting_app_teardown(mock_execute, temp_dir, mock_cursor):
+    expected = [
+        # teardown app
+        mock.call("select current_role()", cursor_class=DictCursor),
+        mock.call("use role app_role"),
+        mock.call("show applications like 'My Application'", cursor_class=DictCursor),
+        mock.call('drop application "My Application"'),
+        mock.call("use role old_role"),
+        # teardown package
+        mock.call("select current_role()", cursor_class=DictCursor),
+        mock.call("use role package_role"),
+        mock.call(
+            "show application packages like 'My Package'", cursor_class=DictCursor
+        ),
+        mock.call('drop application package "My Package"'),
+        mock.call("use role old_role"),
+    ]
+    # 1:1 with expected calls; these are return values
+    mock_execute.side_effect = [
+        # teardown app
+        mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+        None,
+        mock_cursor(
+            [
+                {
+                    "comment": SPECIAL_COMMENT,
+                    "version": LOOSE_FILES_MAGIC_VERSION,
+                    "owner": "app_role",
+                }
+            ],
+            [],
+        ),
+        None,
+        None,
+        # teardown package
+        mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+        None,
+        mock_cursor(
+            [
+                {
+                    "comment": SPECIAL_COMMENT,
+                    "owner": "package_role",
+                }
+            ],
+            [],
+        ),
+        None,
+        None,
+    ]
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+    create_named_file(
+        file_name="snowflake.local.yml",
+        dir=current_working_directory,
+        contents=[quoted_override_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.teardown()
+    assert mock_execute.mock_calls == expected

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -131,6 +131,7 @@ def mock_cursor():
             return None
 
         def fetchall(self):
+            print(self._rows)
             return self._rows
 
         @property

--- a/tests/testing_utils/fixtures.py
+++ b/tests/testing_utils/fixtures.py
@@ -131,7 +131,6 @@ def mock_cursor():
             return None
 
         def fetchall(self):
-            print(self._rows)
             return self._rows
 
         @property


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
- rename `identifier_as_part` to `unquote_identifier`
- use `unquote_identifier` for all LIKE queries + introspecting returned results so any identifier will work properly
- search in returned resultsets for the right row, rather than assuming it's the first one (due to LIKE being unable to restrict to exact case)
- fix tests so that unquoted identifiers are returned in UPPERCASE
- fix a bug in config merging uncovered by using quoted identifiers (`YAML` objects can be scalar)
