### PR TITLE
[NADE] Enable directory on stage + debug mode for versioned upgrades

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/commands.py
@@ -160,7 +160,7 @@ def app_open(
     **options,
 ) -> CommandResult:
     """
-    Opens the (development mode) application inside of your browser,
+    Opens the application inside of your browser,
     once it has been installed in your account.
     """
     manager = NativeAppManager(

--- a/src/snowflake/cli/plugins/nativeapp/manager.py
+++ b/src/snowflake/cli/plugins/nativeapp/manager.py
@@ -266,7 +266,8 @@ class NativeAppManager(SqlExecutionMixin):
             self._execute_query(
                 f"""
                     create stage if not exists {self.stage_fqn}
-                    encryption = (TYPE = 'SNOWFLAKE_SSE')"""
+                    encryption = (TYPE = 'SNOWFLAKE_SSE')
+                    DIRECTORY = (ENABLE = TRUE)"""
             )
 
         # Perform a diff operation and display results to the user for informational purposes

--- a/src/snowflake/cli/plugins/nativeapp/run_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/run_processor.py
@@ -309,6 +309,12 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                     self._execute_query(
                         f"alter application {self.app_name} upgrade {using_clause}"
                     )
+
+                    # ensure debug_mode is up-to-date
+                    if using_clause:
+                        self._execute_query(
+                            f"alter application {self.app_name} set debug_mode = {self.debug_mode}"
+                        )
                     return
 
                 except ProgrammingError as err:
@@ -341,6 +347,12 @@ class NativeAppRunProcessor(NativeAppManager, NativeAppCommandProcessor):
                     """
                     )
                 )
+
+                # ensure debug_mode is up-to-date
+                if using_clause:
+                    self._execute_query(
+                        f"alter application {self.app_name} set debug_mode = {self.debug_mode}"
+                    )
             except ProgrammingError as err:
                 generic_sql_error_handler(err)
 

--- a/src/snowflake/cli/plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/plugins/nativeapp/version/commands.py
@@ -40,12 +40,12 @@ log = logging.getLogger(__name__)
 def create(
     version: Optional[str] = typer.Argument(
         None,
-        help=f"""Version of the app package that you would like to create a version or patch for. Defaults to the version specified in the `manifest.yml` file.""",
+        help=f"""Version of the app package for which you want to a version or patch. Defaults to the version specified in the `manifest.yml` file.""",
     ),
     patch: Optional[str] = typer.Option(
         None,
         "--patch",
-        help=f"""The patch number you would like to create for an existing version.
+        help=f"""The patch number you want to create for an existing version.
         Defaults to undefined if it is not set, which means the CLI either uses the patch specified in the `manifest.yml` file or automatically generates a new patch number.""",
     ),
     skip_git_check: Optional[bool] = typer.Option(

--- a/tests/nativeapp/test_manager.py
+++ b/tests/nativeapp/test_manager.py
@@ -79,7 +79,8 @@ def test_sync_deploy_root_with_stage(
         mock.call(
             f"""
                     create stage if not exists app_pkg.app_src.stage
-                    encryption = (TYPE = 'SNOWFLAKE_SSE')"""
+                    encryption = (TYPE = 'SNOWFLAKE_SSE')
+                    DIRECTORY = (ENABLE = TRUE)"""
         ),
         mock.call("use role old_role"),
     ]

--- a/tests/nativeapp/test_run_processor.py
+++ b/tests/nativeapp/test_run_processor.py
@@ -1376,6 +1376,7 @@ def test_upgrade_app_recreate_app_from_version(
                     )
                 ),
             ),
+            (None, mock.call("alter application myapp set debug_mode = True")),
             (None, mock.call("use role old_role")),
         ]
     )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code - N/A
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch -  as of Jan 18, 4:40PM EST
   * [ ] I've described my changes in the release notes - N/A
   * [x] I've described my changes in the section below.

### Changes description
This PR makes two changes:
1. Enables directory param for the stage created where we upload files. This way our customers can explore the contents of the stage when they run `snow app` commands, and they do not need an extra step of enabling it.
2. Enables debug mode for versioned installs/upgrades, to keep it consistent across all development mode instances, not just loose files.
