### PR TITLE
Adopt project definition decorator in native apps commands

### DIFF
--- a/src/snowcli/cli/common/cli_global_context.py
+++ b/src/snowcli/cli/common/cli_global_context.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 from typing import Dict, Optional
 
 from snowcli.exception import InvalidSchemaError
@@ -155,6 +156,7 @@ class _CliGlobalContextManager:
         self._verbose = False
         self._experimental = False
         self._project_definition = None
+        self._project_root = None
 
     def reset(self):
         self.__init__()
@@ -194,6 +196,12 @@ class _CliGlobalContextManager:
     def set_project_definition(self, value: Dict):
         self._project_definition = value
 
+    def project_root(self):
+        return self._project_root
+
+    def set_project_root(self, project_root: Path):
+        self._project_root = project_root
+
     @property
     def connection_context(self) -> _ConnectionContext:
         return self._connection_context
@@ -230,6 +238,10 @@ class _CliGlobalContextAccess:
     @property
     def project_definition(self):
         return self._manager.project_definition
+
+    @property
+    def project_root(self):
+        return self._manager.project_root
 
 
 cli_context_manager: _CliGlobalContextManager = _CliGlobalContextManager()

--- a/src/snowcli/cli/common/flags.py
+++ b/src/snowcli/cli/common/flags.py
@@ -216,6 +216,7 @@ def project_definition_option(project_name: str):
     def _callback(project_path: Optional[str]):
         dm = DefinitionManager(project_path)
         project_definition = dm.project_definition.get(project_name)
+        project_root = dm.project_root
 
         if not project_definition:
             raise NoProjectDefinitionError(
@@ -223,6 +224,7 @@ def project_definition_option(project_name: str):
             )
 
         cli_context_manager.set_project_definition(project_definition)
+        cli_context_manager.set_project_root(project_root)
         return project_definition
 
     return typer.Option(

--- a/src/snowcli/cli/nativeapp/commands.py
+++ b/src/snowcli/cli/nativeapp/commands.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Optional
 
 import typer
+from snowcli.cli.common.cli_global_context import cli_context
 from snowcli.cli.common.decorators import (
     global_options,
     global_options_with_connection,
+    with_project_definition,
 )
 from snowcli.cli.common.flags import DEFAULT_CONTEXT_SETTINGS
 from snowcli.cli.nativeapp.init import nativeapp_init
@@ -19,14 +20,6 @@ app = typer.Typer(
 )
 
 log = logging.getLogger(__name__)
-
-ProjectArgument = typer.Option(
-    None,
-    "-p",
-    "--project",
-    help="Path where the Native Apps project resides. Defaults to current working directory",
-    show_default=False,
-)
 
 
 @app.command("init")
@@ -71,24 +64,27 @@ def app_init(
 
 @app.command("bundle", hidden=True)
 @with_output
+@with_project_definition("native_app")
 @global_options
 def app_bundle(
-    project_path: Optional[str] = ProjectArgument,
     **options,
 ) -> CommandResult:
     """
     Prepares a local folder with configured app artifacts.
     """
-    manager = NativeAppManager(project_path)
+    manager = NativeAppManager(
+        project_definition=cli_context.project_definition,
+        project_root=cli_context.project_root,
+    )
     manager.build_bundle()
     return MessageResult(f"Bundle generated at {manager.deploy_root}")
 
 
 @app.command("run")
 @with_output
+@with_project_definition("native_app")
 @global_options_with_connection
 def app_run(
-    project_path: Optional[str] = ProjectArgument,
     **options,
 ) -> CommandResult:
     """
@@ -97,7 +93,10 @@ def app_run(
     command does not accept role or warehouse overrides to your `config.toml` file, because your
     native app definition in `snowflake.yml` or `snowflake.local.yml` is used for any overrides.
     """
-    manager = NativeAppManager(project_path)
+    manager = NativeAppManager(
+        project_definition=cli_context.project_definition,
+        project_root=cli_context.project_root,
+    )
     manager.build_bundle()
     manager.app_run()
     return MessageResult(
@@ -108,16 +107,19 @@ def app_run(
 
 @app.command("open")
 @with_output
+@with_project_definition("native_app")
 @global_options_with_connection
 def app_open(
-    project_path: Optional[str] = ProjectArgument,
     **options,
 ) -> CommandResult:
     """
     Opens the (development mode) application inside of your browser,
     once it has been installed in your account.
     """
-    manager = NativeAppManager(project_path)
+    manager = NativeAppManager(
+        project_definition=cli_context.project_definition,
+        project_root=cli_context.project_root,
+    )
     if manager.app_exists():
         typer.launch(manager.get_snowsight_url())
         return MessageResult(f"Application opened in browser.")
@@ -129,9 +131,9 @@ def app_open(
 
 @app.command("teardown")
 @with_output
+@with_project_definition("native_app")
 @global_options_with_connection
 def app_teardown(
-    project_path: Optional[str] = ProjectArgument,
     **options,
 ) -> CommandResult:
     """
@@ -140,6 +142,9 @@ def app_teardown(
     As a note, this command does not accept role or warehouse overrides to your `config.toml` file,
     because your native app definition in `snowflake.yml/snowflake.local.yml` is used for any overrides.
     """
-    manager = NativeAppManager(project_path)
+    manager = NativeAppManager(
+        project_definition=cli_context.project_definition,
+        project_root=cli_context.project_root,
+    )
     manager.teardown()
     return MessageResult(f"Teardown is now complete.")

--- a/src/snowcli/cli/nativeapp/manager.py
+++ b/src/snowcli/cli/nativeapp/manager.py
@@ -4,7 +4,7 @@ import logging
 from functools import cached_property
 from pathlib import Path
 from textwrap import dedent
-from typing import Callable, List, Literal, Optional
+from typing import Callable, Dict, List, Literal, Optional
 
 import jinja2
 from click.exceptions import ClickException
@@ -145,19 +145,18 @@ def _generic_sql_error_handler(
 
 
 class NativeAppManager(SqlExecutionMixin):
-    definition_manager: DefinitionManager
-
-    def __init__(self, search_path: Optional[str] = None):
+    def __init__(self, project_definition: Dict, project_root: Path):
         super().__init__()
-        self.definition_manager = DefinitionManager(search_path or "")
+        self._project_root = project_root
+        self._project_definition = project_definition
 
     @property
     def project_root(self) -> Path:
-        return self.definition_manager.project_root
+        return self._project_root
 
     @property
-    def definition(self) -> dict:
-        return self.definition_manager.project_definition["native_app"]
+    def definition(self) -> Dict:
+        return self._project_definition
 
     @cached_property
     def artifacts(self) -> List[ArtifactMapping]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,7 @@ from snowcli.cli import loggers
 from snowcli.cli.common.cli_global_context import cli_context_manager
 from snowcli.config import config_init
 
-pytest_plugins = [
-    "tests.testing_utils.fixtures",
-]
+pytest_plugins = ["tests.testing_utils.fixtures", "tests.project.fixtures"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/nativeapp/test_manager_teardown.py
+++ b/tests/nativeapp/test_manager_teardown.py
@@ -7,6 +7,7 @@ from snowcli.cli.nativeapp.manager import (
     NativeAppManager,
     SnowflakeSQLExecutionError,
 )
+from snowcli.cli.project.definition_manager import DefinitionManager
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import DictCursor
 
@@ -65,6 +66,14 @@ quoted_override_yml_file = dedent(
                     "My Package"
     """
 )
+
+
+def _get_na_manager():
+    dm = DefinitionManager()
+    return NativeAppManager(
+        project_definition=dm.project_definition["native_app"],
+        project_root=dm.project_root,
+    )
 
 
 def mock_execute_helper(mock_input: list):
@@ -158,7 +167,7 @@ def test_idempotent_app_teardown(mock_execute, temp_dir, mock_cursor):
         contents=[mock_snowflake_yml_file],
     )
 
-    native_app_manager = NativeAppManager()
+    native_app_manager = _get_na_manager()
     native_app_manager.teardown()
     native_app_manager.teardown()
     assert mock_execute.mock_calls == expected
@@ -214,7 +223,7 @@ def test_teardown_without_app_instance(mock_execute, temp_dir, mock_cursor):
         contents=[mock_snowflake_yml_file],
     )
 
-    native_app_manager = NativeAppManager()
+    native_app_manager = _get_na_manager()
     native_app_manager.teardown()
     assert mock_execute.mock_calls == expected
 
@@ -256,7 +265,7 @@ def test_teardown_app_has_wrong_comment(mock_execute, temp_dir, mock_cursor):
         contents=[mock_snowflake_yml_file],
     )
 
-    native_app_manager = NativeAppManager()
+    native_app_manager = _get_na_manager()
     with pytest.raises(CouldNotDropObjectError):
         native_app_manager.teardown()
 
@@ -307,7 +316,7 @@ def test_teardown_drop_app_fails(mock_execute, temp_dir, mock_cursor):
         contents=[mock_snowflake_yml_file],
     )
 
-    native_app_manager = NativeAppManager()
+    native_app_manager = _get_na_manager()
     with pytest.raises(SnowflakeSQLExecutionError):
         native_app_manager.teardown()
 
@@ -382,6 +391,6 @@ def test_quoting_app_teardown(mock_execute, temp_dir, mock_cursor):
         contents=[quoted_override_yml_file],
     )
 
-    native_app_manager = NativeAppManager()
+    native_app_manager = _get_na_manager()
     native_app_manager.teardown()
     assert mock_execute.mock_calls == expected


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Adopt `@with_project_definition` decorator in native apps commands.
