### PR TITLE
SNOW-986249-option-for-intermediate-output-of-command: global `silent…

### DIFF
--- a/src/snowcli/api/cli_global_context.py
+++ b/src/snowcli/api/cli_global_context.py
@@ -145,7 +145,7 @@ class _ConnectionContext:
         return connect_to_snowflake(
             temporary_connection=self.temporary_connection,
             connection_name=self.connection_name,
-            **self._collect_not_empty_connection_attributes()
+            **self._collect_not_empty_connection_attributes(),
         )
 
 
@@ -158,6 +158,7 @@ class _CliGlobalContextManager:
         self._experimental = False
         self._project_definition = None
         self._project_root = None
+        self._silent: bool = False
 
     def reset(self):
         self.__init__()
@@ -212,6 +213,13 @@ class _CliGlobalContextManager:
     def connection(self) -> SnowflakeConnection:
         return self.connection_context.connection
 
+    @property
+    def silent(self) -> bool:
+        return self._silent
+
+    def set_silent(self, value: bool):
+        self._silent = value
+
 
 class _CliGlobalContextAccess:
     def __init__(self, manager: _CliGlobalContextManager):
@@ -244,6 +252,10 @@ class _CliGlobalContextAccess:
     @property
     def project_root(self):
         return self._manager.project_root
+
+    @property
+    def silent(self) -> bool:
+        return self._manager.silent
 
 
 cli_context_manager: _CliGlobalContextManager = _CliGlobalContextManager()

--- a/src/snowcli/api/commands/decorators.py
+++ b/src/snowcli/api/commands/decorators.py
@@ -17,6 +17,7 @@ from snowcli.api.commands.flags import (
     PrivateKeyPathOption,
     RoleOption,
     SchemaOption,
+    SilentOption,
     TemporaryConnectionOption,
     UserOption,
     VerboseOption,
@@ -254,6 +255,12 @@ GLOBAL_OPTIONS = [
         inspect.Parameter.KEYWORD_ONLY,
         annotation=Optional[bool],
         default=DebugOption,
+    ),
+    inspect.Parameter(
+        "silent",
+        inspect.Parameter.KEYWORD_ONLY,
+        annotation=Optional[bool],
+        default=SilentOption,
     ),
 ]
 

--- a/src/snowcli/api/commands/flags.py
+++ b/src/snowcli/api/commands/flags.py
@@ -151,6 +151,16 @@ OutputFormatOption = typer.Option(
     rich_help_panel=_CLI_BEHAVIOUR,
 )
 
+SilentOption = typer.Option(
+    False,
+    "--silent",
+    "-s",
+    help="Turns off intermediate output to console.",
+    callback=_callback(lambda: cli_context_manager.set_silent),
+    is_flag=True,
+    rich_help_panel=_CLI_BEHAVIOUR,
+)
+
 VerboseOption = typer.Option(
     False,
     "--verbose",

--- a/src/snowcli/api/commands/flags.py
+++ b/src/snowcli/api/commands/flags.py
@@ -154,7 +154,6 @@ OutputFormatOption = typer.Option(
 SilentOption = typer.Option(
     False,
     "--silent",
-    "-s",
     help="Turns off intermediate output to console.",
     callback=_callback(lambda: cli_context_manager.set_silent),
     is_flag=True,

--- a/tests/output/test_silent_output.py
+++ b/tests/output/test_silent_output.py
@@ -1,0 +1,15 @@
+def test_silent_output_help(runner):
+    result = runner.invoke(["streamlit", "get-url", "--help"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    expected_message = "Turns off intermediate output to console"
+    assert expected_message in result.output, result.output
+
+
+def test_proper_context_values_for_silent(runner):
+    result = runner.invoke(["streamlit", "get-url", "--silent", "--help"])
+    assert runner.app is not None
+    assert runner.app
+
+    assert result.exit_code == 0, result.output
+    print(dir(runner))

--- a/tests/test_common_decorators.py
+++ b/tests/test_common_decorators.py
@@ -20,9 +20,10 @@ _KNOWN_SIG_GLOBAL_PARAMETERS_WITH_CONNECTION = [
     "format",
     "verbose",
     "debug",
+    "silent",
 ]
 
-_KNOWN_SIG_GLOBAL_PARAMETERS = ["format", "verbose", "debug"]
+_KNOWN_SIG_GLOBAL_PARAMETERS = ["format", "verbose", "debug", "silent"]
 
 
 def _extract_arguments(func):


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
- New global option `--silent` was added. No shortcut was defined for command _(`-s` would collide with snowpark package upload and connection schema)_
