### PR TITLE
Skip 'checkout' step if checkout has already been added

### DIFF
--- a/src/snowflake/cli/plugins/streamlit/manager.py
+++ b/src/snowflake/cli/plugins/streamlit/manager.py
@@ -116,7 +116,8 @@ class StreamlitManager(SqlExecutionMixin):
             try:
                 self._execute_query(f"ALTER streamlit {streamlit_name} CHECKOUT")
             except ProgrammingError as e:
-                # Handle case that CHECKOUT has already been created
+                # If an error is raised because a CHECKOUT has already occured,
+                # simply skip it and continue
                 if "Checkout already exists" not in str(e):
                     raise
                 log.info("Checkout already exists, continuing")

--- a/src/snowflake/cli/plugins/streamlit/manager.py
+++ b/src/snowflake/cli/plugins/streamlit/manager.py
@@ -118,9 +118,10 @@ class StreamlitManager(SqlExecutionMixin):
             except ProgrammingError as e:
                 # If an error is raised because a CHECKOUT has already occured,
                 # simply skip it and continue
-                if "Checkout already exists" not in str(e):
+                if "Checkout already exists" in str(e):
+                    log.info("Checkout already exists, continuing")
+                else:
                     raise
-                log.info("Checkout already exists, continuing")
             stage_path = stage_manager.to_fully_qualified_name(streamlit_name)
             embedded_stage_name = f"snow://streamlit/{stage_path}"
             root_location = f"{embedded_stage_name}/default_checkout"

--- a/tests/streamlit/test_commands.py
+++ b/tests/streamlit/test_commands.py
@@ -463,6 +463,71 @@ def test_deploy_streamlit_main_and_pages_files_experimental(
 
 
 @mock.patch("snowflake.connector.connect")
+def test_deploy_streamlit_main_and_pages_files_experimental_double_deploy(
+    mock_connector,
+    mock_cursor,
+    runner,
+    mock_ctx,
+    project_directory,
+):
+    ctx = mock_ctx(
+        mock_cursor(
+            rows=[
+                {"SYSTEM$GET_SNOWSIGHT_HOST()": "https://snowsight.domain"},
+                {"REGIONLESS": "false"},
+                {"CURRENT_ACCOUNT_NAME()": "https://snowsight.domain"},
+            ],
+            columns=["SYSTEM$GET_SNOWSIGHT_HOST()"],
+        )
+    )
+    mock_connector.return_value = ctx
+
+    with project_directory("example_streamlit"):
+        result1 = runner.invoke(["streamlit", "deploy", "--experimental"])
+
+    assert result1.exit_code == 0, result1.output
+
+    # Reset to a fresh cursor, and clear the list of queries,
+    # keeping the same connection context
+    ctx.cs = mock_cursor(
+        rows=[
+            {"SYSTEM$GET_SNOWSIGHT_HOST()": "https://snowsight.domain"},
+            {"REGIONLESS": "false"},
+            {"CURRENT_ACCOUNT_NAME()": "https://snowsight.domain"},
+        ],
+        columns=["SYSTEM$GET_SNOWSIGHT_HOST()"],
+    )
+    ctx.queries = []
+
+    with project_directory("example_streamlit"):
+        result2 = runner.invoke(["streamlit", "deploy", "--experimental"])
+
+    assert result2.exit_code == 0, result2.output
+
+    root_path = (
+        f"snow://streamlit/MOCKDATABASE.MOCKSCHEMA.{STREAMLIT_NAME.upper()}/"
+        "default_checkout"
+    )
+
+    # Same as normal, except no CHECKOUT query
+    assert ctx.get_queries() == [
+        dedent(
+            f"""
+            CREATE STREAMLIT IF NOT EXISTS {STREAMLIT_NAME}
+            MAIN_FILE = 'streamlit_app.py'
+            QUERY_WAREHOUSE = test_warehouse
+            """
+        ).strip(),
+        _put_query("streamlit_app.py", root_path),
+        _put_query("environment.yml", f"{root_path}"),
+        _put_query("pages/*.py", f"{root_path}/pages"),
+        f"select system$get_snowsight_host()",
+        REGIONLESS_QUERY,
+        f"select current_account_name()",
+    ]
+
+
+@mock.patch("snowflake.connector.connect")
 def test_deploy_streamlit_main_and_pages_files_experimental_no_stage(
     mock_connector, mock_cursor, runner, mock_ctx, project_directory
 ):

--- a/tests_integration/test_streamlit.py
+++ b/tests_integration/test_streamlit.py
@@ -76,6 +76,82 @@ def test_streamlit_deploy(
 
 
 @pytest.mark.integration
+@pytest.mark.skip(
+    reason="only works in accounts with experimental checkout behavior enabled"
+)
+def test_streamlit_deploy_experimental_twice(
+    runner,
+    snowflake_session,
+    test_database,
+    _new_streamlit_role,
+    project_directory,
+):
+    streamlit_name = "test_streamlit_deploy_snowcli"
+
+    with project_directory("streamlit"):
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "deploy", "--experimental"]
+        )
+        assert result.exit_code == 0
+
+        # Test that second deploy does not fail
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "deploy", "--experimental"]
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke_with_connection_json(["object", "list", "streamlit"])
+        assert_that_result_is_successful(result)
+
+        expect = snowflake_session.execute_string(
+            f"show streamlits like '{streamlit_name}'"
+        )
+        assert contains_row_with(result.json, row_from_snowflake_session(expect)[0])
+
+        result = runner.invoke_with_connection_json(
+            ["object", "describe", "streamlit", streamlit_name]
+        )
+        expect = snowflake_session.execute_string(
+            f"describe streamlit {streamlit_name}"
+        )
+        assert contains_row_with(result.json[0], row_from_snowflake_session(expect)[0])
+
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "get-url", streamlit_name]
+        )
+
+        assert result.json["message"].endswith(
+            f"/#/streamlit-apps/{test_database.upper()}.PUBLIC.{streamlit_name.upper()}"
+        )
+
+        result = runner.invoke_with_connection_json(
+            ["streamlit", "share", streamlit_name, _new_streamlit_role]
+        )
+        assert contains_row_with(
+            result.json,
+            {"status": "Statement executed successfully."},
+        )
+        expect = snowflake_session.execute_string(
+            f"use role {_new_streamlit_role}; show streamlits like '{streamlit_name}'; use role integration_tests;"
+        )
+        assert contains_row_with(
+            rows_from_snowflake_session(expect)[1], {"name": streamlit_name.upper()}
+        )
+
+    result = runner.invoke_with_connection_json(
+        ["object", "drop", "streamlit", streamlit_name]
+    )
+    assert contains_row_with(
+        result.json,
+        {"status": f"{streamlit_name.upper()} successfully dropped."},
+    )
+    expect = snowflake_session.execute_string(
+        f"show streamlits like '{streamlit_name}'"
+    )
+    assert row_from_snowflake_session(expect) == []
+
+
+@pytest.mark.integration
 def test_streamlit_is_visible_in_anaconda_channel():
     from requirements.requirement import Requirement
     from snowflake.cli.plugins.snowpark.package_utils import parse_anaconda_packages


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

Currently, if you do `snow streamlit deploy --experimental` it works fine, but if you do it a second time, it fails, because the ALTER STREAMLIT <name> CHECKOUT has already been done once. This is analogous to the normal `snow streamlit deploy`, which creates a STAGE the first time you do it, and then simply skips it in the future without raising an error.

There is an open [ticket](https://snowflakecomputing.atlassian.net/browse/STREAMLIT-5019) to make this behavior different, but it may be a while.