### PR TITLE
Fix: Add authenticator and private_key_path fields to ConnectionDetails dataclass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,11 @@ Once you created a dedicated virtual environment you can install SnowCLI in edit
 pip install -e ".[dev]"
 ```
 
+## Unit tests
+
+Unit tests are executed in random order. If tests fail after your change, you can re-execute them in the same order using `pytest --randomly-seed=<number>`, where number is a seed printed at the beginning of the test execution output.
+Random order of test execution is provided by pytest-randomly, so more details are available in [pytest-randomly docs](https://pypi.org/project/pytest-randomly/).
+
 ## Integration tests
 
 Every integration test should have `integration` mark. By default, integration tests are not execute when running `pytest`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "coverage==7.3.2",
   "pre-commit==3.5.0",
   "pytest==7.4.2",
+  "pytest-randomly==3.15.0",
   "syrupy==4.5.0",
   "tox==4.6.4",
 ]

--- a/src/snowcli/cli/common/snow_cli_global_context.py
+++ b/src/snowcli/cli/common/snow_cli_global_context.py
@@ -110,21 +110,23 @@ class SnowCliGlobalContextManager:
         return self._cached_connector
 
 
+def _create_global_context_with_default_values() -> SnowCliGlobalContext:
+    return SnowCliGlobalContext(
+        enable_tracebacks=True,
+        connection=ConnectionDetails(),
+        output_format=OutputFormat.TABLE,
+        verbose=False,
+        experimental=False,
+    )
+
+
 def _create_snow_cli_global_context_manager_with_default_values() -> (
     SnowCliGlobalContextManager
 ):
     """
     Creates a manager with global state filled with default values.
     """
-    return SnowCliGlobalContextManager(
-        SnowCliGlobalContext(
-            enable_tracebacks=True,
-            connection=ConnectionDetails(),
-            output_format=OutputFormat.TABLE,
-            verbose=False,
-            experimental=False,
-        )
-    )
+    return SnowCliGlobalContextManager(_create_global_context_with_default_values())
 
 
 def setup_global_context(param_name: str, value: Union[bool, str]):
@@ -135,6 +137,18 @@ def setup_global_context(param_name: str, value: Union[bool, str]):
     def modifications(context: SnowCliGlobalContext) -> SnowCliGlobalContext:
         setattr(context, param_name, value)
         return context
+
+    snow_cli_global_context_manager.update_global_context(modifications)
+
+
+def reset_global_context():
+    """
+    Global context reset is required to make tests working properly.
+    Without it, context state from previous tests is visible in following tests.
+    """
+
+    def modifications(context: SnowCliGlobalContext) -> SnowCliGlobalContext:
+        return _create_global_context_with_default_values()
 
     snow_cli_global_context_manager.update_global_context(modifications)
 

--- a/src/snowcli/cli/common/snow_cli_global_context.py
+++ b/src/snowcli/cli/common/snow_cli_global_context.py
@@ -17,6 +17,8 @@ class ConnectionDetails:
     schema: Optional[str] = None
     user: Optional[str] = None
     password: Optional[str] = None
+    authenticator: Optional[str] = None
+    private_key_path: Optional[str] = None
     warehouse: Optional[str] = None
     temporary_connection: bool = False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,11 @@ class SnowCLIRunner(CliRunner):
 
     @functools.wraps(CliRunner.invoke)
     def invoke(self, *a, **kw):
+        return self.invoke_with_config_file(self.test_snowcli_config, *a, **kw)
+
+    def invoke_with_config_file(self, config_file: str, *a, **kw):
         kw.update(catch_exceptions=False)
-        return super().invoke(
-            self.app, ["--config-file", self.test_snowcli_config, *a[0]], **kw
-        )
+        return super().invoke(self.app, ["--config-file", config_file, *a[0]], **kw)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,44 +1,39 @@
 from __future__ import annotations
 
-import functools
 import logging
 
 import pytest
-from typer import Typer
-from typer.testing import CliRunner
 
 from snowcli.cli.common import snow_cli_global_context
-
-
-class SnowCLIRunner(CliRunner):
-    def __init__(self, app: Typer, test_snowcli_config: str):
-        super().__init__()
-        self.app = app
-        self.test_snowcli_config = test_snowcli_config
-
-    @functools.wraps(CliRunner.invoke)
-    def invoke(self, *a, **kw):
-        return self.invoke_with_config_file(self.test_snowcli_config, *a, **kw)
-
-    def invoke_with_config_file(self, config_file: str, *a, **kw):
-        kw.update(catch_exceptions=False)
-        return super().invoke(self.app, ["--config-file", config_file, *a[0]], **kw)
+from snowcli.config import config_init
+from tests.testing_utils.fixtures import test_snowcli_config
 
 
 @pytest.fixture(autouse=True)
+# Global context reset is required.
+# Without it, context state from previous tests is visible in following tests.
 def reset_global_context_after_each_test(request):
     snow_cli_global_context.reset_global_context()
     yield
 
 
-# This cleanup function is required to avoid random breaking of logging
+# This automatically used cleanup fixture is required to avoid random breaking of logging
 # in one test caused by presence of capsys in other test.
 # See similar issues: https://github.com/pytest-dev/pytest/issues/5502
 @pytest.fixture(autouse=True)
 def clean_logging_handlers(request):
+    yield
     for logger in [logging.getLogger()] + list(
         logging.Logger.manager.loggerDict.values()
     ):
         handlers = getattr(logger, "handlers", [])
         for handler in handlers:
             logger.removeHandler(handler)
+
+
+# This automatically used setup fixture is required to use test.conf from resources
+# in unit tests which are not using "runner" fixture (tests which do not invoke CLI command).
+@pytest.fixture(autouse=True)
+def set_test_config_in_config_manager(request, test_snowcli_config):
+    config_init(test_snowcli_config)
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,12 +18,8 @@ class SnowCLIRunner(CliRunner):
     @functools.wraps(CliRunner.invoke)
     def invoke(self, *a, **kw):
         kw.update(catch_exceptions=False)
-        return super().invoke(self.app, *a, **kw)
-
-    def invoke_with_config(self, *args, **kwargs):
-        return self.invoke(
-            ["--config-file", self.test_snowcli_config, *args[0]],
-            **kwargs,
+        return super().invoke(
+            self.app, ["--config-file", self.test_snowcli_config, *a[0]], **kw
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import functools
 
+import pytest
 from typer import Typer
 from typer.testing import CliRunner
+
+from snowcli.cli.common import snow_cli_global_context
 
 
 class SnowCLIRunner(CliRunner):
@@ -22,3 +25,9 @@ class SnowCLIRunner(CliRunner):
             ["--config-file", self.test_snowcli_config, *args[0]],
             **kwargs,
         )
+
+
+@pytest.fixture(autouse=True)
+def reset_global_context_after_each_test(request):
+    snow_cli_global_context.reset_global_context()
+    yield

--- a/tests/snowpark/test_function.py
+++ b/tests/snowpark/test_function.py
@@ -411,7 +411,7 @@ def _deploy_function(
     app = Path(execute_in_tmp_dir) / "app.zip"
     app.touch()
     with project_directory("snowpark_functions"):
-        result = runner.invoke_with_config(
+        result = runner.invoke(
             [
                 "snowpark",
                 "function",

--- a/tests/snowpark/test_procedure.py
+++ b/tests/snowpark/test_procedure.py
@@ -30,7 +30,7 @@ def test_deploy_procedure(
     app = local_dir / "app.py"
     app.touch()
 
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -94,7 +94,7 @@ def test_deploy_procedure_with_coverage(
     app = local_dir / "app.py"
     app.touch()
 
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -276,7 +276,7 @@ def test_deploy_procedure_update_because_handler_changed(
 def test_execute_procedure(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -293,7 +293,7 @@ def test_execute_procedure(mock_connector, runner, mock_ctx):
 def test_describe_procedure_from_signature(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -310,7 +310,7 @@ def test_describe_procedure_from_signature(mock_connector, runner, mock_ctx):
 def test_describe_procedure_from_name(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -327,7 +327,7 @@ def test_describe_procedure_from_name(mock_connector, runner, mock_ctx):
 def test_list_procedure(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -345,7 +345,7 @@ def test_list_procedure(mock_connector, runner, mock_ctx):
 def test_drop_procedure_from_signature(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -362,7 +362,7 @@ def test_drop_procedure_from_signature(mock_connector, runner, mock_ctx):
 def test_drop_procedure_from_name(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()
     mock_connector.return_value = ctx
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",
@@ -395,7 +395,7 @@ def _deploy_procedure(
     app.touch()
     artifact_path = f"{tmp_dir.name}/{app.name}"
 
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "snowpark",
             "procedure",

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -13,7 +13,7 @@ STAGE_MANAGER = "snowcli.cli.stage.manager.StageManager"
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_list(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
-    result = runner.invoke_with_config(["stage", "list", "-c", "empty", "stageName"])
+    result = runner.invoke(["stage", "list", "-c", "empty", "stageName"])
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with("ls @stageName")
 
@@ -22,7 +22,7 @@ def test_stage_list(mock_execute, runner, mock_cursor):
 def test_stage_get(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     with TemporaryDirectory() as tmp_dir:
-        result = runner.invoke_with_config(
+        result = runner.invoke(
             ["stage", "get", "-c", "empty", "stageName", str(tmp_dir)]
         )
     assert result.exit_code == 0, result.output
@@ -34,7 +34,7 @@ def test_stage_get(mock_execute, runner, mock_cursor):
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_get_default_path(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
-    result = runner.invoke_with_config(["stage", "get", "-c", "empty", "stageName"])
+    result = runner.invoke(["stage", "get", "-c", "empty", "stageName"])
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with(
         f'get @stageName file://{Path(".").resolve()}/'
@@ -45,7 +45,7 @@ def test_stage_get_default_path(mock_execute, runner, mock_cursor):
 def test_stage_put(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     with TemporaryDirectory() as tmp_dir:
-        result = runner.invoke_with_config(
+        result = runner.invoke(
             [
                 "stage",
                 "put",
@@ -68,7 +68,7 @@ def test_stage_put(mock_execute, runner, mock_cursor):
 def test_stage_put_star(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
     with TemporaryDirectory() as tmp_dir:
-        result = runner.invoke_with_config(
+        result = runner.invoke(
             [
                 "stage",
                 "put",
@@ -90,7 +90,7 @@ def test_stage_put_star(mock_execute, runner, mock_cursor):
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_create(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
-    result = runner.invoke_with_config(["stage", "create", "-c", "empty", "stageName"])
+    result = runner.invoke(["stage", "create", "-c", "empty", "stageName"])
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with("create stage if not exists stageName")
 
@@ -98,7 +98,7 @@ def test_stage_create(mock_execute, runner, mock_cursor):
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_drop(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
-    result = runner.invoke_with_config(["stage", "drop", "-c", "empty", "stageName"])
+    result = runner.invoke(["stage", "drop", "-c", "empty", "stageName"])
     assert result.exit_code == 0, result.output
     mock_execute.assert_called_once_with("drop stage stageName")
 
@@ -106,7 +106,7 @@ def test_stage_drop(mock_execute, runner, mock_cursor):
 @mock.patch(f"{STAGE_MANAGER}._execute_query")
 def test_stage_remove(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         ["stage", "remove", "-c", "empty", "stageName", "my/file/foo.csv"]
     )
     assert result.exit_code == 0, result.output

--- a/tests/streamlit/test_commands.py
+++ b/tests/streamlit/test_commands.py
@@ -64,7 +64,7 @@ def test_deploy_only_streamlit_file(
     with project_directory("example_streamlit") as pdir:
         (pdir / "environment.yml").unlink()
         shutil.rmtree(pdir / "pages")
-        result = runner.invoke_with_config(["streamlit", "deploy"])
+        result = runner.invoke(["streamlit", "deploy"])
 
     assert result.exit_code == 0, result.output
     assert ctx.get_queries() == [
@@ -97,7 +97,7 @@ def test_deploy_launch_browser(
     mock_connector.return_value = ctx
 
     with project_directory("example_streamlit"):
-        result = runner.invoke_with_config(["streamlit", "deploy", "--open"])
+        result = runner.invoke(["streamlit", "deploy", "--open"])
 
     assert result.exit_code == 0, result.output
 

--- a/tests/test_command_registration.py
+++ b/tests/test_command_registration.py
@@ -153,7 +153,6 @@ def test_not_existing_command_group_handling(connection_command_spec_mock, runne
 
     result = runner.invoke(["-h"])
     assert result.exit_code == 0
-    assert result.output.count("xyz123") == 0
     assert result.output.count("Manages connections to Snowflake") == 0
     assert result.output.count("Manages Streamlit in Snowflake") == 1
 

--- a/tests/test_command_registration.py
+++ b/tests/test_command_registration.py
@@ -153,6 +153,7 @@ def test_not_existing_command_group_handling(connection_command_spec_mock, runne
 
     result = runner.invoke(["-h"])
     assert result.exit_code == 0
+    assert result.output.count("xyz123") == 0
     assert result.output.count("Manages connections to Snowflake") == 0
     assert result.output.count("Manages Streamlit in Snowflake") == 1
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -144,7 +144,7 @@ def test_fails_if_existing_connection(runner):
 
 
 def test_lists_connection_information(runner):
-    result = runner.invoke_with_config(["connection", "list", "--format", "json"])
+    result = runner.invoke(["connection", "list", "--format", "json"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload == [
@@ -216,7 +216,7 @@ def test_second_connection_not_update_default_connection(runner, snapshot):
 
 @mock.patch("snowcli.cli.connection.commands.connect_to_snowflake")
 def test_connection_test(mock_connect, runner):
-    result = runner.invoke_with_config(["connection", "test", "-c", "full"])
+    result = runner.invoke(["connection", "test", "-c", "full"])
     assert result.exit_code == 0, result.output
     assert "Host" in result.output
     assert "Password" not in result.output

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -12,10 +12,9 @@ from tests.testing_utils.fixtures import *
 
 def test_new_connection_can_be_added(runner, snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
                 "--connection-name",
@@ -28,7 +27,7 @@ def test_new_connection_can_be_added(runner, snapshot):
                 "account1",
                 "--port",
                 "8080",
-            ]
+            ],
         )
         content = tmp_file.read()
     assert result.exit_code == 0, result.output
@@ -37,10 +36,9 @@ def test_new_connection_can_be_added(runner, snapshot):
 
 def test_port_has_cannot_be_string(runner):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
                 "--connection-name",
@@ -51,7 +49,7 @@ def test_port_has_cannot_be_string(runner):
                 "account1",
                 "--port",
                 "portValue",
-            ]
+            ],
         )
     assert result.exit_code == 1, result.output
     assert "Value of port must be integer" in result.output
@@ -59,10 +57,9 @@ def test_port_has_cannot_be_string(runner):
 
 def test_port_has_cannot_be_float(runner):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
                 "--connection-name",
@@ -73,7 +70,7 @@ def test_port_has_cannot_be_float(runner):
                 "account1",
                 "--port",
                 "123.45",
-            ]
+            ],
         )
     assert result.exit_code == 1, result.output
     assert "Value of port must be integer" in result.output
@@ -81,10 +78,9 @@ def test_port_has_cannot_be_float(runner):
 
 def test_new_connection_add_prompt_handles_default_values(runner, snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
             ],
@@ -97,10 +93,9 @@ def test_new_connection_add_prompt_handles_default_values(runner, snapshot):
 
 def test_new_connection_add_prompt_handles_prompt_override(runner, snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
             ],
@@ -123,10 +118,9 @@ def test_fails_if_existing_connection(runner):
             )
         )
         tmp_file.flush()
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
                 "--connection-name",
@@ -137,7 +131,7 @@ def test_fails_if_existing_connection(runner):
                 "password1",
                 "--account",
                 "account1",
-            ]
+            ],
         )
     assert result.exit_code == 1, result.output
     assert "Connection conn2 already exists  " in result.output
@@ -191,10 +185,9 @@ def test_second_connection_not_update_default_connection(runner, snapshot):
             )
         )
         tmp_file.flush()
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "connection",
                 "add",
                 "--connection-name",
@@ -205,7 +198,7 @@ def test_second_connection_not_update_default_connection(runner, snapshot):
                 "password1",
                 "--account",
                 "account1",
-            ]
+            ],
         )
         tmp_file.seek(0)
         content = tmp_file.read()
@@ -365,13 +358,12 @@ def test_key_pair_authentication_from_config(mock_load, mock_conn, temp_dir, run
         )
         tmp_file.flush()
 
-        result = runner.invoke(
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
             [
-                "--config-file",
-                tmp_file.name,
                 "warehouse",
                 "status",
-            ]
+            ],
         )
 
     assert result.exit_code == 1, result.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,8 +31,9 @@ def test_custom_config_path(mock_conn, runner, mock_cursor):
         None,
         mock_cursor(["row"], []),
     ]
-    result = runner.invoke(
-        ["--config-file", str(config_file), "warehouse", "status"],
+    result = runner.invoke_with_config_file(
+        config_file,
+        ["warehouse", "status"],
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -46,7 +46,7 @@ def test_command_context_is_passed_to_snowflake_connection(
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_returns_nice_error_in_case_of_connectivity_error(runner):
-    result = runner.invoke_with_config(["sql", "-q", "select 1"])
+    result = runner.invoke(["sql", "-q", "select 1"])
     assert result.exit_code == 1
     assert "Invalid connection configuration" in result.output
     assert "User is empty" in result.output

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -71,7 +71,7 @@ def test_sql_fails_for_both_query_and_file(runner):
 def test_sql_overrides_connection_configuration(mock_conn, runner, mock_cursor):
     mock_conn.return_value.execute_string.return_value = [mock_cursor(["row"], [])]
 
-    result = runner.invoke_with_config(
+    result = runner.invoke(
         [
             "sql",
             "-q",

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -19,13 +19,14 @@ from snowcli.app.cli_app import app
 from typer import Typer
 from typer.testing import CliRunner
 from typing import List, Dict, Any, Optional
+
+from snowcli.cli.common import snow_cli_global_context
 from snowcli.cli.project.definition import merge_left
 
 pytest_plugins = [
     "tests_integration.testing_utils",
     "tests_integration.snowflake_connector",
 ]
-
 
 TEST_DIR = Path(__file__).parent
 DEFAULT_TEST_CONFIG = "connection_configs.toml"
@@ -171,3 +172,9 @@ def project_directory(temporary_working_directory, test_root_path):
         yield temporary_working_directory
 
     return _temporary_project_directory
+
+
+@pytest.fixture(autouse=True)
+def reset_global_context_after_each_test(request):
+    snow_cli_global_context.reset_global_context()
+    yield

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ isolated_build = True
 deps =
     pytest
     pytest-cov
+    pytest-randomly
     syrupy
     requests-mock
 extras = tests


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
   * `tests/nativeapp/test_manager.py` was failing on try of running it as single test module (`pytest tests/nativeapp/test_manager.py`) but everything was ok when running it as part of all tests (just `pytest`)
      * The error occurred only in `test_get_snowsight_url` test case.
      * The error was indicating that `authenticator` attribute is not present in `ConnectionDetails` in the global context.
      * The error was correct because that class did not have `authenticator` and `private_key_path` fields.
      * So why it worked for all other tests, why it worked in regular CLI invocations, why `pytest` didn't fail?
        * `ConnectionDetails._connection_update` function sets attributes from CLI connection options. It added new attributes (not present as dataclass fields) to `ConnectionDetails` object for `--authenticator` and `--private-key-path` options.
        * So every in regular CLI invocations, these attributes were present but not as dataclass fields.
        * The same is about all other test cases which use connection -> they all use CLI runner, so there is CLI options handling included in each of them.
        * `pytest` did not fail for `tests/nativeapp/test_manager.py` because other tests invoking CLI runner in other test modules set the attribute before that test. 
      * So why it didn't work for `pytest tests/nativeapp/test_manager.py`?
        *  No test case in `tests/nativeapp/test_manager.py` runs actual CLI. This test module tests manager without invoking the CLI runner. So there was no CLI flags handling and no invocation of `ConnectionDetails._connection_update`.
   * Fixed by:
     * Adding `conftest.py # reset_global_context_after_each_test` autouse fixture to both `tests` and `tests_integrations` to guarantee clear global context for each test case and make `tests/nativeapp/test_manager.py` fail also when running just `pytest`.
     * Adding `authenticator` and `private_key_path` fields to `ConnectionDetails` dataclass.
     * Adding `pytest-randomly` plugin as a dev dependency to introduce random order of tests execution.
     * Fixing other issues found after adding `pytest-randomly`.
