### PR TITLE
[DO NOT MERGE][NADE] Hide Native Apps Commands in Main Branch

### DIFF
--- a/src/snowcli/cli/nativeapp/commands.py
+++ b/src/snowcli/cli/nativeapp/commands.py
@@ -17,6 +17,7 @@ from snowcli.output.types import CommandResult, MessageResult
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
+    hidden=True,
     name="app",
     help="Manage Native Apps in Snowflake",
 )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
DO NOT MERGE
Now that a separate tag for sharing Native Apps commands has been created: https://github.com/Snowflake-Labs/snowcli/blob/na-preview/src/snowcli/cli/nativeapp/commands.py, we can safely re-hide the native apps commands from main to prevent any accidental exposure during 2.0 release of the CLI. 
The providers with whom we want to share the native apps commands will have access to the above tag which has the commands visible. 
