### PR TITLE
[SNOW-961823] [SNOW-956924] Fix specification inlining when creating snowpark job or service

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,6 +38,7 @@ databases, tables, warehouses, functions, procedures, roles, schemas, services, 
 ## Fixes and improvements
 * Resolved `-a` option conflict in `snow snowpark procedure update` command by removing short version of `--replace-always` option (it was conflicting with short version of `--check-anaconda-for-pypi-deps`).
 * Allow the use of quoted identifiers in stages
+* Fixed parsing of commands and arguments lists in specifications of snowpark services and jobs
 
 
 # v1.2.1

--- a/src/snowcli/cli/snowpark/jobs/manager.py
+++ b/src/snowcli/cli/snowpark/jobs/manager.py
@@ -14,9 +14,9 @@ class JobManager(SqlExecutionMixin):
             f"""\
             EXECUTE SERVICE
             IN COMPUTE POOL {compute_pool}
-            FROM SPECIFICATION '
+            FROM SPECIFICATION $$
             {spec}
-            '
+            $$
             """
         )
 

--- a/src/snowcli/cli/snowpark/services/manager.py
+++ b/src/snowcli/cli/snowpark/services/manager.py
@@ -17,9 +17,9 @@ class ServiceManager(SqlExecutionMixin):
             f"""\
             CREATE SERVICE IF NOT EXISTS {service_name}
             IN COMPUTE POOL {compute_pool}
-            FROM SPECIFICATION '
+            FROM SPECIFICATION $$
             {spec}
-            '
+            $$
             WITH
             MIN_INSTANCES = {num_instances}
             MAX_INSTANCES = {num_instances}

--- a/tests/snowpark/test_jobs.py
+++ b/tests/snowpark/test_jobs.py
@@ -36,9 +36,9 @@ spec:
         "USE MockDatabase.MockSchema\n"
         "EXECUTE SERVICE\n"
         "IN COMPUTE POOL testPool\n"
-        "FROM SPECIFICATION '\n"
+        "FROM SPECIFICATION $$\n"
         '{"spec": {"containers": [{"name": "main", "image": "public.ecr.aws/myrepo:latest"}]}}\n'
-        "'\n"
+        "$$\n"
     )
 
 

--- a/tests/snowpark/test_services.py
+++ b/tests/snowpark/test_services.py
@@ -40,9 +40,9 @@ def test_create_service(mock_execute_schema_query, other_directory):
     expected_query = (
         "CREATE SERVICE IF NOT EXISTS test_service "
         "IN COMPUTE POOL test_pool "
-        'FROM SPECIFICATION \' {"spec": {"containers": [{"name": "cloudbeaver", "image": '
+        'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image": '
         '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver", '
-        '"port": 80, "public": true}]}} \' '
+        '"port": 80, "public": true}]}} $$ '
         "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42"
     )
     actual_query = " ".join(


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added new automated tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * [X] I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description
   * Fixes parsing of quotes and multiline strings in snowpark service / job specification
   * Fixes #521
   * Fixed by changing specification inlining to use `FROM SPECIFICATION $$ ... $$` syntax instead of `FROM SPECIFICATION ' ... '` syntax. `$$ ... $$` syntax is mentioned [here](https://docs.snowflake.com/LIMITEDACCESS/snowpark-containers/working-with-services) in docs.