### PR TITLE
SNOW-1011737, SNOW-1011750: Add options to create commands for compute pool and service

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,7 @@
   * `services` commands were renamed to `service`
   * `pool`, `job` and `service` commands were moved from `snowpark` group to a new `containers` group.
   * `snow snowpark registry` was replaced with `snow registry` command.
+  * `snow services pool create` and `snow containers service create` have been updated with all options available through SQL interface.
 
 * Streamlit changes
   * `snow streamlit deploy` is requiring `snowflake.yml` project file with a Streamlit definition.

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -42,7 +42,7 @@ class OutputDataTypeError(ClickException):
 
 class CommandReturnTypeError(ClickException):
     def __init__(self, got_type: type):
-        super().__init__(f"Commads have to return OutputData type, but got {got_type}")
+        super().__init__(f"Commands have to return OutputData type, but got {got_type}")
 
 
 class SnowflakeSQLExecutionError(ClickException):

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -13,7 +13,7 @@ SINGLE_QUOTED_STRING_LITERAL_REGEX = r"'((?:\\.|''|[^'\n])+?)'"
 
 # See https://docs.snowflake.com/en/sql-reference/identifiers-syntax for identifier syntax
 UNQUOTED_IDENTIFIER_REGEX = r"(^[a-zA-Z_])([a-zA-Z0-9_$]{0,254})"
-QUOTED_IDENTIFIER_REGEX = r'"((""|[^"])*)"'
+QUOTED_IDENTIFIER_REGEX = r'"((""|[^"]){0,255})"'
 
 
 def clean_identifier(input_: str):

--- a/src/snowflake/cli/plugins/containers/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/containers/compute_pool/commands.py
@@ -32,7 +32,7 @@ def create(
     ),
     auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume", help="The compute pool will automatically resume when a service or job is submitted to it."),
     initially_suspended: bool = typer.Option(False, "--init-suspend", help="The compute pool will start in a suspended state."),
-    auto_suspend_secs: int = typer.Option(3600, "--auto-suspend", help="Number of seconds of inactivity after which you want Snowflake to automatically suspend the compute pool."),
+    auto_suspend_secs: int = typer.Option(3600, "--auto-suspend-secs", help="Number of seconds of inactivity after which you want Snowflake to automatically suspend the compute pool."),
     comment: Optional[str] = comment_option("compute pool"),
     **options,
 ) -> CommandResult:

--- a/src/snowflake/cli/plugins/containers/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/containers/compute_pool/commands.py
@@ -30,9 +30,21 @@ def create(
         "--family",
         help="Name of the instance family. For more information about instance families, refer to the SQL CREATE COMPUTE POOL command.",
     ),
-    auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume", help="The compute pool will automatically resume when a service or job is submitted to it."),
-    initially_suspended: bool = typer.Option(False, "--init-suspend", help="The compute pool will start in a suspended state."),
-    auto_suspend_secs: int = typer.Option(3600, "--auto-suspend-secs", help="Number of seconds of inactivity after which you want Snowflake to automatically suspend the compute pool."),
+    auto_resume: bool = typer.Option(
+        True,
+        "--auto-resume/--no-auto-resume",
+        help="The compute pool will automatically resume when a service or job is submitted to it.",
+    ),
+    initially_suspended: bool = typer.Option(
+        False,
+        "--init-suspend",
+        help="The compute pool will start in a suspended state.",
+    ),
+    auto_suspend_secs: int = typer.Option(
+        3600,
+        "--auto-suspend-secs",
+        help="Number of seconds of inactivity after which you want Snowflake to automatically suspend the compute pool.",
+    ),
     comment: Optional[str] = comment_option("compute pool"),
     **options,
 ) -> CommandResult:
@@ -40,7 +52,13 @@ def create(
     Creates a compute pool with a specified number of instances.
     """
     cursor = ComputePoolManager().create(
-        pool_name=name, num_instances=num_instances, instance_family=instance_family, auto_resume=auto_resume, initially_suspended=initially_suspended, auto_suspend_secs=auto_suspend_secs, comment=comment
+        pool_name=name,
+        num_instances=num_instances,
+        instance_family=instance_family,
+        auto_resume=auto_resume,
+        initially_suspended=initially_suspended,
+        auto_suspend_secs=auto_suspend_secs,
+        comment=comment,
     )
     return SingleQueryResult(cursor)
 

--- a/src/snowflake/cli/plugins/containers/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/containers/compute_pool/commands.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import typer
 from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
@@ -6,6 +8,7 @@ from snowflake.cli.api.commands.decorators import (
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
 from snowflake.cli.api.output.types import CommandResult, SingleQueryResult
 from snowflake.cli.plugins.containers.compute_pool.manager import ComputePoolManager
+from snowflake.cli.plugins.object.common import comment_option
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
@@ -27,13 +30,17 @@ def create(
         "--family",
         help="Name of the instance family. For more information about instance families, refer to the SQL CREATE COMPUTE POOL command.",
     ),
+    auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume", help="The compute pool will automatically resume when a service or job is submitted to it."),
+    initially_suspended: bool = typer.Option(False, "--init-suspend", help="The compute pool will start in a suspended state."),
+    auto_suspend_secs: int = typer.Option(3600, "--auto-suspend", help="Number of seconds of inactivity after which you want Snowflake to automatically suspend the compute pool."),
+    comment: Optional[str] = comment_option("compute pool"),
     **options,
 ) -> CommandResult:
     """
     Creates a compute pool with a specified number of instances.
     """
     cursor = ComputePoolManager().create(
-        pool_name=name, num_instances=num_instances, instance_family=instance_family
+        pool_name=name, num_instances=num_instances, instance_family=instance_family, auto_resume=auto_resume, initially_suspended=initially_suspended, auto_suspend_secs=auto_suspend_secs, comment=comment
     )
     return SingleQueryResult(cursor)
 

--- a/src/snowflake/cli/plugins/containers/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/containers/compute_pool/manager.py
@@ -6,7 +6,14 @@ from snowflake.connector.cursor import SnowflakeCursor
 
 class ComputePoolManager(SqlExecutionMixin):
     def create(
-        self, pool_name: str, num_instances: int, instance_family: str, auto_resume: bool, initially_suspended: bool, auto_suspend_secs: int, comment: Optional[str]
+        self,
+        pool_name: str,
+        num_instances: int,
+        instance_family: str,
+        auto_resume: bool,
+        initially_suspended: bool,
+        auto_suspend_secs: int,
+        comment: Optional[str],
     ) -> SnowflakeCursor:
         query = f"""\
             CREATE COMPUTE POOL {pool_name}
@@ -16,13 +23,13 @@ class ComputePoolManager(SqlExecutionMixin):
             AUTO_RESUME = {auto_resume}
             INITIALLY_SUSPENDED = {initially_suspended}
             AUTO_SUSPEND_SECS = {auto_suspend_secs}
-            """.split("\n")
+            """.split(
+            "\n"
+        )
         if comment:
             query.append(f"COMMENT = {comment}")
-        query = "\n".join([q.strip() for q in query if q.strip()])
-        return self._execute_query(
-            query
-        )
+        query_string = "\n".join([q.strip() for q in query if q.strip()])
+        return self._execute_query(query_string)
 
     def stop(self, pool_name: str) -> SnowflakeCursor:
         return self._execute_query(f"alter compute pool {pool_name} stop all;")

--- a/src/snowflake/cli/plugins/containers/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/containers/compute_pool/manager.py
@@ -1,18 +1,27 @@
+from typing import Optional
+
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import SnowflakeCursor
 
 
 class ComputePoolManager(SqlExecutionMixin):
     def create(
-        self, pool_name: str, num_instances: int, instance_family: str
+        self, pool_name: str, num_instances: int, instance_family: str, auto_resume: bool, initially_suspended: bool, auto_suspend_secs: int, comment: Optional[str]
     ) -> SnowflakeCursor:
-        return self._execute_query(
-            f"""\
+        query = f"""\
             CREATE COMPUTE POOL {pool_name}
             MIN_NODES = {num_instances}
             MAX_NODES = {num_instances}
-            INSTANCE_FAMILY = {instance_family};
-        """
+            INSTANCE_FAMILY = {instance_family}
+            AUTO_RESUME = {auto_resume}
+            INITIALLY_SUSPENDED = {initially_suspended}
+            AUTO_SUSPEND_SECS = {auto_suspend_secs}
+            """.split("\n")
+        if comment:
+            query.append(f"COMMENT = {comment}")
+        query = "\n".join([q.strip() for q in query if q.strip()])
+        return self._execute_query(
+            query
         )
 
     def stop(self, pool_name: str) -> SnowflakeCursor:

--- a/src/snowflake/cli/plugins/containers/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/containers/compute_pool/manager.py
@@ -23,9 +23,7 @@ class ComputePoolManager(SqlExecutionMixin):
             AUTO_RESUME = {auto_resume}
             INITIALLY_SUSPENDED = {initially_suspended}
             AUTO_SUSPEND_SECS = {auto_suspend_secs}
-            """.split(
-            "\n"
-        )
+            """.splitlines()
         if comment:
             query.append(f"COMMENT = {comment}")
         query_string = "\n".join([q.strip() for q in query if q.strip()])

--- a/src/snowflake/cli/plugins/containers/services/commands.py
+++ b/src/snowflake/cli/plugins/containers/services/commands.py
@@ -1,9 +1,8 @@
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import typer
-
 from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
     with_output,
@@ -16,7 +15,7 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.plugins.containers.common import print_log_lines
 from snowflake.cli.plugins.containers.services.manager import ServiceManager
-from snowflake.cli.plugins.object.common import tag_option, comment_option, Tag
+from snowflake.cli.plugins.object.common import Tag, comment_option, tag_option
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
@@ -29,26 +28,35 @@ app = typer.Typer(
 @with_output
 @global_options_with_connection
 def create(
-        name: str = typer.Option(..., "--name", help="Job Name"),
-        compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
-        spec_path: Path = typer.Option(
-            ...,
-            "--spec-path",
-            help="Spec Path",
-            file_okay=True,
-            dir_okay=False,
-            exists=True,
-        ),
-        num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
-        auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume",
-                                         help="The service will automatically resume when a service function or ingress is called."),
-        external_access_integrations: Optional[List[str]] = typer.Option(None, "--eai-name",
-                                                                         help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs."),
-        query_warehouse: Optional[str] = typer.Option(None, "--query-warehouse",
-                                                      help="Warehouse to use if a service container connects to Snowflake to execute a query but does not explicitly specify a warehouse to use."),
-        tags: Optional[List[Tag]] = tag_option("service"),
-        comment: Optional[str] = comment_option("service"),
-        **options,
+    name: str = typer.Option(..., "--name", help="Job Name"),
+    compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
+    spec_path: Path = typer.Option(
+        ...,
+        "--spec-path",
+        help="Spec Path",
+        file_okay=True,
+        dir_okay=False,
+        exists=True,
+    ),
+    num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
+    auto_resume: bool = typer.Option(
+        True,
+        "--auto-resume/--no-auto-resume",
+        help="The service will automatically resume when a service function or ingress is called.",
+    ),
+    external_access_integrations: Optional[List[str]] = typer.Option(
+        None,
+        "--eai-name",
+        help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs.",
+    ),
+    query_warehouse: Optional[str] = typer.Option(
+        None,
+        "--query-warehouse",
+        help="Warehouse to use if a service container connects to Snowflake to execute a query without explicitly specifying a warehouse to use.",
+    ),
+    tags: Optional[List[Tag]] = tag_option("service"),
+    comment: Optional[str] = comment_option("service"),
+    **options,
 ) -> CommandResult:
     """
     Creates a new Snowpark Container Services service in the current schema.
@@ -63,7 +71,7 @@ def create(
         auto_resume=auto_resume,
         query_warehouse=query_warehouse,
         tags=tags,
-        comment=comment
+        comment=comment,
     )
     return SingleQueryResult(cursor)
 

--- a/src/snowflake/cli/plugins/containers/services/commands.py
+++ b/src/snowflake/cli/plugins/containers/services/commands.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 import typer
+
 from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
     with_output,
@@ -14,6 +16,7 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.plugins.containers.common import print_log_lines
 from snowflake.cli.plugins.containers.services.manager import ServiceManager
+from snowflake.cli.plugins.object.common import tag_option, comment_option, Tag
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
@@ -26,18 +29,26 @@ app = typer.Typer(
 @with_output
 @global_options_with_connection
 def create(
-    name: str = typer.Option(..., "--name", help="Job Name"),
-    compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
-    spec_path: Path = typer.Option(
-        ...,
-        "--spec-path",
-        help="Spec Path",
-        file_okay=True,
-        dir_okay=False,
-        exists=True,
-    ),
-    num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
-    **options,
+        name: str = typer.Option(..., "--name", help="Job Name"),
+        compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
+        spec_path: Path = typer.Option(
+            ...,
+            "--spec-path",
+            help="Spec Path",
+            file_okay=True,
+            dir_okay=False,
+            exists=True,
+        ),
+        num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
+        auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume",
+                                         help="The service will automatically resume when a service function or ingress is called."),
+        external_access_integrations: Optional[List[str]] = typer.Option(None, "--eai-name",
+                                                                         help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs."),
+        query_warehouse: Optional[str] = typer.Option(None, "--query-warehouse",
+                                                      help="Warehouse to use if a service container connects to Snowflake to execute a query but does not explicitly specify a warehouse to use."),
+        tags: Optional[List[Tag]] = tag_option("service"),
+        comment: Optional[str] = comment_option("service"),
+        **options,
 ) -> CommandResult:
     """
     Creates a new Snowpark Container Services service in the current schema.
@@ -48,6 +59,11 @@ def create(
         num_instances=num_instances,
         compute_pool=compute_pool,
         spec_path=spec_path,
+        external_access_integrations=external_access_integrations,
+        auto_resume=auto_resume,
+        query_warehouse=query_warehouse,
+        tags=tags,
+        comment=comment
     )
     return SingleQueryResult(cursor)
 

--- a/src/snowflake/cli/plugins/containers/services/manager.py
+++ b/src/snowflake/cli/plugins/containers/services/manager.py
@@ -1,24 +1,23 @@
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.cli.plugins.object.common import Tag
 from snowflake.connector.cursor import SnowflakeCursor
 
-from snowflake.cli.plugins.object.common import Tag
 
 class ServiceManager(SqlExecutionMixin):
-
     def create(
-            self,
-            service_name: str,
-            compute_pool: str,
-            spec_path: Path,
-            num_instances: int,
-            auto_resume: bool,
-            external_access_integrations: Optional[List[str]],
-            query_warehouse: Optional[str],
-            tags: Optional[List[Tag]],
-            comment: Optional[str]
+        self,
+        service_name: str,
+        compute_pool: str,
+        spec_path: Path,
+        num_instances: int,
+        auto_resume: bool,
+        external_access_integrations: Optional[List[str]],
+        query_warehouse: Optional[str],
+        tags: Optional[List[Tag]],
+        comment: Optional[str],
     ) -> SnowflakeCursor:
         spec = self._read_yaml(spec_path)
 
@@ -32,28 +31,30 @@ class ServiceManager(SqlExecutionMixin):
             MIN_INSTANCES = {num_instances}
             MAX_INSTANCES = {num_instances}
             AUTO_RESUME = {auto_resume}
-            """.split("\n")
+            """.split(
+            "\n"
+        )
 
         if external_access_integrations:
             external_access_integration_list = ",".join(
                 f"{e}" for e in external_access_integrations
             )
-            query.append(f"EXTERNAL_ACCESS_INTEGRATIONS = ({external_access_integration_list})")
+            query.append(
+                f"EXTERNAL_ACCESS_INTEGRATIONS = ({external_access_integration_list})"
+            )
 
         if query_warehouse:
             query.append(f"QUERY_WAREHOUSE = {query_warehouse}")
 
         if tags:
-            tag_list = ",".join(
-                f"{t.name}={t.value_string_literal()}" for t in tags
-            )
+            tag_list = ",".join(f"{t.name}={t.value_string_literal()}" for t in tags)
             query.append(f"TAG ({tag_list})")
 
         if comment:
             query.append(f"COMMENT = {comment}")
 
-        query = "\n".join([q.strip() for q in query if q.strip()])
-        return self._execute_schema_query(query)
+        query_string = "\n".join([q.strip() for q in query if q.strip()])
+        return self._execute_schema_query(query_string)
 
     def _read_yaml(self, path: Path) -> str:
         # TODO(aivanou): Add validation towards schema
@@ -71,7 +72,7 @@ class ServiceManager(SqlExecutionMixin):
         )
 
     def logs(
-            self, service_name: str, instance_id: str, container_name: str, num_lines: int
+        self, service_name: str, instance_id: str, container_name: str, num_lines: int
     ):
         return self._execute_schema_query(
             f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines});"

--- a/src/snowflake/cli/plugins/containers/services/manager.py
+++ b/src/snowflake/cli/plugins/containers/services/manager.py
@@ -31,9 +31,7 @@ class ServiceManager(SqlExecutionMixin):
             MIN_INSTANCES = {num_instances}
             MAX_INSTANCES = {num_instances}
             AUTO_RESUME = {auto_resume}
-            """.split(
-            "\n"
-        )
+            """.splitlines()
 
         if external_access_integrations:
             external_access_integration_list = ",".join(

--- a/src/snowflake/cli/plugins/containers/services/manager.py
+++ b/src/snowflake/cli/plugins/containers/services/manager.py
@@ -1,20 +1,30 @@
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import SnowflakeCursor
 
+from snowflake.cli.api.project.util import to_string_literal
+
+from snowflake.cli.plugins.object.common import Tag
 
 class ServiceManager(SqlExecutionMixin):
+
     def create(
-        self,
-        service_name: str,
-        compute_pool: str,
-        spec_path: Path,
-        num_instances: int,
+            self,
+            service_name: str,
+            compute_pool: str,
+            spec_path: Path,
+            num_instances: int,
+            auto_resume: bool,
+            external_access_integrations: Optional[List[str]],
+            query_warehouse: Optional[str],
+            tags: Optional[List[Tag]],
+            comment: Optional[str]
     ) -> SnowflakeCursor:
         spec = self._read_yaml(spec_path)
-        return self._execute_schema_query(
-            f"""\
+
+        query = f"""\
             CREATE SERVICE IF NOT EXISTS {service_name}
             IN COMPUTE POOL {compute_pool}
             FROM SPECIFICATION $$
@@ -23,8 +33,29 @@ class ServiceManager(SqlExecutionMixin):
             WITH
             MIN_INSTANCES = {num_instances}
             MAX_INSTANCES = {num_instances}
-            """
-        )
+            AUTO_RESUME = {auto_resume}
+            """.split("\n")
+
+        if external_access_integrations:
+            external_access_integration_list = ",".join(
+                f"{e}" for e in external_access_integrations
+            )
+            query.append(f"EXTERNAL_ACCESS_INTEGRATIONS = ({external_access_integration_list})")
+
+        if query_warehouse:
+            query.append(f"QUERY_WAREHOUSE = {query_warehouse}")
+
+        if tags:
+            tag_list = ",".join(
+                f"{t.name}={t.value}" for t in tags
+            )
+            query.append(f"TAG ({tag_list})")
+
+        if comment:
+            query.append(f"COMMENT = {comment}")
+
+        query = "\n".join([q.strip() for q in query if q.strip()])
+        return self._execute_schema_query(query)
 
     def _read_yaml(self, path: Path) -> str:
         # TODO(aivanou): Add validation towards schema
@@ -42,7 +73,7 @@ class ServiceManager(SqlExecutionMixin):
         )
 
     def logs(
-        self, service_name: str, instance_id: str, container_name: str, num_lines: int
+            self, service_name: str, instance_id: str, container_name: str, num_lines: int
     ):
         return self._execute_schema_query(
             f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines});"

--- a/src/snowflake/cli/plugins/containers/services/manager.py
+++ b/src/snowflake/cli/plugins/containers/services/manager.py
@@ -4,8 +4,6 @@ from typing import List, Optional, Tuple
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import SnowflakeCursor
 
-from snowflake.cli.api.project.util import to_string_literal
-
 from snowflake.cli.plugins.object.common import Tag
 
 class ServiceManager(SqlExecutionMixin):
@@ -47,7 +45,7 @@ class ServiceManager(SqlExecutionMixin):
 
         if tags:
             tag_list = ",".join(
-                f"{t.name}={t.value}" for t in tags
+                f"{t.name}={t.value_string_literal()}" for t in tags
             )
             query.append(f"TAG ({tag_list})")
 

--- a/src/snowflake/cli/plugins/object/common.py
+++ b/src/snowflake/cli/plugins/object/common.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from snowflake.cli.api.project.util import QUOTED_IDENTIFIER_REGEX, UNQUOTED_IDENTIFIER_REGEX, to_string_literal, is_valid_identifier, is_valid_string_literal
-
-from click import ClickException
-
 import typer
+from click import ClickException
+from snowflake.cli.api.project.util import (
+    QUOTED_IDENTIFIER_REGEX,
+    UNQUOTED_IDENTIFIER_REGEX,
+    is_valid_identifier,
+    to_string_literal,
+)
 
 
 @dataclass
@@ -23,37 +26,53 @@ class Tag:
 
 def _parse_tag(tag: str) -> Tag:
     import re
-    identifier_pattern = re.compile(f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})")
+
+    identifier_pattern = re.compile(
+        f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})"
+    )
     value_pattern = re.compile(f"(?P<tag_value>.+)")
     match = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
     if match is not None:
         try:
-            return Tag(match.group('tag_name'), match.group('tag_value'))
+            return Tag(match.group("tag_name"), match.group("tag_value"))
         except ValueError:
             raise ClickException(
-                "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string")
+                "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string"
+            )
     else:
         raise ClickException(
-            "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string")
+            "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string"
+        )
+
 
 def tag_option(object_type: str):
     """
     Provides a common interface for all commands that accept a tag option (e.g. when altering the tag of an object).
     Parses the input string in the format "name=value" into a Tag object with 'name' and 'value' properties.
     """
-    return typer.Option(None, "--tag", help=f"Tag for the {object_type}", parser=_parse_tag, metavar="NAME=VALUE")
+    return typer.Option(
+        None,
+        "--tag",
+        help=f"Tag for the {object_type}",
+        parser=_parse_tag,
+        metavar="NAME=VALUE",
+    )
+
 
 def _comment_callback(comment: Optional[str]):
     if comment is None:
         return comment
     return to_string_literal(comment)
 
+
 def comment_option(object_type: str):
     """
     Provides a common interface for all commands that accept a comment option (e.g. when creating a new object).
     Parses the input string into a string literal.
     """
-    return typer.Option(None, "--comment", help=f"Comment for the {object_type}", callback=_comment_callback)
-
-
-
+    return typer.Option(
+        None,
+        "--comment",
+        help=f"Comment for the {object_type}",
+        callback=_comment_callback,
+    )

--- a/src/snowflake/cli/plugins/object/common.py
+++ b/src/snowflake/cli/plugins/object/common.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from snowflake.cli.api.project.util import QUOTED_IDENTIFIER_REGEX, UNQUOTED_IDENTIFIER_REGEX, to_string_literal
+
+from click import ClickException
+
+import typer
+
+
+@dataclass
+class Tag:
+    name: str
+    value: str
+
+
+def _parse_tag(tag: str) -> Tag:
+    import re
+    identifier_pattern = re.compile(f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})")
+    value_pattern = re.compile(f"(?P<tag_value>.+)")
+    match = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
+    if match is not None:
+        return Tag(match.group('tag_name'), to_string_literal(match.group('tag_value')))
+    else:
+        raise ClickException(
+            "tag must be in the format <tag_name>=<tag_value> where tag_name is a valid unquoted identifier and tag_value is a string")
+
+
+def comment_option(object_type: str):
+    """
+    Provides a common interface for all commands that accept a comment option (e.g. when creating a new object).
+    Parses the input string into a string literal.
+    """
+    return typer.Option(None, "--comment", help=f"Comment for the {object_type}", callback=to_string_literal)
+
+
+def tag_option(object_type: str):
+    """
+    Provides a common interface for all commands that accept a tag option (e.g. when altering the tag of an object).
+    Parses the input string in the format "tag_name=tag_value" into a Tag object with 'name' and 'value' properties.
+    """
+    return typer.Option(None, "--tag", help=f"Tag for the {object_type}", parser=_parse_tag)

--- a/src/snowflake/cli/plugins/object/common.py
+++ b/src/snowflake/cli/plugins/object/common.py
@@ -31,10 +31,10 @@ def _parse_tag(tag: str) -> Tag:
         f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})"
     )
     value_pattern = re.compile(f"(?P<tag_value>.+)")
-    match = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
-    if match is not None:
+    result = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
+    if result is not None:
         try:
-            return Tag(match.group("tag_name"), match.group("tag_value"))
+            return Tag(result.group("tag_name"), result.group("tag_value"))
         except ValueError:
             raise ClickException(
                 "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string"

--- a/tests/containers/test_compute_pool.py
+++ b/tests/containers/test_compute_pool.py
@@ -3,56 +3,82 @@ from unittest.mock import Mock, patch
 
 from snowflake.cli.plugins.containers.compute_pool.manager import ComputePoolManager
 from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.cli.api.project.util import to_string_literal
 
 
-class TestComputePoolManager(unittest.TestCase):
-    def setUp(self):
-        self.compute_pool_manager = ComputePoolManager()
-
-    @patch(
-        "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager._execute_query"
+@patch(
+    "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager._execute_query"
+)
+def test_create(mock_execute_query):
+    pool_name = "test_pool"
+    num_instances = 2
+    instance_family = "test_family"
+    auto_resume = True
+    initially_suspended = False
+    auto_suspend_secs = 7200
+    comment = "'test comment'"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ComputePoolManager().create(
+        pool_name, num_instances, instance_family, auto_resume, initially_suspended, auto_suspend_secs, comment
     )
-    def test_create(self, mock_execute_query):
-        pool_name = "test_pool"
-        num_instances = 2
-        instance_family = "test_family"
-        auto_resume = True
-        initially_suspended = False
-        auto_suspend_secs = 7200
-        comment = "'test comment'"
-        cursor = Mock(spec=SnowflakeCursor)
-        mock_execute_query.return_value = cursor
-        result = self.compute_pool_manager.create(
-            pool_name, num_instances, instance_family, auto_resume, initially_suspended, auto_suspend_secs, comment
-        )
-        expected_query = " ".join([
-            "CREATE COMPUTE POOL test_pool",
-            "MIN_NODES = 2",
-            "MAX_NODES = 2",
-            "INSTANCE_FAMILY = test_family",
-            "AUTO_RESUME = True",
-            "INITIALLY_SUSPENDED = False",
-            "AUTO_SUSPEND_SECS = 7200",
-            "COMMENT = 'test comment'"
-        ])
-        actual_query = " ".join(
-            mock_execute_query.mock_calls[0].args[0].split()
-        )
-        self.assertEqual(expected_query, actual_query)
-        self.assertEqual(result, cursor)
-
-    @patch(
-        "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager._execute_query"
+    expected_query = " ".join([
+        "CREATE COMPUTE POOL test_pool",
+        "MIN_NODES = 2",
+        "MAX_NODES = 2",
+        "INSTANCE_FAMILY = test_family",
+        "AUTO_RESUME = True",
+        "INITIALLY_SUSPENDED = False",
+        "AUTO_SUSPEND_SECS = 7200",
+        "COMMENT = 'test comment'"
+    ])
+    actual_query = " ".join(
+        mock_execute_query.mock_calls[0].args[0].split()
     )
-    def test_stop(self, mock_execute_query):
-        pool_name = "test_pool"
-        cursor = Mock(spec=SnowflakeCursor)
-        mock_execute_query.return_value = cursor
-        result = self.compute_pool_manager.stop(pool_name)
-        expected_query = "alter compute pool test_pool stop all;"
-        mock_execute_query.assert_called_once_with(expected_query)
-        self.assertEqual(result, cursor)
+    assert expected_query == actual_query
+    assert result == cursor
+
+@patch(
+    "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager.create"
+)
+def test_create_pool_cli_defaults(mock_create, runner):
+    result = runner.invoke([
+        "containers", "pool", "create",
+        "--name", "test_pool",
+        "--num", "42",
+        "--family", "test_family"
+    ])
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(pool_name = "test_pool", num_instances=42, instance_family="test_family", auto_resume=True, initially_suspended=False, auto_suspend_secs=3600, comment=None)
+
+@patch(
+    "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager.create"
+)
+def test_create_pool_cli(mock_create, runner):
+    result = runner.invoke([
+        "containers", "pool", "create",
+        "--name", "test_pool",
+        "--num", "42",
+        "--family", "test_family",
+        "--no-auto-resume",
+        "--init-suspend",
+        "--auto-suspend-secs", "7200",
+        "--comment", "this is a test"
+    ])
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(pool_name="test_pool", num_instances=42, instance_family="test_family",
+                                        auto_resume=False, initially_suspended=True, auto_suspend_secs=7200,
+                                        comment=to_string_literal("this is a test"))
+@patch(
+    "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager._execute_query"
+)
+def test_stop( mock_execute_query):
+    pool_name = "test_pool"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ComputePoolManager().stop(pool_name)
+    expected_query = "alter compute pool test_pool stop all;"
+    mock_execute_query.assert_called_once_with(expected_query)
+    assert result == cursor
 
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/containers/test_compute_pool.py
+++ b/tests/containers/test_compute_pool.py
@@ -16,19 +16,27 @@ class TestComputePoolManager(unittest.TestCase):
         pool_name = "test_pool"
         num_instances = 2
         instance_family = "test_family"
+        auto_resume = True
+        initially_suspended = False
+        auto_suspend_secs = 7200
+        comment = "'test comment'"
         cursor = Mock(spec=SnowflakeCursor)
         mock_execute_query.return_value = cursor
         result = self.compute_pool_manager.create(
-            pool_name, num_instances, instance_family
+            pool_name, num_instances, instance_family, auto_resume, initially_suspended, auto_suspend_secs, comment
         )
-        expected_query = (
-            "CREATE COMPUTE POOL test_pool "
-            "MIN_NODES = 2 "
-            "MAX_NODES = 2 "
-            "INSTANCE_FAMILY = test_family;"
-        )
+        expected_query = " ".join([
+            "CREATE COMPUTE POOL test_pool",
+            "MIN_NODES = 2",
+            "MAX_NODES = 2",
+            "INSTANCE_FAMILY = test_family",
+            "AUTO_RESUME = True",
+            "INITIALLY_SUSPENDED = False",
+            "AUTO_SUSPEND_SECS = 7200",
+            "COMMENT = 'test comment'"
+        ])
         actual_query = " ".join(
-            mock_execute_query.mock_calls[0].args[0].replace("\n", "").split()
+            mock_execute_query.mock_calls[0].args[0].split()
         )
         self.assertEqual(expected_query, actual_query)
         self.assertEqual(result, cursor)

--- a/tests/containers/test_compute_pool.py
+++ b/tests/containers/test_compute_pool.py
@@ -20,59 +20,99 @@ def test_create(mock_execute_query):
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
     result = ComputePoolManager().create(
-        pool_name, num_instances, instance_family, auto_resume, initially_suspended, auto_suspend_secs, comment
+        pool_name,
+        num_instances,
+        instance_family,
+        auto_resume,
+        initially_suspended,
+        auto_suspend_secs,
+        comment,
     )
-    expected_query = " ".join([
-        "CREATE COMPUTE POOL test_pool",
-        "MIN_NODES = 2",
-        "MAX_NODES = 2",
-        "INSTANCE_FAMILY = test_family",
-        "AUTO_RESUME = True",
-        "INITIALLY_SUSPENDED = False",
-        "AUTO_SUSPEND_SECS = 7200",
-        "COMMENT = 'test comment'"
-    ])
-    actual_query = " ".join(
-        mock_execute_query.mock_calls[0].args[0].split()
+    expected_query = " ".join(
+        [
+            "CREATE COMPUTE POOL test_pool",
+            "MIN_NODES = 2",
+            "MAX_NODES = 2",
+            "INSTANCE_FAMILY = test_family",
+            "AUTO_RESUME = True",
+            "INITIALLY_SUSPENDED = False",
+            "AUTO_SUSPEND_SECS = 7200",
+            "COMMENT = 'test comment'",
+        ]
     )
+    actual_query = " ".join(mock_execute_query.mock_calls[0].args[0].split())
     assert expected_query == actual_query
     assert result == cursor
+
 
 @patch(
     "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager.create"
 )
 def test_create_pool_cli_defaults(mock_create, runner):
-    result = runner.invoke([
-        "containers", "pool", "create",
-        "--name", "test_pool",
-        "--num", "42",
-        "--family", "test_family"
-    ])
+    result = runner.invoke(
+        [
+            "containers",
+            "pool",
+            "create",
+            "--name",
+            "test_pool",
+            "--num",
+            "42",
+            "--family",
+            "test_family",
+        ]
+    )
     assert result.exit_code == 0, result.output
-    mock_create.assert_called_once_with(pool_name = "test_pool", num_instances=42, instance_family="test_family", auto_resume=True, initially_suspended=False, auto_suspend_secs=3600, comment=None)
+    mock_create.assert_called_once_with(
+        pool_name="test_pool",
+        num_instances=42,
+        instance_family="test_family",
+        auto_resume=True,
+        initially_suspended=False,
+        auto_suspend_secs=3600,
+        comment=None,
+    )
+
 
 @patch(
     "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager.create"
 )
 def test_create_pool_cli(mock_create, runner):
-    result = runner.invoke([
-        "containers", "pool", "create",
-        "--name", "test_pool",
-        "--num", "42",
-        "--family", "test_family",
-        "--no-auto-resume",
-        "--init-suspend",
-        "--auto-suspend-secs", "7200",
-        "--comment", "this is a test"
-    ])
+    result = runner.invoke(
+        [
+            "containers",
+            "pool",
+            "create",
+            "--name",
+            "test_pool",
+            "--num",
+            "42",
+            "--family",
+            "test_family",
+            "--no-auto-resume",
+            "--init-suspend",
+            "--auto-suspend-secs",
+            "7200",
+            "--comment",
+            "this is a test",
+        ]
+    )
     assert result.exit_code == 0, result.output
-    mock_create.assert_called_once_with(pool_name="test_pool", num_instances=42, instance_family="test_family",
-                                        auto_resume=False, initially_suspended=True, auto_suspend_secs=7200,
-                                        comment=to_string_literal("this is a test"))
+    mock_create.assert_called_once_with(
+        pool_name="test_pool",
+        num_instances=42,
+        instance_family="test_family",
+        auto_resume=False,
+        initially_suspended=True,
+        auto_suspend_secs=7200,
+        comment=to_string_literal("this is a test"),
+    )
+
+
 @patch(
     "snowflake.cli.plugins.containers.compute_pool.manager.ComputePoolManager._execute_query"
 )
-def test_stop( mock_execute_query):
+def test_stop(mock_execute_query):
     pool_name = "test_pool"
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
@@ -80,5 +120,3 @@ def test_stop( mock_execute_query):
     expected_query = "alter compute pool test_pool stop all;"
     mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
-
-

--- a/tests/containers/test_services.py
+++ b/tests/containers/test_services.py
@@ -8,7 +8,8 @@ import strictyaml
 from snowflake.cli.plugins.containers.services.manager import ServiceManager
 from snowflake.cli.plugins.object.common import Tag
 from tests.testing_utils.fixtures import *
-
+from snowflake.cli.api.project.util import to_string_literal
+from snowflake.cli.plugins.object.common import Tag
 
 @patch(
     "snowflake.cli.plugins.containers.services.manager.ServiceManager._execute_schema_query"
@@ -37,7 +38,7 @@ def test_create_service(mock_execute_schema_query, other_directory):
     auto_resume = True
     external_access_integrations = ["google_apis_access_integration", "salesforce_api_access_integration"]
     query_warehouse = "test_warehouse"
-    tags = [Tag("test_tag", "'test value'"), Tag("key", "'value'")]
+    tags = [Tag("test_tag", "test value"), Tag("key", "value")]
     comment = "'user\\'s comment'"
 
     cursor = Mock(spec=SnowflakeCursor)
@@ -66,6 +67,69 @@ def test_create_service(mock_execute_schema_query, other_directory):
     assert expected_query == actual_query
     assert result == cursor
 
+@patch(
+    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
+)
+def test_create_service_cli_defaults(mock_create, other_directory, runner):
+    tmp_dir = Path(other_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            """
+    spec:
+        containers:
+        - name: cloudbeaver
+          image: /spcs_demos_db/cloudbeaver:23.2.1
+        endpoints:
+        - name: cloudbeaver
+          port: 80
+          public: true
+
+    """
+        )
+    )
+    result = runner.invoke(["containers", "service", "create", "--name", "test_service", "--compute-pool", "test_pool", "--spec-path", f"{spec_path}"])
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path, num_instances=1, auto_resume=True, external_access_integrations=[], query_warehouse=None, tags=[], comment=None)
+@patch(
+    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
+)
+def test_create_service_cli(mock_create, other_directory, runner):
+    tmp_dir = Path(other_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            """
+    spec:
+        containers:
+        - name: cloudbeaver
+          image: /spcs_demos_db/cloudbeaver:23.2.1
+        endpoints:
+        - name: cloudbeaver
+          port: 80
+          public: true
+
+    """
+        )
+    )
+    result = runner.invoke(
+        ["containers", "service", "create",
+         "--name", "test_service",
+         "--compute-pool", "test_pool",
+         "--spec-path", f"{spec_path}",
+         "--num-instances", "42",
+         "--no-auto-resume",
+         "--eai-name", "google_api", "--eai-name", "salesforce_api",
+         "--query-warehouse", "test_warehouse",
+         "--tag", "name=value", "--tag", "\"$trange name\"=normal value",
+         "--comment", "this is a test"
+    ])
+    assert result.exit_code == 0, result.output
+    print(mock_create.mock_calls[0])
+    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path,
+                                        num_instances=42, auto_resume=False, external_access_integrations=["google_api", "salesforce_api"],
+                                        query_warehouse="test_warehouse", tags=[Tag("name", "value"), Tag("\"$trange name\"", "normal value")], comment=to_string_literal("this is a test"))
+
 
 @patch("snowflake.cli.plugins.containers.services.manager.ServiceManager._read_yaml")
 def test_create_service_with_invalid_spec(mock_read_yaml):
@@ -82,29 +146,6 @@ def test_create_service_with_invalid_spec(mock_read_yaml):
             service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
             query_warehouse, tags, comment
         )
-
-
-@patch("snowflake.cli.plugins.object.common._parse_tag")
-@patch("snowflake.cli.plugins.containers.services.manager.ServiceManager._read_yaml")
-def test_create_service_with_invalid_tag(mock_parse_tag, mock_read_yaml):
-    service_name = "test_service"
-    compute_pool = "test_pool"
-    spec_path = "/path/to/spec.yaml"
-    num_instances = 42
-    tags = [Tag("test name", "test_value")]
-    external_access_integrations = query_warehouse = comment = None
-    auto_resume = False
-    mock_parse_tag.side_effect = ClickException("Invalid Tag")
-    with pytest.raises(ClickException):
-        ServiceManager().create(
-            service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
-            query_warehouse, tags, comment
-        )
-
-
-
-
-
 @patch(
     "snowflake.cli.plugins.containers.services.manager.ServiceManager._execute_schema_query"
 )

--- a/tests/containers/test_services.py
+++ b/tests/containers/test_services.py
@@ -11,6 +11,7 @@ from tests.testing_utils.fixtures import *
 from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.plugins.object.common import Tag
 
+
 @patch(
     "snowflake.cli.plugins.containers.services.manager.ServiceManager._execute_schema_query"
 )
@@ -36,7 +37,10 @@ def test_create_service(mock_execute_schema_query, other_directory):
         )
     )
     auto_resume = True
-    external_access_integrations = ["google_apis_access_integration", "salesforce_api_access_integration"]
+    external_access_integrations = [
+        "google_apis_access_integration",
+        "salesforce_api_access_integration",
+    ]
     query_warehouse = "test_warehouse"
     tags = [Tag("test_tag", "test value"), Tag("key", "value")]
     comment = "'user\\'s comment'"
@@ -45,31 +49,37 @@ def test_create_service(mock_execute_schema_query, other_directory):
     mock_execute_schema_query.return_value = cursor
 
     result = ServiceManager().create(
-        service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
-        query_warehouse, tags, comment
+        service_name,
+        compute_pool,
+        Path(spec_path),
+        num_instances,
+        auto_resume,
+        external_access_integrations,
+        query_warehouse,
+        tags,
+        comment,
     )
-    expected_query = " ".join([
-        "CREATE SERVICE IF NOT EXISTS test_service",
-        "IN COMPUTE POOL test_pool",
-        'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
-        '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',
-        '"port": 80, "public": true}]}} $$',
-        "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42",
-        "AUTO_RESUME = True",
-        "EXTERNAL_ACCESS_INTEGRATIONS = (google_apis_access_integration,salesforce_api_access_integration)",
-        "QUERY_WAREHOUSE = test_warehouse",
-        "TAG (test_tag='test value',key='value')",
-        "COMMENT = 'user\\'s comment'",
-    ])
-    actual_query = " ".join(
-        mock_execute_schema_query.mock_calls[0].args[0].split()
+    expected_query = " ".join(
+        [
+            "CREATE SERVICE IF NOT EXISTS test_service",
+            "IN COMPUTE POOL test_pool",
+            'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
+            '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',
+            '"port": 80, "public": true}]}} $$',
+            "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42",
+            "AUTO_RESUME = True",
+            "EXTERNAL_ACCESS_INTEGRATIONS = (google_apis_access_integration,salesforce_api_access_integration)",
+            "QUERY_WAREHOUSE = test_warehouse",
+            "TAG (test_tag='test value',key='value')",
+            "COMMENT = 'user\\'s comment'",
+        ]
     )
+    actual_query = " ".join(mock_execute_schema_query.mock_calls[0].args[0].split())
     assert expected_query == actual_query
     assert result == cursor
 
-@patch(
-    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
-)
+
+@patch("snowflake.cli.plugins.containers.services.manager.ServiceManager.create")
 def test_create_service_cli_defaults(mock_create, other_directory, runner):
     tmp_dir = Path(other_directory)
     spec_path = tmp_dir / "spec.yml"
@@ -88,12 +98,34 @@ def test_create_service_cli_defaults(mock_create, other_directory, runner):
     """
         )
     )
-    result = runner.invoke(["containers", "service", "create", "--name", "test_service", "--compute-pool", "test_pool", "--spec-path", f"{spec_path}"])
+    result = runner.invoke(
+        [
+            "containers",
+            "service",
+            "create",
+            "--name",
+            "test_service",
+            "--compute-pool",
+            "test_pool",
+            "--spec-path",
+            f"{spec_path}",
+        ]
+    )
     assert result.exit_code == 0, result.output
-    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path, num_instances=1, auto_resume=True, external_access_integrations=[], query_warehouse=None, tags=[], comment=None)
-@patch(
-    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
-)
+    mock_create.assert_called_once_with(
+        service_name="test_service",
+        compute_pool="test_pool",
+        spec_path=spec_path,
+        num_instances=1,
+        auto_resume=True,
+        external_access_integrations=[],
+        query_warehouse=None,
+        tags=[],
+        comment=None,
+    )
+
+
+@patch("snowflake.cli.plugins.containers.services.manager.ServiceManager.create")
 def test_create_service_cli(mock_create, other_directory, runner):
     tmp_dir = Path(other_directory)
     spec_path = tmp_dir / "spec.yml"
@@ -113,22 +145,46 @@ def test_create_service_cli(mock_create, other_directory, runner):
         )
     )
     result = runner.invoke(
-        ["containers", "service", "create",
-         "--name", "test_service",
-         "--compute-pool", "test_pool",
-         "--spec-path", f"{spec_path}",
-         "--num-instances", "42",
-         "--no-auto-resume",
-         "--eai-name", "google_api", "--eai-name", "salesforce_api",
-         "--query-warehouse", "test_warehouse",
-         "--tag", "name=value", "--tag", "\"$trange name\"=normal value",
-         "--comment", "this is a test"
-    ])
+        [
+            "containers",
+            "service",
+            "create",
+            "--name",
+            "test_service",
+            "--compute-pool",
+            "test_pool",
+            "--spec-path",
+            f"{spec_path}",
+            "--num-instances",
+            "42",
+            "--no-auto-resume",
+            "--eai-name",
+            "google_api",
+            "--eai-name",
+            "salesforce_api",
+            "--query-warehouse",
+            "test_warehouse",
+            "--tag",
+            "name=value",
+            "--tag",
+            '"$trange name"=normal value',
+            "--comment",
+            "this is a test",
+        ]
+    )
     assert result.exit_code == 0, result.output
     print(mock_create.mock_calls[0])
-    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path,
-                                        num_instances=42, auto_resume=False, external_access_integrations=["google_api", "salesforce_api"],
-                                        query_warehouse="test_warehouse", tags=[Tag("name", "value"), Tag("\"$trange name\"", "normal value")], comment=to_string_literal("this is a test"))
+    mock_create.assert_called_once_with(
+        service_name="test_service",
+        compute_pool="test_pool",
+        spec_path=spec_path,
+        num_instances=42,
+        auto_resume=False,
+        external_access_integrations=["google_api", "salesforce_api"],
+        query_warehouse="test_warehouse",
+        tags=[Tag("name", "value"), Tag('"$trange name"', "normal value")],
+        comment=to_string_literal("this is a test"),
+    )
 
 
 @patch("snowflake.cli.plugins.containers.services.manager.ServiceManager._read_yaml")
@@ -143,9 +199,18 @@ def test_create_service_with_invalid_spec(mock_read_yaml):
 
     with pytest.raises(strictyaml.YAMLError):
         ServiceManager().create(
-            service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
-            query_warehouse, tags, comment
+            service_name,
+            compute_pool,
+            Path(spec_path),
+            num_instances,
+            auto_resume,
+            external_access_integrations,
+            query_warehouse,
+            tags,
+            comment,
         )
+
+
 @patch(
     "snowflake.cli.plugins.containers.services.manager.ServiceManager._execute_schema_query"
 )

--- a/tests/object/test_common.py
+++ b/tests/object/test_common.py
@@ -12,7 +12,7 @@ INVALID_TAGS = (
     "tag",  # no equals sign
     "=value",  # empty identifier
     "a" * 257 + "=value",  # identifier is over 256 characters
-    '"tag"name"=value'  # undoubled quote in tag name
+    '"tag"name"=value',  # undoubled quote in tag name
 )
 VALID_TAGS = (
     ("tag=value", ("tag", "value")),
@@ -22,8 +22,14 @@ VALID_TAGS = (
     ("mixedCase=value", ("mixedCase", "value")),
     ("_=value", ("_", "value")),
     ("tag='this is a value'", ("tag", "'this is a value'")),
-    ("\"tag name!@#\"=value", ("\"tag name!@#\"", "value")),  # quoted identifier allows for spaces and special characters
-    ("tag==value", ("tag", "=value"))  # This is a strange case which we may not actually want to support
+    (
+        '"tag name!@#"=value',
+        ('"tag name!@#"', "value"),
+    ),  # quoted identifier allows for spaces and special characters
+    (
+        "tag==value",
+        ("tag", "=value"),
+    ),  # This is a strange case which we may not actually want to support
 )
 
 

--- a/tests/object/test_common.py
+++ b/tests/object/test_common.py
@@ -1,0 +1,35 @@
+from snowflake.cli.plugins.object.common import _parse_tag, Tag
+
+import pytest
+
+from click import ClickException
+
+
+INVALID_TAGS = (
+    "123_name=value",  # starts with a digit
+    "tag name=value",  # space in identifier
+    "tag&_name=value",  # special characters in identifier
+    "tag",  # no equals sign
+    "=value",  # empty identifier
+    "a" * 257 + "=value",  # identifier is over 256 characters
+    '"tag"name"=value'  # undoubled quote in tag name
+)
+VALID_TAGS = (
+    ("tag=value", ("tag", "value")),
+    ("_underscore_start=value", ("_underscore_start", "value")),
+    ("a=xyz", ("a", "xyz")),
+    ("A=123", ("A", "123")),
+    ("mixedCase=value", ("mixedCase", "value")),
+    ("_=value", ("_", "value")),
+    ("tag='this is a value'", ("tag", "'this is a value'")),
+    ("\"tag name!@#\"=value", ("\"tag name!@#\"", "value")),  # quoted identifier allows for spaces and special characters
+    ("tag==value", ("tag", "=value"))  # This is a strange case which we may not actually want to support
+)
+
+
+def test_parse_tag():
+    for tag in INVALID_TAGS:
+        with pytest.raises(ClickException):
+            _parse_tag(tag)
+    for tag in VALID_TAGS:
+        assert Tag(*tag[1]) == _parse_tag(tag[0])

--- a/tests/object/test_common.py
+++ b/tests/object/test_common.py
@@ -1,41 +1,46 @@
 from snowflake.cli.plugins.object.common import _parse_tag, Tag
-
+from typing import Tuple
 import pytest
 
 from click import ClickException
 
 
-INVALID_TAGS = (
-    "123_name=value",  # starts with a digit
-    "tag name=value",  # space in identifier
-    "tag&_name=value",  # special characters in identifier
-    "tag",  # no equals sign
-    "=value",  # empty identifier
-    "a" * 257 + "=value",  # identifier is over 256 characters
-    '"tag"name"=value',  # undoubled quote in tag name
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("tag=value", ("tag", "value")),
+        ("_underscore_start=value", ("_underscore_start", "value")),
+        ("a=xyz", ("a", "xyz")),
+        ("A=123", ("A", "123")),
+        ("mixedCase=value", ("mixedCase", "value")),
+        ("_=value", ("_", "value")),
+        ("tag='this is a value'", ("tag", "'this is a value'")),
+        (
+            '"tag name!@#"=value',
+            ('"tag name!@#"', "value"),
+        ),  # quoted identifier allows for spaces and special characters
+        (
+            "tag==value",
+            ("tag", "=value"),
+        ),  # This is a strange case which we may not actually want to support
+    ],
 )
-VALID_TAGS = (
-    ("tag=value", ("tag", "value")),
-    ("_underscore_start=value", ("_underscore_start", "value")),
-    ("a=xyz", ("a", "xyz")),
-    ("A=123", ("A", "123")),
-    ("mixedCase=value", ("mixedCase", "value")),
-    ("_=value", ("_", "value")),
-    ("tag='this is a value'", ("tag", "'this is a value'")),
-    (
-        '"tag name!@#"=value',
-        ('"tag name!@#"', "value"),
-    ),  # quoted identifier allows for spaces and special characters
-    (
-        "tag==value",
-        ("tag", "=value"),
-    ),  # This is a strange case which we may not actually want to support
-)
+def test_parse_tag_valid(value: str, expected: Tuple[str, str]):
+    assert _parse_tag(value) == Tag(*expected)
 
 
-def test_parse_tag():
-    for tag in INVALID_TAGS:
-        with pytest.raises(ClickException):
-            _parse_tag(tag)
-    for tag in VALID_TAGS:
-        assert Tag(*tag[1]) == _parse_tag(tag[0])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "123_name=value",  # starts with a digit
+        "tag name=value",  # space in identifier
+        "tag&_name=value",  # special characters in identifier
+        "tag",  # no equals sign
+        "=value",  # empty identifier
+        "a" * 257 + "=value",  # identifier is over 256 characters
+        '"tag"name"=value',  # undoubled quote in tag name
+    ],
+)
+def test_parse_tag_invalid(value: str):
+    with pytest.raises(ClickException):
+        _parse_tag(value)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code. (additional options should not impact integration tests as far as I can see)
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
- Added additional CLI options to `snow containers service create` and `snow containers pool create` to match SQL interface. 
- Updated unit tests for ServiceManager.create() and ComputePoolManager.create() and CLI interface of `snow containers service create` and `snow containers pool create`. 
- Added generic CLI options for Comment and Tag options under object/common.py. These can be used for all other CLI commands that take Tag or Comment (e.g. other create commands, alter tag, alter comment, etc.).
- Minor unrelated typo fixes.

New Service Options:
<img width="1578" alt="image" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/a0d935b4-875f-48e7-9e67-aa1e2a0d5e08">

New Compute Pool Options:
<img width="1450" alt="image" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/bf6f5820-7636-43ba-92b6-eaa06b955d60">


