### PR TITLE
[NADE] Allow for INTERNAL/EXTERNAL distribution on prod-ready app packages

### DIFF
--- a/src/snowcli/cli/project/schemas/native_app.py
+++ b/src/snowcli/cli/project/schemas/native_app.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from snowcli.cli.project.schemas.relaxed_map import FilePath, Glob, RelaxedMap
-from snowcli.cli.project.util import IDENTIFIER, SCHEMA_AND_NAME
+from snowcli.cli.project.util import (
+    IDENTIFIER,
+    PACKAGE_DISTRIBUTION_REGEX,
+    SCHEMA_AND_NAME,
+)
 from strictyaml import (
     Bool,
     Optional,
@@ -30,6 +34,9 @@ native_app_schema = RelaxedMap(
                 Optional("role"): Regex(IDENTIFIER),
                 Optional("name"): Regex(IDENTIFIER),
                 Optional("warehouse"): Regex(IDENTIFIER),
+                Optional("distribution", default="internal"): Regex(
+                    PACKAGE_DISTRIBUTION_REGEX
+                ),
             }
         ),
         Optional("application"): RelaxedMap(

--- a/src/snowcli/cli/project/util.py
+++ b/src/snowcli/cli/project/util.py
@@ -15,6 +15,8 @@ SINGLE_QUOTED_STRING_LITERAL_REGEX = r"'((?:\\.|''|[^'\n])+?)'"
 UNQUOTED_IDENTIFIER_REGEX = r"(^[a-zA-Z_])([a-zA-Z0-9_$]{0,254})"
 QUOTED_IDENTIFIER_REGEX = r'"((""|[^"])*)"'
 
+PACKAGE_DISTRIBUTION_REGEX = r"^(internal|external|INTERNAL|EXTERNAL)$"
+
 
 def clean_identifier(input):
     """
@@ -88,6 +90,13 @@ def is_valid_string_literal(literal: str) -> bool:
     Determines if a literal is a valid single quoted string literal
     """
     return re.fullmatch(SINGLE_QUOTED_STRING_LITERAL_REGEX, literal) is not None
+
+
+def is_valid_package_distribution(distribution: str) -> bool:
+    """
+    Determines whether the provided distribution is a valid Snowflake distribution type.
+    """
+    return re.fullmatch(PACKAGE_DISTRIBUTION_REGEX, distribution) is not None
 
 
 def to_string_literal(raw_value: str) -> str:

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -1,61 +1,25 @@
+import unittest
 from textwrap import dedent
-from unittest.mock import PropertyMock
 
 from snowcli.cli.nativeapp.manager import (
     LOOSE_FILES_MAGIC_VERSION,
     SPECIAL_COMMENT,
-    ApplicationAlreadyExistsError,
-    CouldNotDropObjectError,
     NativeAppManager,
-    UnexpectedOwnerError,
+    SnowflakeSQLExecutionError,
 )
 from snowcli.cli.object.stage.diff import DiffResult
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
 
+from tests.nativeapp.utils import (
+    NATIVEAPP_MANAGER_EXECUTE,
+    NATIVEAPP_MODULE,
+    mock_connection,
+    mock_execute_helper,
+    mock_get_app_pkg_distribution_in_sf,
+    mock_snowflake_yml_file,
+)
 from tests.testing_utils.fixtures import *
-
-NATIVEAPP_MODULE = "snowcli.cli.nativeapp.manager"
-NATIVEAPP_MANAGER_EXECUTE = f"{NATIVEAPP_MODULE}.NativeAppManager._execute_query"
-NATIVEAPP_MANAGER_EXECUTE_QUERIES = (
-    f"{NATIVEAPP_MODULE}.NativeAppManager._execute_queries"
-)
-
-
-mock_connection = mock.patch(
-    "snowcli.cli.common.cli_global_context._CliGlobalContextAccess.connection",
-    new_callable=PropertyMock,
-)
-
-
-mock_snowflake_yml_file = dedent(
-    """\
-        definition_version: 1
-        native_app:
-            name: myapp
-
-            source_stage:
-                app_src.stage
-
-            artifacts:
-                - setup.sql
-                - app/README.md
-                - src: app/streamlit/*.py
-                  dest: ui/
-
-            application:
-                name: myapp
-                role: app_role
-                warehouse: app_warehouse
-                debug: true
-
-            package:
-                name: app_pkg
-                role: package_role
-                scripts:
-                    - shared_content.sql
-    """
-)
 
 mock_project_definition_override = {
     "native_app": {
@@ -69,23 +33,6 @@ mock_project_definition_override = {
         },
     }
 }
-
-quoted_override_yml_file = dedent(
-    """\
-        native_app:
-            application:
-                name: >-
-                    "My Application"
-            package:
-                name: >-
-                    "My Package"
-    """
-)
-
-
-def mock_execute_helper(mock_input: list):
-    side_effects, expected = map(list, zip(*mock_input))
-    return side_effects, expected
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
@@ -133,126 +80,27 @@ def test_sync_deploy_root_with_stage(
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_drop_object(mock_execute, temp_dir, mock_cursor):
+def test_get_app_pkg_distribution_in_snowflake(mock_execute, temp_dir, mock_cursor):
+
     side_effects, expected = mock_execute_helper(
         [
             (
                 mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
-            (mock_cursor(["row"], []), mock.call("use role sample_package_role")),
+            (None, mock.call("use role package_role")),
             (
                 mock_cursor(
                     [
-                        {
-                            "name": "SAMPLE_PACKAGE_NAME",
-                            "owner": "SAMPLE_PACKAGE_ROLE",
-                            "blank": "blank",
-                            "comment": "GENERATED_BY_SNOWCLI",
-                        }
+                        ("name", "app_pkg"),
+                        ["owner", "package_role"],
+                        ["distribution", "EXTERNAL"],
                     ],
                     [],
                 ),
-                mock.call(
-                    "show application packages like 'SAMPLE_PACKAGE_NAME'",
-                    cursor_class=DictCursor,
-                ),
+                mock.call("describe application package app_pkg"),
             ),
-            (
-                mock_cursor(["row"], []),
-                mock.call("drop application package sample_package_name"),
-            ),
-            (mock_cursor(["row"], []), mock.call("use role old_role")),
-        ]
-    )
-
-    mock_execute.side_effect = side_effects
-
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-
-    native_app_manager = NativeAppManager()
-    native_app_manager.drop_object(
-        object_name="sample_package_name",
-        object_role="sample_package_role",
-        object_type="package",
-        query_dict={
-            "show": "show application packages like",
-            "drop": "drop application package",
-        },
-    )
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_drop_object_no_show_object(mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (mock_cursor(["row"], []), mock.call("use role sample_package_role")),
-            (
-                mock_cursor([], []),
-                mock.call(
-                    "show application packages like 'SAMPLE_PACKAGE_NAME'",
-                    cursor_class=DictCursor,
-                ),
-            ),
-            (mock_cursor(["row"], []), mock.call("use role old_role")),
-        ]
-    )
-    mock_execute.side_effect = side_effects
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-    native_app_manager = NativeAppManager()
-
-    dropped = native_app_manager.drop_object(
-        object_name="sample_package_name",
-        object_role="sample_package_role",
-        object_type="package",
-        query_dict={"show": "show application packages like"},
-    )
-    assert not dropped
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-def test_drop_object_no_special_comment(mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (mock_cursor(["row"], []), mock.call("use role sample_package_role")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "SAMPLE_PACKAGE_NAME",
-                            "owner": "SAMPLE_PACKAGE_ROLE",
-                            "blank": "blank",
-                            "comment": "NOT_GENERATED_BY_SNOWCLI",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call(
-                    "show application packages like 'SAMPLE_PACKAGE_NAME'",
-                    cursor_class=DictCursor,
-                ),
-            ),
-            (mock_cursor(["row"], []), mock.call("use role old_role")),
+            (None, mock.call("use role old_role")),
         ]
     )
     mock_execute.side_effect = side_effects
@@ -263,49 +111,36 @@ def test_drop_object_no_special_comment(mock_execute, temp_dir, mock_cursor):
         dir=current_working_directory,
         contents=[mock_snowflake_yml_file],
     )
-    native_app_manager = NativeAppManager()
-    with pytest.raises(
-        CouldNotDropObjectError,
-        match="Application Package sample_package_name was not created by SnowCLI. Cannot drop the application package.",
-    ):
-        native_app_manager.drop_object(
-            object_name="sample_package_name",
-            object_role="sample_package_role",
-            object_type="package",
-            query_dict={
-                "show": "show application packages like",
-            },
-        )
 
+    native_app_manager = NativeAppManager()
+    actual_distribution = native_app_manager.get_app_pkg_distribution_in_snowflake
+    assert actual_distribution == "external"
     assert mock_execute.mock_calls == expected
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_w_warehouse_access_exception(
-    mock_conn, mock_execute, temp_dir, mock_cursor
+def test_get_app_pkg_distribution_in_snowflake_throws_programming_error(
+    mock_execute, temp_dir, mock_cursor
 ):
+
     side_effects, expected = mock_execute_helper(
         [
             (
                 mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
-            (None, mock.call("use role app_role")),
+            (None, mock.call("use role package_role")),
             (
                 ProgrammingError(
-                    msg="Object does not exist, or operation cannot be performed.",
-                    errno=2043,
+                    msg="Application package app_pkg does not exist or not authorized."
                 ),
-                mock.call("use warehouse app_warehouse"),
+                mock.call("describe application package app_pkg"),
             ),
             (None, mock.call("use role old_role")),
         ]
     )
-    mock_conn.return_value = MockConnectionCtx()
     mock_execute.side_effect = side_effects
 
-    mock_diff_result = DiffResult()
     current_working_directory = os.getcwd()
     create_named_file(
         file_name="snowflake.yml",
@@ -314,155 +149,30 @@ def test_create_dev_app_w_warehouse_access_exception(
     )
 
     native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
+    with pytest.raises(ProgrammingError):
+        native_app_manager.get_app_pkg_distribution_in_snowflake
 
-    with pytest.raises(ProgrammingError) as err:
-        native_app_manager._create_dev_app(mock_diff_result)
-
-    assert mock_execute.mock_calls == expected
-    assert "Please grant usage privilege on warehouse to this role." in err.value.msg
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_noop(mock_conn, mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "MYAPP",
-                            "comment": SPECIAL_COMMENT,
-                            "version": LOOSE_FILES_MAGIC_VERSION,
-                            "owner": "APP_ROLE",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (None, mock.call("alter application myapp set debug_mode = True")),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult()
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-
-    native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
-    native_app_manager._create_dev_app(mock_diff_result)
     assert mock_execute.mock_calls == expected
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_recreate(mock_conn, mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "MYAPP",
-                            "comment": SPECIAL_COMMENT,
-                            "version": LOOSE_FILES_MAGIC_VERSION,
-                            "owner": "APP_ROLE",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (
-                None,
-                mock.call(
-                    "alter application myapp upgrade using @app_pkg.app_src.stage"
-                ),
-            ),
-            (None, mock.call("alter application myapp set debug_mode = True")),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult(different=["setup.sql"])
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-
-    native_app_manager = NativeAppManager()
-    assert mock_diff_result.has_changes()
-    native_app_manager._create_dev_app(mock_diff_result)
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_recreate_w_missing_warehouse_exception(
-    mock_conn, mock_execute, temp_dir, mock_cursor
+def test_get_app_pkg_distribution_in_snowflake_throws_execution_error(
+    mock_execute, temp_dir, mock_cursor
 ):
+
     side_effects, expected = mock_execute_helper(
         [
             (
                 mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "MYAPP",
-                            "comment": SPECIAL_COMMENT,
-                            "version": LOOSE_FILES_MAGIC_VERSION,
-                            "owner": "APP_ROLE",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (
-                ProgrammingError(
-                    msg="No active warehouse selected in the current session", errno=606
-                ),
-                mock.call(
-                    "alter application myapp upgrade using @app_pkg.app_src.stage"
-                ),
-            ),
+            (None, mock.call("use role package_role")),
+            (mock_cursor([], []), mock.call("describe application package app_pkg")),
             (None, mock.call("use role old_role")),
         ]
     )
-    mock_conn.return_value = MockConnectionCtx()
     mock_execute.side_effect = side_effects
 
-    mock_diff_result = DiffResult(different=["setup.sql"])
     current_working_directory = os.getcwd()
     create_named_file(
         file_name="snowflake.yml",
@@ -471,313 +181,84 @@ def test_create_dev_app_recreate_w_missing_warehouse_exception(
     )
 
     native_app_manager = NativeAppManager()
-    assert mock_diff_result.has_changes()
-
-    with pytest.raises(ProgrammingError) as err:
-        native_app_manager._create_dev_app(mock_diff_result)
+    with pytest.raises(SnowflakeSQLExecutionError):
+        native_app_manager.get_app_pkg_distribution_in_snowflake
 
     assert mock_execute.mock_calls == expected
-    assert "Please provide a warehouse for the active session role" in err.value.msg
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_create_new(mock_conn, mock_execute, temp_dir, mock_cursor):
+def test_get_app_pkg_distribution_in_snowflake_throws_distribution_error(
+    mock_execute, temp_dir, mock_cursor
+):
+
     side_effects, expected = mock_execute_helper(
         [
             (
                 mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
                 mock.call("select current_role()", cursor_class=DictCursor),
             ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
+            (None, mock.call("use role package_role")),
             (
-                mock_cursor([], []),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (
-                None,
-                mock.call(
-                    f"""
-                    create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
-                        comment = {SPECIAL_COMMENT}
-                    """
-                ),
+                mock_cursor([("name", "app_pkg"), ["owner", "package_role"]], []),
+                mock.call("describe application package app_pkg"),
             ),
             (None, mock.call("use role old_role")),
         ]
     )
-    mock_conn.return_value = MockConnectionCtx()
     mock_execute.side_effect = side_effects
 
-    mock_diff_result = DiffResult()
     current_working_directory = os.getcwd()
     create_named_file(
         file_name="snowflake.yml",
         dir=current_working_directory,
-        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
+        contents=[mock_snowflake_yml_file],
     )
 
     native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
-    native_app_manager._create_dev_app(mock_diff_result)
+    with pytest.raises(ProgrammingError):
+        native_app_manager.get_app_pkg_distribution_in_snowflake
+
     assert mock_execute.mock_calls == expected
 
 
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_create_new_w_missing_warehouse_exception(
-    mock_conn, mock_execute, temp_dir, mock_cursor
-):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor([], []),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (
-                ProgrammingError(
-                    msg="No active warehouse selected in the current session", errno=606
-                ),
-                mock.call(
-                    f"""
-                    create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
-                        comment = {SPECIAL_COMMENT}
-                    """
-                ),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
-    )
+@mock_get_app_pkg_distribution_in_sf
+def test_is_app_pkg_distribution_same_in_sf_no_mismatch(mock_mismatch, temp_dir):
+    mock_mismatch.return_value = "external"
 
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult()
     current_working_directory = os.getcwd()
     create_named_file(
         file_name="snowflake.yml",
         dir=current_working_directory,
-        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
+        contents=[mock_snowflake_yml_file],
     )
 
-    native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
-
-    with pytest.raises(ProgrammingError) as err:
-        native_app_manager._create_dev_app(mock_diff_result)
-
-    assert "Please provide a warehouse for the active session role" in err.value.msg
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_create_new_quoted(
-    mock_conn, mock_execute, temp_dir, mock_cursor
-):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor([], []),
-                mock.call(
-                    "show applications like 'My Application'", cursor_class=DictCursor
-                ),
-            ),
-            (
-                None,
-                mock.call(
-                    f"""
-                    create application "My Application"
-                        from application package "My Package"
-                        using '@"My Package".app_src.stage'
-                        debug_mode = True
-                        comment = {SPECIAL_COMMENT}
-                    """
-                ),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult()
-    current_working_directory = os.getcwd()
     create_named_file(
-        file_name="snowflake.yml",
+        file_name="snowflake.local.yml",
         dir=current_working_directory,
         contents=[
             dedent(
                 """\
-            definition_version: 1
-            native_app:
-                name: '"My Native Application"'
-
-                source_stage:
-                    app_src.stage
-
-                artifacts:
-                - setup.sql
-                - app/README.md
-                - src: app/streamlit/*.py
-                dest: ui/
-
-                application:
-                    name: >-
-                        "My Application"
-                    role: app_role
-                    warehouse: app_warehouse
-                    debug: true
-
-                package:
-                    name: >-
-                        "My Package"
-                    role: app_role
-                    scripts:
-                    - shared_content.sql
-        """
+                    native_app:
+                        package:
+                            distribution: >-
+                                EXTERNAL
+                """
             )
         ],
     )
 
     native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
-    native_app_manager._create_dev_app(mock_diff_result)
-    assert mock_execute.mock_calls == expected
+    assert native_app_manager.is_app_pkg_distribution_same_in_sf() is True
 
 
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_create_new_quoted_override(
-    mock_conn, mock_execute, temp_dir, mock_cursor
+@mock_get_app_pkg_distribution_in_sf
+@mock.patch(f"{NATIVEAPP_MODULE}.log.warning")
+def test_is_app_pkg_distribution_same_in_sf_has_mismatch(
+    mock_warning, mock_mismatch, temp_dir
 ):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor([], []),
-                mock.call(
-                    "show applications like 'My Application'", cursor_class=DictCursor
-                ),
-            ),
-            (
-                None,
-                mock.call(
-                    f"""
-                    create application "My Application"
-                        from application package "My Package"
-                        using '@"My Package".app_src.stage'
-                        debug_mode = True
-                        comment = {SPECIAL_COMMENT}
-                    """
-                ),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
+    mock_mismatch.return_value = "external"
 
-    mock_diff_result = DiffResult()
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
-    )
-    create_named_file(
-        file_name="snowflake.local.yml",
-        dir=current_working_directory,
-        contents=[quoted_override_yml_file],
-    )
-
-    native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
-    native_app_manager._create_dev_app(mock_diff_result)
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
-@mock_connection
-def test_create_dev_app_create_new_with_additional_privileges(
-    mock_conn, mock_execute_queries, mock_execute_query, temp_dir, mock_cursor
-):
-    side_effects, mock_execute_query_expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor([], []),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (
-                mock_cursor([{"CURRENT_ROLE()": "app_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role package_role")),
-            (None, mock.call("use role app_role")),
-            (
-                None,
-                mock.call(
-                    f"""
-                    create application myapp
-                        from application package app_pkg
-                        using @app_pkg.app_src.stage
-                        debug_mode = True
-                        comment = {SPECIAL_COMMENT}
-                    """
-                ),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute_query.side_effect = side_effects
-
-    mock_execute_queries_expected = [
-        mock.call(
-            dedent(
-                f"""\
-            grant install, develop on application package app_pkg to role app_role;
-            grant usage on schema app_pkg.app_src to role app_role;
-            grant read on stage app_pkg.app_src.stage to role app_role;
-            """
-            )
-        )
-    ]
-    mock_execute_queries.side_effect = [None, None, None]
-
-    mock_diff_result = DiffResult()
     current_working_directory = os.getcwd()
     create_named_file(
         file_name="snowflake.yml",
@@ -786,151 +267,10 @@ def test_create_dev_app_create_new_with_additional_privileges(
     )
 
     native_app_manager = NativeAppManager()
-    assert not mock_diff_result.has_changes()
-    native_app_manager._create_dev_app(mock_diff_result)
-    assert mock_execute_query.mock_calls == mock_execute_query_expected
-    assert mock_execute_queries.mock_calls == mock_execute_queries_expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_bad_comment(mock_conn, mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "MYAPP",
-                            "comment": "bad comment",
-                            "version": LOOSE_FILES_MAGIC_VERSION,
-                            "owner": "APP_ROLE",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
+    assert native_app_manager.is_app_pkg_distribution_same_in_sf() is False
+    mock_warning.assert_called_once_with(
+        "App pkg app_pkg in your Snowflake account has distribution property external,\nwhich does not match the value specified in project definition file: internal.\n"
     )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult()
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-
-    with pytest.raises(ApplicationAlreadyExistsError):
-        native_app_manager = NativeAppManager()
-        assert not mock_diff_result.has_changes()
-        native_app_manager._create_dev_app(mock_diff_result)
-
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_bad_version(mock_conn, mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "MYAPP",
-                            "comment": SPECIAL_COMMENT,
-                            "version": "v1",
-                            "owner": "app_role",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult()
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-
-    with pytest.raises(ApplicationAlreadyExistsError):
-        native_app_manager = NativeAppManager()
-        assert not mock_diff_result.has_changes()
-        native_app_manager._create_dev_app(mock_diff_result)
-
-    assert mock_execute.mock_calls == expected
-
-
-@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
-@mock_connection
-def test_create_dev_app_bad_owner(mock_conn, mock_execute, temp_dir, mock_cursor):
-    side_effects, expected = mock_execute_helper(
-        [
-            (
-                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
-                mock.call("select current_role()", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role app_role")),
-            (None, mock.call("use warehouse app_warehouse")),
-            (
-                mock_cursor(
-                    [
-                        {
-                            "name": "MYAPP",
-                            "comment": SPECIAL_COMMENT,
-                            "version": LOOSE_FILES_MAGIC_VERSION,
-                            "owner": "accountadmin_or_something",
-                        }
-                    ],
-                    [],
-                ),
-                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
-            ),
-            (None, mock.call("use role old_role")),
-        ]
-    )
-    mock_conn.return_value = MockConnectionCtx()
-    mock_execute.side_effect = side_effects
-
-    mock_diff_result = DiffResult()
-    current_working_directory = os.getcwd()
-    create_named_file(
-        file_name="snowflake.yml",
-        dir=current_working_directory,
-        contents=[mock_snowflake_yml_file],
-    )
-
-    with pytest.raises(UnexpectedOwnerError):
-        native_app_manager = NativeAppManager()
-        assert not mock_diff_result.has_changes()
-        native_app_manager._create_dev_app(mock_diff_result)
-
-    assert mock_execute.mock_calls == expected
 
 
 @mock.patch(NATIVEAPP_MANAGER_EXECUTE)

--- a/tests/nativeapp/test_manager_run.py
+++ b/tests/nativeapp/test_manager_run.py
@@ -1,0 +1,936 @@
+import unittest
+from textwrap import dedent
+
+from snowcli.cli.nativeapp.manager import (
+    LOOSE_FILES_MAGIC_VERSION,
+    SPECIAL_COMMENT,
+    ApplicationAlreadyExistsError,
+    ApplicationPackageAlreadyExistsError,
+    NativeAppManager,
+    UnexpectedOwnerError,
+)
+from snowcli.cli.object.stage.diff import DiffResult
+from snowflake.connector import ProgrammingError
+from snowflake.connector.cursor import DictCursor
+
+from tests.nativeapp.utils import (
+    NATIVEAPP_MANAGER_APP_PKG_DISTRIBUTION_IN_SF,
+    NATIVEAPP_MANAGER_EXECUTE,
+    NATIVEAPP_MANAGER_EXECUTE_QUERIES,
+    NATIVEAPP_MODULE,
+    mock_connection,
+    mock_execute_helper,
+    mock_get_app_pkg_distribution_in_sf,
+    mock_snowflake_yml_file,
+    quoted_override_yml_file,
+)
+from tests.testing_utils.fixtures import *
+
+mock_project_definition_override = {
+    "native_app": {
+        "application": {
+            "name": "sample_application_name",
+            "role": "sample_application_role",
+        },
+        "package": {
+            "name": "sample_package_name",
+            "role": "sample_package_role",
+        },
+    }
+}
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_w_warehouse_access_exception(
+    mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (
+                ProgrammingError(
+                    msg="Object does not exist, or operation cannot be performed.",
+                    errno=2043,
+                ),
+                mock.call("use warehouse app_warehouse"),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+
+    with pytest.raises(ProgrammingError) as err:
+        native_app_manager._create_dev_app(mock_diff_result)
+
+    assert mock_execute.mock_calls == expected
+    assert "Please grant usage privilege on warehouse to this role." in err.value.msg
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_noop(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": SPECIAL_COMMENT,
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "APP_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("alter application myapp set debug_mode = True")),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+    native_app_manager._create_dev_app(mock_diff_result)
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_recreate(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": SPECIAL_COMMENT,
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "APP_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (
+                None,
+                mock.call(
+                    "alter application myapp upgrade using @app_pkg.app_src.stage"
+                ),
+            ),
+            (None, mock.call("alter application myapp set debug_mode = True")),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult(different=["setup.sql"])
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert mock_diff_result.has_changes()
+    native_app_manager._create_dev_app(mock_diff_result)
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_recreate_w_missing_warehouse_exception(
+    mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": SPECIAL_COMMENT,
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "APP_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (
+                ProgrammingError(
+                    msg="No active warehouse selected in the current session", errno=606
+                ),
+                mock.call(
+                    "alter application myapp upgrade using @app_pkg.app_src.stage"
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult(different=["setup.sql"])
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert mock_diff_result.has_changes()
+
+    with pytest.raises(ProgrammingError) as err:
+        native_app_manager._create_dev_app(mock_diff_result)
+
+    assert mock_execute.mock_calls == expected
+    assert "Please provide a warehouse for the active session role" in err.value.msg
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_create_new(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor([], []),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (
+                None,
+                mock.call(
+                    f"""
+                    create application myapp
+                        from application package app_pkg
+                        using @app_pkg.app_src.stage
+                        debug_mode = True
+                        comment = {SPECIAL_COMMENT}
+                    """
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+    native_app_manager._create_dev_app(mock_diff_result)
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_create_new_w_missing_warehouse_exception(
+    mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor([], []),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (
+                ProgrammingError(
+                    msg="No active warehouse selected in the current session", errno=606
+                ),
+                mock.call(
+                    f"""
+                    create application myapp
+                        from application package app_pkg
+                        using @app_pkg.app_src.stage
+                        debug_mode = True
+                        comment = {SPECIAL_COMMENT}
+                    """
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+
+    with pytest.raises(ProgrammingError) as err:
+        native_app_manager._create_dev_app(mock_diff_result)
+
+    assert "Please provide a warehouse for the active session role" in err.value.msg
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_create_new_quoted(
+    mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor([], []),
+                mock.call(
+                    "show applications like 'My Application'", cursor_class=DictCursor
+                ),
+            ),
+            (
+                None,
+                mock.call(
+                    f"""
+                    create application "My Application"
+                        from application package "My Package"
+                        using '@"My Package".app_src.stage'
+                        debug_mode = True
+                        comment = {SPECIAL_COMMENT}
+                    """
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[
+            dedent(
+                """\
+            definition_version: 1
+            native_app:
+                name: '"My Native Application"'
+
+                source_stage:
+                    app_src.stage
+
+                artifacts:
+                - setup.sql
+                - app/README.md
+                - src: app/streamlit/*.py
+                dest: ui/
+
+                application:
+                    name: >-
+                        "My Application"
+                    role: app_role
+                    warehouse: app_warehouse
+                    debug: true
+
+                package:
+                    name: >-
+                        "My Package"
+                    role: app_role
+                    scripts:
+                    - shared_content.sql
+        """
+            )
+        ],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+    native_app_manager._create_dev_app(mock_diff_result)
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_create_new_quoted_override(
+    mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor([], []),
+                mock.call(
+                    "show applications like 'My Application'", cursor_class=DictCursor
+                ),
+            ),
+            (
+                None,
+                mock.call(
+                    f"""
+                    create application "My Application"
+                        from application package "My Package"
+                        using '@"My Package".app_src.stage'
+                        debug_mode = True
+                        comment = {SPECIAL_COMMENT}
+                    """
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file.replace("package_role", "app_role")],
+    )
+    create_named_file(
+        file_name="snowflake.local.yml",
+        dir=current_working_directory,
+        contents=[quoted_override_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+    native_app_manager._create_dev_app(mock_diff_result)
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE_QUERIES)
+@mock_connection
+def test_create_dev_app_create_new_with_additional_privileges(
+    mock_conn, mock_execute_queries, mock_execute_query, temp_dir, mock_cursor
+):
+    side_effects, mock_execute_query_expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor([], []),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (
+                mock_cursor([{"CURRENT_ROLE()": "app_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (None, mock.call("use role app_role")),
+            (
+                None,
+                mock.call(
+                    f"""
+                    create application myapp
+                        from application package app_pkg
+                        using @app_pkg.app_src.stage
+                        debug_mode = True
+                        comment = {SPECIAL_COMMENT}
+                    """
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute_query.side_effect = side_effects
+
+    mock_execute_queries_expected = [
+        mock.call(
+            dedent(
+                f"""\
+            grant install, develop on application package app_pkg to role app_role;
+            grant usage on schema app_pkg.app_src to role app_role;
+            grant read on stage app_pkg.app_src.stage to role app_role;
+            """
+            )
+        )
+    ]
+    mock_execute_queries.side_effect = [None, None, None]
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    assert not mock_diff_result.has_changes()
+    native_app_manager._create_dev_app(mock_diff_result)
+    assert mock_execute_query.mock_calls == mock_execute_query_expected
+    assert mock_execute_queries.mock_calls == mock_execute_queries_expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_bad_comment(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": "bad comment",
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "APP_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    with pytest.raises(ApplicationAlreadyExistsError):
+        native_app_manager = NativeAppManager()
+        assert not mock_diff_result.has_changes()
+        native_app_manager._create_dev_app(mock_diff_result)
+
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_bad_version(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": SPECIAL_COMMENT,
+                            "version": "v1",
+                            "owner": "app_role",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    with pytest.raises(ApplicationAlreadyExistsError):
+        native_app_manager = NativeAppManager()
+        assert not mock_diff_result.has_changes()
+        native_app_manager._create_dev_app(mock_diff_result)
+
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_dev_app_bad_owner(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role app_role")),
+            (None, mock.call("use warehouse app_warehouse")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "MYAPP",
+                            "comment": SPECIAL_COMMENT,
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "accountadmin_or_something",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call("show applications like 'MYAPP'", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    mock_diff_result = DiffResult()
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    with pytest.raises(UnexpectedOwnerError):
+        native_app_manager = NativeAppManager()
+        assert not mock_diff_result.has_changes()
+        native_app_manager._create_dev_app(mock_diff_result)
+
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_app_pkg_no_show(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor([], []),
+                mock.call(
+                    "show application packages like 'APP_PKG'", cursor_class=DictCursor
+                ),
+            ),
+            (
+                None,
+                mock.call(
+                    f"""
+                    create application package app_pkg
+                        comment = {SPECIAL_COMMENT}
+                        distribution = internal
+                    """
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.create_app_package()
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+def test_create_app_pkg_bad_owner(mock_conn, mock_execute, temp_dir, mock_cursor):
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "APP_PKG",
+                            "comment": SPECIAL_COMMENT,
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "accountadmin_or_something",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'APP_PKG'", cursor_class=DictCursor
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    with pytest.raises(UnexpectedOwnerError):
+        native_app_manager = NativeAppManager()
+        native_app_manager.create_app_package()
+
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+@mock_get_app_pkg_distribution_in_sf
+def test_create_app_pkg_internal_distribution_special_comment(
+    mock_mismatch, mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    mock_mismatch.return_value = "internal"
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "APP_PKG",
+                            "comment": SPECIAL_COMMENT,
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "PACKAGE_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'APP_PKG'", cursor_class=DictCursor
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.create_app_package()
+
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+@mock_get_app_pkg_distribution_in_sf
+def test_create_app_pkg_internal_distribution_wrong_comment(
+    mock_mismatch, mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    mock_mismatch.return_value = "internal"
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "APP_PKG",
+                            "comment": "random",
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "PACKAGE_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'APP_PKG'", cursor_class=DictCursor
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    with pytest.raises(ApplicationPackageAlreadyExistsError):
+        native_app_manager = NativeAppManager()
+        native_app_manager.create_app_package()
+
+    assert mock_execute.mock_calls == expected
+
+
+@mock.patch(NATIVEAPP_MANAGER_EXECUTE)
+@mock_connection
+@mock_get_app_pkg_distribution_in_sf
+@mock.patch(f"{NATIVEAPP_MODULE}.log.warning")
+def test_create_app_pkg_external_distribution(
+    mock_warning, mock_mismatch, mock_conn, mock_execute, temp_dir, mock_cursor
+):
+    mock_mismatch.return_value = "external"
+    side_effects, expected = mock_execute_helper(
+        [
+            (
+                mock_cursor([{"CURRENT_ROLE()": "old_role"}], []),
+                mock.call("select current_role()", cursor_class=DictCursor),
+            ),
+            (None, mock.call("use role package_role")),
+            (
+                mock_cursor(
+                    [
+                        {
+                            "name": "APP_PKG",
+                            "comment": "random",
+                            "version": LOOSE_FILES_MAGIC_VERSION,
+                            "owner": "PACKAGE_ROLE",
+                        }
+                    ],
+                    [],
+                ),
+                mock.call(
+                    "show application packages like 'APP_PKG'", cursor_class=DictCursor
+                ),
+            ),
+            (None, mock.call("use role old_role")),
+        ]
+    )
+    mock_conn.return_value = MockConnectionCtx()
+    mock_execute.side_effect = side_effects
+
+    current_working_directory = os.getcwd()
+    create_named_file(
+        file_name="snowflake.yml",
+        dir=current_working_directory,
+        contents=[mock_snowflake_yml_file],
+    )
+
+    native_app_manager = NativeAppManager()
+    native_app_manager.create_app_package()
+
+    assert mock_execute.mock_calls == expected
+    mock_warning.assert_any_call(
+        "Continuing to execute `snow app run` on app pkg app_pkg with distribution 'external'.\n"
+    )
+    assert mock_warning.call_count == 2

--- a/tests/nativeapp/utils.py
+++ b/tests/nativeapp/utils.py
@@ -1,0 +1,69 @@
+from textwrap import dedent
+from unittest import mock
+from unittest.mock import PropertyMock
+
+NATIVEAPP_MODULE = "snowcli.cli.nativeapp.manager"
+NATIVEAPP_MANAGER_EXECUTE = f"{NATIVEAPP_MODULE}.NativeAppManager._execute_query"
+NATIVEAPP_MANAGER_EXECUTE_QUERIES = (
+    f"{NATIVEAPP_MODULE}.NativeAppManager._execute_queries"
+)
+NATIVEAPP_MANAGER_APP_PKG_DISTRIBUTION_IN_SF = (
+    f"{NATIVEAPP_MODULE}.NativeAppManager.get_app_pkg_distribution_in_snowflake"
+)
+NATIVEAPP_MANAGER_TYPER_CONFIRM = f"{NATIVEAPP_MODULE}.typer.confirm"
+
+mock_snowflake_yml_file = dedent(
+    """\
+        definition_version: 1
+        native_app:
+            name: myapp
+
+            source_stage:
+                app_src.stage
+
+            artifacts:
+                - setup.sql
+                - app/README.md
+                - src: app/streamlit/*.py
+                  dest: ui/
+
+            application:
+                name: myapp
+                role: app_role
+                warehouse: app_warehouse
+                debug: true
+
+            package:
+                name: app_pkg
+                role: package_role
+                scripts:
+                    - shared_content.sql
+    """
+)
+
+quoted_override_yml_file = dedent(
+    """\
+        native_app:
+            application:
+                name: >-
+                    "My Application"
+            package:
+                name: >-
+                    "My Package"
+    """
+)
+
+mock_connection = mock.patch(
+    "snowcli.cli.common.cli_global_context._CliGlobalContextAccess.connection",
+    new_callable=PropertyMock,
+)
+
+mock_get_app_pkg_distribution_in_sf = mock.patch(
+    NATIVEAPP_MANAGER_APP_PKG_DISTRIBUTION_IN_SF,
+    new_callable=PropertyMock,
+)
+
+
+def mock_execute_helper(mock_input: list):
+    side_effects, expected = map(list, zip(*mock_input))
+    return side_effects, expected

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -1,10 +1,8 @@
-from typing import List, Optional
 from unittest import mock
 from unittest.mock import PropertyMock
 
 import pytest
 from snowcli.cli.project.definition import (
-    generate_local_override_yml,
     load_project_definition,
 )
 from strictyaml import YAMLValidationError
@@ -29,33 +27,6 @@ def test_na_minimal_project(project_definition_files: List[Path]):
     project = load_project_definition(project_definition_files)
     assert project["native_app"]["name"] == "minimal"
     assert project["native_app"]["artifacts"] == ["setup.sql", "README.md"]
-
-    from os import getenv as original_getenv
-
-    def mock_getenv(key: str, default: Optional[str] = None) -> Optional[str]:
-        if key.lower() == "user":
-            return "jsmith"
-        return original_getenv(key, default)
-
-    with mock.patch(
-        "snowcli.cli.common.cli_global_context._CliGlobalContextAccess.connection",
-        new_callable=PropertyMock,
-    ) as connection:
-        connection.return_value.role = "resolved_role"
-        connection.return_value.warehouse = "resolved_warehouse"
-        with mock.patch("os.getenv", side_effect=mock_getenv):
-            # TODO: probably a better way of going about this is to not generate
-            # a definition structure for these values but directly return defaults
-            # in "getter" functions (higher-level data structures).
-            local = generate_local_override_yml(project)
-            assert local["native_app"]["application"]["name"] == "minimal_jsmith"
-            assert local["native_app"]["application"]["role"] == "resolved_role"
-            assert (
-                local["native_app"]["application"]["warehouse"] == "resolved_warehouse"
-            )
-            assert local["native_app"]["application"]["debug"] == True
-            assert local["native_app"]["package"]["name"] == "minimal_pkg_jsmith"
-            assert local["native_app"]["package"]["role"] == "resolved_role"
 
 
 @pytest.mark.parametrize("project_definition_files", ["underspecified"], indirect=True)

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -2,6 +2,7 @@ import pytest
 from snowcli.cli.project.util import (
     append_to_identifier,
     is_valid_identifier,
+    is_valid_package_distribution,
     is_valid_quoted_identifier,
     is_valid_string_literal,
     is_valid_unquoted_identifier,
@@ -138,6 +139,23 @@ def test_append_to_identifier():
 )
 def test_is_valid_string_literal(literal, valid):
     assert is_valid_string_literal(literal) == valid
+
+
+@pytest.mark.parametrize(
+    "distribution,valid",
+    [
+        ("internal", True),
+        ("external", True),
+        ("INTERNAL", True),
+        ("EXTERNAL", True),
+        ("Jinternal", False),
+        ("internalJ", False),
+        ("random", False),
+        ("", False),
+    ],
+)
+def test_is_valid_package_distribution(distribution, valid):
+    assert is_valid_package_distribution(distribution) == valid
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code - N/A
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch - as of Dec 12, 9:20AM EST
   * [ ] I've described my changes in the release notes - N/A
   * [x] I've described my changes in the section below.

### Changes description
This PR introduces changes to `snow app` commands to allow setting distribution of app packages to external, as well as interacting with objects if they already have been created outside the CLI. 
Integration Tests are not relevant for this PR. This is because with changes to distribution, teardown behavior will change. But teardown is part of a follow up ticket. Therefore changes/addition to integration tests will be relevant once teardown is under review. 

### Note
This PR should not be merged just yet, even if approved. This is because the `alpha 2` tag should not include this change, but since the tag is created from the main branch, it might accidentally contain this commit too. 
