### PR TITLE
mraba/ruff-linting-in-pyproject: move select to tool.ruff.lint section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,15 +66,17 @@ packages = ["src/snowcli", "src/templates"]
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 select = [
-    "N",
-    "I",  # isort
-    "G",  # flake8-logging-format
-    "N",  # pep8 naming
-    "A",  # flake 8 builtins
-    "TID252",  # relative imports
-    "SLF",  # Accessing private methods
-    "F401", # unused imports
+  "N",
+  "I",      # isort
+  "G",      # flake8-logging-format
+  "N",      # pep8 naming
+  "A",      # flake 8 builtins
+  "TID252", # relative imports
+  "SLF",    # Accessing private methods
+  "F401",   # unused imports
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Moved `ruff` linting rules to `[tool.ruff.lint]` according to [docs](https://docs.astral.sh/ruff/configuration/#__tabbed_3_1)
