### PR TITLE
[NADE] Fix Error Handling for SQL Queries Involving Warehouse

### DIFF
--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from textwrap import dedent
 from typing import List, Optional, Literal, Callable
 from click.exceptions import ClickException
-from snowcli.exception import SnowflakeSQLExecutionError, MissingWarehouseError
+from snowcli.exception import SnowflakeSQLExecutionError
 from snowflake.connector import ProgrammingError
 
 import jinja2
@@ -45,6 +45,9 @@ NAME_COL = "name"
 COMMENT_COL = "comment"
 OWNER_COL = "owner"
 VERSION_COL = "version"
+
+ERROR_MESSAGE_2043 = "Object does not exist, or operation cannot be performed."
+ERROR_MESSAGE_606 = "No active warehouse selected in the current session."
 
 log = logging.getLogger(__name__)
 
@@ -113,6 +116,35 @@ def find_row(cursor: DictCursor, predicate: Callable[[dict], bool]) -> Optional[
         (row for row in cursor.fetchall() if predicate(row)),
         None,
     )
+
+
+def _use_warehouse_error_handler(err: ProgrammingError, role, warehouse):
+    if err.errno == 2043 or err.msg.__contains__(ERROR_MESSAGE_2043):
+        raise ProgrammingError(
+            msg=dedent(
+                f"""\
+                Received error message '{err.msg}' while executing SQL statement.
+                '{role}' may not have access to warehouse '{warehouse}'.
+                Please grant usage privilege on warehouse to this role.
+                """
+            ),
+            errno=err.errno,
+        )
+    raise err
+
+
+def _generic_sql_error_handler(err: ProgrammingError):
+    if err.errno == 606 or err.msg.__contains__(ERROR_MESSAGE_606):
+        raise ProgrammingError(
+            msg=dedent(
+                f"""\
+                Received error message '{err.msg}' while executing SQL statement.
+                Please provide a warehouse for the active session role in your project definition file, config.toml file, or via command line.
+                """
+            ),
+            errno=err.errno,
+        )
+    raise err
 
 
 class NativeAppManager(SqlExecutionMixin):
@@ -250,13 +282,6 @@ class NativeAppManager(SqlExecutionMixin):
             )
         return diff
 
-    def _raise_err(self, err: ProgrammingError) -> None:
-        if err.errno == 606 or err.msg.__contains__(
-            "No active warehouse selected in the current session"
-        ):
-            raise MissingWarehouseError(str(err.errno).zfill(6), err.msg)
-        raise err
-
     def _apply_package_scripts(self) -> None:
         """
         Assuming the application package exists and we are using the correct role,
@@ -285,23 +310,33 @@ class NativeAppManager(SqlExecutionMixin):
                 raise InvalidPackageScriptError(relpath, e)
 
         # once we're sure all the templates expanded correctly, execute all of them
-        if self.package_warehouse:
-            self._execute_query(f"use warehouse {self.package_warehouse}")
+        try:
+            if self.package_warehouse:
+                self._execute_query(f"use warehouse {self.package_warehouse}")
+        except ProgrammingError as err:
+            _use_warehouse_error_handler(
+                err=err, role=self.package_role, warehouse=self.package_warehouse
+            )
 
         try:
             for i, queries in enumerate(queued_queries):
                 log.info(f"Applying package script: {self.package_scripts[i]}")
                 self._execute_queries(queries)
         except ProgrammingError as err:
-            self._raise_err(err)
+            _generic_sql_error_handler(err)
 
     def _create_dev_app(self, diff: DiffResult) -> None:
         """
         (Re-)creates the application with our up-to-date stage.
         """
         with self.use_role(self.app_role):
-            if self.application_warehouse:
-                self._execute_query(f"use warehouse {self.application_warehouse}")
+            try:
+                if self.application_warehouse:
+                    self._execute_query(f"use warehouse {self.application_warehouse}")
+            except ProgrammingError as err:
+                _use_warehouse_error_handler(
+                    err=err, role=self.app_role, warehouse=self.application_warehouse
+                )
 
             show_app_cursor = self._execute_query(
                 f"show applications like '{unquote_identifier(self.app_name)}'",
@@ -341,7 +376,7 @@ class NativeAppManager(SqlExecutionMixin):
                     )
                     return
                 except ProgrammingError as err:
-                    self._raise_err(err)
+                    _generic_sql_error_handler(err)
 
             # Create an app using "loose files" / stage dev mode.
             log.info(f"Creating new application {self.app_name} in account.")
@@ -371,7 +406,7 @@ class NativeAppManager(SqlExecutionMixin):
                     """,
                 )
             except ProgrammingError as err:
-                self._raise_err(err)
+                _generic_sql_error_handler(err)
 
     def app_exists(self) -> bool:
         """Returns True iff the application exists on Snowflake."""

--- a/src/snowcli/exception.py
+++ b/src/snowcli/exception.py
@@ -56,16 +56,3 @@ class SnowflakeSQLExecutionError(ClickException):
 class ObjectAlreadyExistsError(ClickException):
     def __init__(self, object_type: ObjectType, name: str):
         super().__init__(f"{object_type.value.capitalize()} {name} already exists.")
-
-
-class MissingWarehouseError(ClickException):
-    def __init__(self, errno: str, err_message: str):
-        super().__init__(
-            dedent(
-                f"""\
-            Could not execute SQL statement due to error: '{err_message}' with error code {errno}.
-            Please add a warehouse for the active session role in your project definition file,
-            config.toml file, or via command line.
-            """
-            )
-        )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added new automated tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are up-to-date with the target branch. [As of Nov 8, 9:00AM EST]
   * [ ] I've described my changes in the release notes. N/A
   * [x] I've described my changes in the section below.

### Changes description
1. There is scope for better error handling when the native apps commands try to execute either a `use warehouse ...` directly, or execute a query that requires use of warehouse, such as creation of an application. This PR is to address that scope.
2. There were some flaky unit tests observed intermittently on python 3.8/3.9/3.10 unit tests with use of `assert` with `ProgrammingError` depending on log level. So instead of testing for the whole error message's string, I have picked out a unique part of it to ensure it is present in the return values.
