### PR TITLE
Idempotent + flexible app teardown

### DIFF
--- a/src/snowcli/cli/nativeapp/commands.py
+++ b/src/snowcli/cli/nativeapp/commands.py
@@ -135,7 +135,8 @@ def app_teardown(
     **options,
 ) -> CommandResult:
     """
-    Drops an application and an application package as defined in the project definition file.
+    Attempts to drop both the application and package as defined in the project definition file.
+    This command will succeed even if one or both of these objects do not exist.
     As a note, this command does not accept role or warehouse overrides to your `config.toml` file,
     because your native app definition in `snowflake.yml/snowflake.local.yml` is used for any overrides.
     """

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -247,7 +247,10 @@ def test_drop_object_no_special_comment(mock_execute, temp_dir, mock_cursor):
                     ],
                     [],
                 ),
-                mock.call("show application packages like 'sample_package_name'"),
+                mock.call(
+                    "show application packages like 'SAMPLE_PACKAGE_NAME'",
+                    cursor_class=DictCursor,
+                ),
             ),
             (mock_cursor(["row"], []), mock.call("use role old_role")),
         ]
@@ -273,7 +276,8 @@ def test_drop_object_no_special_comment(mock_execute, temp_dir, mock_cursor):
                 "show": "show application packages like",
             },
         )
-        assert mock_execute.mock_calls == expected
+
+    assert mock_execute.mock_calls == expected
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -199,7 +199,10 @@ def test_drop_object_no_show_object(mock_execute, temp_dir, mock_cursor):
             (mock_cursor(["row"], []), mock.call("use role sample_package_role")),
             (
                 mock_cursor([], []),
-                mock.call("show application packages like 'SAMPLE_PACKAGE_NAME'"),
+                mock.call(
+                    "show application packages like 'SAMPLE_PACKAGE_NAME'",
+                    cursor_class=DictCursor,
+                ),
             ),
             (mock_cursor(["row"], []), mock.call("use role old_role")),
         ]
@@ -212,17 +215,15 @@ def test_drop_object_no_show_object(mock_execute, temp_dir, mock_cursor):
         contents=[mock_snowflake_yml_file],
     )
     native_app_manager = NativeAppManager()
-    with pytest.raises(
-        CouldNotDropObjectError,
-        match="Role sample_package_role does not own any application package with the name sample_package_name!",
-    ):
-        native_app_manager.drop_object(
-            object_name="sample_package_name",
-            object_role="sample_package_role",
-            object_type="package",
-            query_dict={"show": "show application packages like"},
-        )
-        assert mock_execute.mock_calls == expected
+
+    dropped = native_app_manager.drop_object(
+        object_name="sample_package_name",
+        object_role="sample_package_role",
+        object_type="package",
+        query_dict={"show": "show application packages like"},
+    )
+    assert not dropped
+    assert mock_execute.mock_calls == expected
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
@@ -1025,76 +1026,3 @@ def test_get_snowsight_url(
         native_app_manager.get_snowsight_url()
         == "https://host/organization/account/#/apps/application/MYAPP"
     )
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_quoting_app_teardown(mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            # teardown app
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "My Application",
-                            "comment": SPECIAL_COMMENT,
-                            "version": "UNVERSIONED",
-                            "owner": "APP_ROLE",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call(
-                    "show applications like 'My Application'", cursor_class=DictCursor
-                ),
-            ),
-            (None, mock.call('drop application "My Application"')),
-            (None, mock.call("use role old_role")),
-            # teardown package
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role package_role")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "My Package",
-                            "comment": SPECIAL_COMMENT,
-                            "owner": "PACKAGE_ROLE",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call(
-                    "show application packages like 'My Package'",
-                    cursor_class=DictCursor,
-                ),
-            ),
-            (None, mock.call('drop application package "My Package"')),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_execute.side_effect = side_effects
-
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-    create_named_file(
-        file_name="snowflake.local.yml",
-        dir=current_working_directory,
-        contents=[quoted_override_yml_file],
-    )
-
-    native_app_manager = NativeAppManager()
-    native_app_manager.teardown()
-    assert mock_execute.mock_calls == expected

--- a/tests/nativeapp/test_manager_teardown.py
+++ b/tests/nativeapp/test_manager_teardown.py
@@ -221,7 +221,7 @@ def test_teardown_without_app_instance(mock_execute, temp_dir, mock_cursor):
 def test_teardown_could_not_drop_app(mock_execute, temp_dir, mock_cursor):
     side_effects, expected = mock_execute_helper(
         [
-            # teardown app: app does not exist + is skipped
+            # teardown app: app has wrong comment; drop throws an error
             (
                 mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
                 mock.call("select current_role()", cursor_class=DictCursor),
@@ -242,6 +242,7 @@ def test_teardown_could_not_drop_app(mock_execute, temp_dir, mock_cursor):
                 mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
             ),
             (None, mock.call("use role old_role")),
+            # teardown package: never happens
         ]
     )
     mock_execute.side_effect = side_effects

--- a/tests/nativeapp/test_manager_teardown.py
+++ b/tests/nativeapp/test_manager_teardown.py
@@ -1,0 +1,289 @@
+from textwrap import dedent
+from unittest.mock import PropertyMock
+
+from snowcli.cli.nativeapp.manager import (
+    SPECIAL_COMMENT,
+    NativeAppManager,
+)
+from snowflake.connector.cursor import DictCursor
+
+from tests.testing_utils.fixtures import *
+
+NATIVEAPP_MODULE = "snowcli.cli.nativeapp.manager"
+NATIVEAPP_MANAGER_EXECUTE = f"{NATIVEAPP_MODULE}.NativeAppManager._execute_query"
+NATIVEAPP_MANAGER_EXECUTE_QUERIES = (
+    f"{NATIVEAPP_MODULE}.NativeAppManager._execute_queries"
+)
+
+
+mock_connection = mock.patch(
+    "snowcli.cli.common.cli_global_context._CliGlobalContextAccess.connection",
+    new_callable=PropertyMock,
+)
+
+
+mock_snowflake_yml_file = dedent(
+    """\
+        definition_version: 1
+        native_app:
+            name: myapp
+
+            source_stage:
+                app_src.stage
+
+            artifacts:
+                - setup.sql
+                - app/README.md
+                - src: app/streamlit/*.py
+                  dest: ui/
+
+            application:
+                name: myapp
+                role: app_role
+                warehouse: app_warehouse
+                debug: true
+
+            package:
+                name: app_pkg
+                role: package_role
+                scripts:
+                    - shared_content.sql
+    """
+)
+
+quoted_override_yml_file = dedent(
+    """\
+        native_app:
+            application:
+                name: >-
+                    "My Application"
+            package:
+                name: >-
+                    "My Package"
+    """
+)
+
+
+def mock_execute_helper(mock_input: list):
+    side_effects, expected = map(list, zip(*mock_input))
+    return side_effects, expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+def test_idempotent_app_teardown(mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            # teardown app 1: app exists + is dropped
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": SPECIAL_COMMENT,
+                            "version": "UNVERSIONED",
+                            "owner": "APP_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("drop application myapp")),
+            (None, mock.call("use role old_role")),
+            # teardown package 1: package exists + is dropped
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "APP_PKG",
+                            "comment": SPECIAL_COMMENT,
+                            "owner": "PACKAGE_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'APP_PKG'",
+                    cursor_class=DictCursor,
+                ),
+            ),
+            (None, mock.call("drop application package app_pkg")),
+            (None, mock.call("use role old_role")),
+            # teardown app 2: app doesn't exist
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (
+                mock_cursor([], []),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role old_role")),
+            # teardown package 2: package doesn't exist
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor([], []),
+                mock.call(
+                    "show application packages like 'APP_PKG'",
+                    cursor_class=DictCursor,
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.teardown()
+    native_app_manager.teardown()
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+def test_teardown_without_app_instance(mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            # teardown app: app does not exist + is skipped
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (
+                mock_cursor([], []),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role old_role")),
+            # teardown package: package exists + is dropped
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "APP_PKG",
+                            "comment": SPECIAL_COMMENT,
+                            "owner": "PACKAGE_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'APP_PKG'",
+                    cursor_class=DictCursor,
+                ),
+            ),
+            (None, mock.call("drop application package app_pkg")),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.teardown()
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+def test_quoting_app_teardown(mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            # teardown app
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "My Application",
+                            "comment": SPECIAL_COMMENT,
+                            "version": "UNVERSIONED",
+                            "owner": "APP_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show applications like 'My Application'", cursor_class=DictCursor
+                ),
+            ),
+            (None, mock.call('drop application "My Application"')),
+            (None, mock.call("use role old_role")),
+            # teardown package
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "My Package",
+                            "comment": SPECIAL_COMMENT,
+                            "owner": "PACKAGE_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'My Package'",
+                    cursor_class=DictCursor,
+                ),
+            ),
+            (None, mock.call('drop application package "My Package"')),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+    create_named_file(
+        file_name="snowflake.local.yml",
+        dir=current_working_directory,
+        contents=[quoted_override_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.teardown()
+    assert mock_execute.mock_calls == expected

--- a/tests_integration/test_nativeapp.py
+++ b/tests_integration/test_nativeapp.py
@@ -72,6 +72,13 @@ def test_nativeapp_init_run_without_modifications(
             )
             assert result.exit_code == 0
 
+            # teardown is idempotent, so we can execute it again with no ill effects
+            result = runner.invoke_with_connection_json(
+                ["app", "teardown"],
+                env=TEST_ENV,
+            )
+            assert result.exit_code == 0
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("project_definition_files", ["integration"], indirect=True)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
`snow app teardown` will no longer error out if either the application instance or package does not exist. As such, it can now drop the package in cases where the app instance has already been dropped. It will also exit successfully when neither the instance nor package exist, reflecting that the desired end-state has been reached (albeit without doing anything).
