### PR TITLE
SNOW-1011737, SNOW-1011750: Add options to create commands for compute pool and service

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 * Switched to Python Connector default connection https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
   * Default connection name changed from `dev` to `default`
   * Environment variable for default connection name changed from `SNOWFLAKE_OPTIONS_DEFAULT_CONNECTION` to `SNOWFLAKE_DEFAULT_CONNECTION_NAME`
+* `snow spcs pool create` and `snow spcs service create` have been updated with all options available through SQL interface.
 
 * Snowpark changes
   * Removed `procedure` and `function` subgroups.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,7 +11,8 @@
 * Switched to Python Connector default connection https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
   * Default connection name changed from `dev` to `default`
   * Environment variable for default connection name changed from `SNOWFLAKE_OPTIONS_DEFAULT_CONNECTION` to `SNOWFLAKE_DEFAULT_CONNECTION_NAME`
-* `snow spcs pool create` and `snow spcs service create` have been updated with all options available through SQL interface.
+* `--num` option for `snow spcs pool create` has been split into `--min-nodes` and `--max-nodes`
+* `--num-instances` option for `snow spcs service create` has been split into `--min-instances` and `--max-instances`
 
 * Snowpark changes
   * Removed `procedure` and `function` subgroups.
@@ -29,6 +30,7 @@
   * `jobs` commands were renamed to `job`.
   * `services` commands were renamed to `service`
   * `pool`, `job`, `service`, and `registry` commands were moved from `snowpark` group to a new `spcs` group (`registry` was renamed to `image-registry`).
+  * `snow spcs pool create` and `snow spcs service create` have been updated with all options available through SQL interface.
 
 * Streamlit changes
   * `snow streamlit deploy` is requiring `snowflake.yml` project file with a Streamlit definition.

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -42,7 +42,7 @@ class OutputDataTypeError(ClickException):
 
 class CommandReturnTypeError(ClickException):
     def __init__(self, got_type: type):
-        super().__init__(f"Commads have to return OutputData type, but got {got_type}")
+        super().__init__(f"Commands have to return OutputData type, but got {got_type}")
 
 
 class SnowflakeSQLExecutionError(ClickException):

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -13,7 +13,7 @@ SINGLE_QUOTED_STRING_LITERAL_REGEX = r"'((?:\\.|''|[^'\n])+?)'"
 
 # See https://docs.snowflake.com/en/sql-reference/identifiers-syntax for identifier syntax
 UNQUOTED_IDENTIFIER_REGEX = r"(^[a-zA-Z_])([a-zA-Z0-9_$]{0,254})"
-QUOTED_IDENTIFIER_REGEX = r'"((""|[^"])*)"'
+QUOTED_IDENTIFIER_REGEX = r'"((""|[^"]){0,255})"'
 
 
 def clean_identifier(input_: str):

--- a/src/snowflake/cli/plugins/object/common.py
+++ b/src/snowflake/cli/plugins/object/common.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from snowflake.cli.api.project.util import QUOTED_IDENTIFIER_REGEX, UNQUOTED_IDENTIFIER_REGEX, to_string_literal, is_valid_identifier, is_valid_string_literal
+
+from click import ClickException
+
+import typer
+
+
+@dataclass
+class Tag:
+    name: str
+    value: str
+
+    def __post_init__(self):
+        if not is_valid_identifier(self.name):
+            raise ValueError("name of a tag must be a valid snowflake identifier")
+
+    def value_string_literal(self):
+        return to_string_literal(self.value)
+
+
+def _parse_tag(tag: str) -> Tag:
+    import re
+    identifier_pattern = re.compile(f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})")
+    value_pattern = re.compile(f"(?P<tag_value>.+)")
+    match = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
+    if match is not None:
+        try:
+            return Tag(match.group('tag_name'), match.group('tag_value'))
+        except ValueError:
+            raise ClickException(
+                "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string")
+    else:
+        raise ClickException(
+            "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string")
+
+def tag_option(object_type: str):
+    """
+    Provides a common interface for all commands that accept a tag option (e.g. when altering the tag of an object).
+    Parses the input string in the format "name=value" into a Tag object with 'name' and 'value' properties.
+    """
+    return typer.Option(None, "--tag", help=f"Tag for the {object_type}", parser=_parse_tag, metavar="NAME=VALUE")
+
+def _comment_callback(comment: Optional[str]):
+    if comment is None:
+        return comment
+    return to_string_literal(comment)
+
+def comment_option(object_type: str):
+    """
+    Provides a common interface for all commands that accept a comment option (e.g. when creating a new object).
+    Parses the input string into a string literal.
+    """
+    return typer.Option(None, "--comment", help=f"Comment for the {object_type}", callback=_comment_callback)
+
+
+

--- a/src/snowflake/cli/plugins/object/common.py
+++ b/src/snowflake/cli/plugins/object/common.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from snowflake.cli.api.project.util import QUOTED_IDENTIFIER_REGEX, UNQUOTED_IDENTIFIER_REGEX, to_string_literal, is_valid_identifier, is_valid_string_literal
-
-from click import ClickException
-
 import typer
+from click import ClickException
+from snowflake.cli.api.project.util import (
+    QUOTED_IDENTIFIER_REGEX,
+    UNQUOTED_IDENTIFIER_REGEX,
+    is_valid_identifier,
+    to_string_literal,
+)
 
 
 @dataclass
@@ -21,39 +24,58 @@ class Tag:
         return to_string_literal(self.value)
 
 
+class TagError(ClickException):
+    def __init__(self):
+        super().__init__(
+            "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string"
+        )
+
+
 def _parse_tag(tag: str) -> Tag:
     import re
-    identifier_pattern = re.compile(f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})")
+
+    identifier_pattern = re.compile(
+        f"(?P<tag_name>{UNQUOTED_IDENTIFIER_REGEX}|{QUOTED_IDENTIFIER_REGEX})"
+    )
     value_pattern = re.compile(f"(?P<tag_value>.+)")
-    match = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
-    if match is not None:
+    result = re.fullmatch(f"{identifier_pattern.pattern}={value_pattern.pattern}", tag)
+    if result is not None:
         try:
-            return Tag(match.group('tag_name'), match.group('tag_value'))
+            return Tag(result.group("tag_name"), result.group("tag_value"))
         except ValueError:
-            raise ClickException(
-                "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string")
+            raise TagError()
     else:
-        raise ClickException(
-            "tag must be in the format <name>=<value> where 'name' is a valid identifier and value is a string")
+        raise TagError()
+
 
 def tag_option(object_type: str):
     """
     Provides a common interface for all commands that accept a tag option (e.g. when altering the tag of an object).
     Parses the input string in the format "name=value" into a Tag object with 'name' and 'value' properties.
     """
-    return typer.Option(None, "--tag", help=f"Tag for the {object_type}", parser=_parse_tag, metavar="NAME=VALUE")
+    return typer.Option(
+        None,
+        "--tag",
+        help=f"Tag for the {object_type}",
+        parser=_parse_tag,
+        metavar="NAME=VALUE",
+    )
+
 
 def _comment_callback(comment: Optional[str]):
     if comment is None:
         return comment
     return to_string_literal(comment)
 
+
 def comment_option(object_type: str):
     """
     Provides a common interface for all commands that accept a comment option (e.g. when creating a new object).
     Parses the input string into a string literal.
     """
-    return typer.Option(None, "--comment", help=f"Comment for the {object_type}", callback=_comment_callback)
-
-
-
+    return typer.Option(
+        None,
+        "--comment",
+        help=f"Comment for the {object_type}",
+        callback=_comment_callback,
+    )

--- a/src/snowflake/cli/plugins/spcs/common.py
+++ b/src/snowflake/cli/plugins/spcs/common.py
@@ -35,3 +35,7 @@ def print_log_lines(file: TextIO, name, identifier, logs):
     logs = logs[0:-1]
     for log in logs:
         print(_prefix_line(prefix, log + "\n"), file=file, end="", flush=True)
+
+
+def strip_empty_lines(lines: list[str]) -> str:
+    return "\n".join(stripped for l in lines if (stripped := l.strip()))

--- a/src/snowflake/cli/plugins/spcs/common.py
+++ b/src/snowflake/cli/plugins/spcs/common.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from typing import TextIO
 
+from click import ClickException
+
 if not sys.stdout.closed and sys.stdout.isatty():
     GREEN = "\033[32m"
     BLUE = "\033[34m"
@@ -39,3 +41,21 @@ def print_log_lines(file: TextIO, name, identifier, logs):
 
 def strip_empty_lines(lines: list[str]) -> str:
     return "\n".join(stripped for l in lines if (stripped := l.strip()))
+
+
+def validate_and_set_instances(min_instances, max_instances, instance_name):
+    """
+    Used to validate that min_instances is positive and that max_instances is not less than min_instances. In the
+    case that max_instances is none, sets it equal to min_instances by default. Used like `max_instances =
+    validate_and_set_instances(min_instances, max_instances, "name")`.
+    """
+    if min_instances < 1:
+        raise ClickException(f"min_{instance_name} must be positive")
+
+    if max_instances is None:
+        max_instances = min_instances
+    elif max_instances < min_instances:
+        raise ClickException(
+            f"max_{instance_name} must be greater or equal to min_{instance_name}"
+        )
+    return max_instances

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import typer
 from snowflake.cli.api.commands.decorators import (
     global_options_with_connection,
@@ -6,6 +8,7 @@ from snowflake.cli.api.commands.decorators import (
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
 from snowflake.cli.api.output.types import CommandResult, SingleQueryResult
 from snowflake.cli.plugins.spcs.compute_pool.manager import ComputePoolManager
+from snowflake.cli.plugins.object.common import comment_option
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
@@ -20,20 +23,42 @@ app = typer.Typer(
 def create(
     name: str = typer.Option(..., "--name", help="Name of the compute pool."),
     num_instances: int = typer.Option(
-        ..., "--num", help="Number of compute pool instances."
+        ..., "--num-instances", help="Number of compute pool instances."
     ),
     instance_family: str = typer.Option(
         ...,
         "--family",
         help="Name of the instance family. For more information about instance families, refer to the SQL CREATE COMPUTE POOL command.",
     ),
+    auto_resume: bool = typer.Option(
+        True,
+        "--auto-resume/--no-auto-resume",
+        help="The compute pool will automatically resume when a service or job is submitted to it.",
+    ),
+    initially_suspended: bool = typer.Option(
+        False,
+        "--init-suspend",
+        help="The compute pool will start in a suspended state.",
+    ),
+    auto_suspend_secs: int = typer.Option(
+        3600,
+        "--auto-suspend-secs",
+        help="Number of seconds of inactivity after which you want Snowflake to automatically suspend the compute pool.",
+    ),
+    comment: Optional[str] = comment_option("compute pool"),
     **options,
 ) -> CommandResult:
     """
     Creates a compute pool with a specified number of instances.
     """
     cursor = ComputePoolManager().create(
-        pool_name=name, num_instances=num_instances, instance_family=instance_family
+        pool_name=name,
+        num_instances=num_instances,
+        instance_family=instance_family,
+        auto_resume=auto_resume,
+        initially_suspended=initially_suspended,
+        auto_suspend_secs=auto_suspend_secs,
+        comment=comment,
     )
     return SingleQueryResult(cursor)
 

--- a/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
@@ -1,19 +1,33 @@
+from typing import Optional
+
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.cli.plugins.spcs.common import strip_empty_lines
 from snowflake.connector.cursor import SnowflakeCursor
 
 
 class ComputePoolManager(SqlExecutionMixin):
     def create(
-        self, pool_name: str, num_instances: int, instance_family: str
+        self,
+        pool_name: str,
+        num_instances: int,
+        instance_family: str,
+        auto_resume: bool,
+        initially_suspended: bool,
+        auto_suspend_secs: int,
+        comment: Optional[str],
     ) -> SnowflakeCursor:
-        return self._execute_query(
-            f"""\
+        query = f"""\
             CREATE COMPUTE POOL {pool_name}
             MIN_NODES = {num_instances}
             MAX_NODES = {num_instances}
-            INSTANCE_FAMILY = {instance_family};
-        """
-        )
+            INSTANCE_FAMILY = {instance_family}
+            AUTO_RESUME = {auto_resume}
+            INITIALLY_SUSPENDED = {initially_suspended}
+            AUTO_SUSPEND_SECS = {auto_suspend_secs}
+            """.splitlines()
+        if comment:
+            query.append(f"COMMENT = {comment}")
+        return self._execute_query(strip_empty_lines(query))
 
     def stop(self, pool_name: str) -> SnowflakeCursor:
         return self._execute_query(f"alter compute pool {pool_name} stop all;")

--- a/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
@@ -9,7 +9,8 @@ class ComputePoolManager(SqlExecutionMixin):
     def create(
         self,
         pool_name: str,
-        num_instances: int,
+        min_nodes: int,
+        max_nodes: int,
         instance_family: str,
         auto_resume: bool,
         initially_suspended: bool,
@@ -18,8 +19,8 @@ class ComputePoolManager(SqlExecutionMixin):
     ) -> SnowflakeCursor:
         query = f"""\
             CREATE COMPUTE POOL {pool_name}
-            MIN_NODES = {num_instances}
-            MAX_NODES = {num_instances}
+            MIN_NODES = {min_nodes}
+            MAX_NODES = {max_nodes}
             INSTANCE_FAMILY = {instance_family}
             AUTO_RESUME = {auto_resume}
             INITIALLY_SUSPENDED = {initially_suspended}

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 import typer
 from snowflake.cli.api.commands.decorators import (
@@ -14,6 +15,7 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.plugins.spcs.common import print_log_lines
 from snowflake.cli.plugins.spcs.services.manager import ServiceManager
+from snowflake.cli.plugins.object.common import tag_option, comment_option, Tag
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
@@ -26,18 +28,26 @@ app = typer.Typer(
 @with_output
 @global_options_with_connection
 def create(
-    name: str = typer.Option(..., "--name", help="Job Name"),
-    compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
-    spec_path: Path = typer.Option(
-        ...,
-        "--spec-path",
-        help="Spec Path",
-        file_okay=True,
-        dir_okay=False,
-        exists=True,
-    ),
-    num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
-    **options,
+        name: str = typer.Option(..., "--name", help="Job Name"),
+        compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
+        spec_path: Path = typer.Option(
+            ...,
+            "--spec-path",
+            help="Spec Path",
+            file_okay=True,
+            dir_okay=False,
+            exists=True,
+        ),
+        num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
+        auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume",
+                                         help="The service will automatically resume when a service function or ingress is called."),
+        external_access_integrations: Optional[List[str]] = typer.Option(None, "--eai-name",
+                                                                         help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs."),
+        query_warehouse: Optional[str] = typer.Option(None, "--query-warehouse",
+                                                      help="Warehouse to use if a service container connects to Snowflake to execute a query but does not explicitly specify a warehouse to use."),
+        tags: Optional[List[Tag]] = tag_option("service"),
+        comment: Optional[str] = comment_option("service"),
+        **options,
 ) -> CommandResult:
     """
     Creates a new Snowpark Container Services service in the current schema.
@@ -48,6 +58,11 @@ def create(
         num_instances=num_instances,
         compute_pool=compute_pool,
         spec_path=spec_path,
+        external_access_integrations=external_access_integrations,
+        auto_resume=auto_resume,
+        query_warehouse=query_warehouse,
+        tags=tags,
+        comment=comment
     )
     return SingleQueryResult(cursor)
 

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import typer
 from snowflake.cli.api.commands.decorators import (
@@ -28,26 +28,35 @@ app = typer.Typer(
 @with_output
 @global_options_with_connection
 def create(
-        name: str = typer.Option(..., "--name", help="Job Name"),
-        compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
-        spec_path: Path = typer.Option(
-            ...,
-            "--spec-path",
-            help="Spec Path",
-            file_okay=True,
-            dir_okay=False,
-            exists=True,
-        ),
-        num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
-        auto_resume: bool = typer.Option(True, "--auto-resume/--no-auto-resume",
-                                         help="The service will automatically resume when a service function or ingress is called."),
-        external_access_integrations: Optional[List[str]] = typer.Option(None, "--eai-name",
-                                                                         help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs."),
-        query_warehouse: Optional[str] = typer.Option(None, "--query-warehouse",
-                                                      help="Warehouse to use if a service container connects to Snowflake to execute a query but does not explicitly specify a warehouse to use."),
-        tags: Optional[List[Tag]] = tag_option("service"),
-        comment: Optional[str] = comment_option("service"),
-        **options,
+    name: str = typer.Option(..., "--name", help="Job Name"),
+    compute_pool: str = typer.Option(..., "--compute-pool", help="Compute Pool"),
+    spec_path: Path = typer.Option(
+        ...,
+        "--spec-path",
+        help="Spec Path",
+        file_okay=True,
+        dir_okay=False,
+        exists=True,
+    ),
+    num_instances: int = typer.Option(1, "--num-instances", help="Number of instances"),
+    auto_resume: bool = typer.Option(
+        True,
+        "--auto-resume/--no-auto-resume",
+        help="The service will automatically resume when a service function or ingress is called.",
+    ),
+    external_access_integrations: Optional[List[str]] = typer.Option(
+        None,
+        "--eai-name",
+        help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs.",
+    ),
+    query_warehouse: Optional[str] = typer.Option(
+        None,
+        "--query-warehouse",
+        help="Warehouse to use if a service container connects to Snowflake to execute a query without explicitly specifying a warehouse to use.",
+    ),
+    tags: Optional[List[Tag]] = tag_option("service"),
+    comment: Optional[str] = comment_option("service"),
+    **options,
 ) -> CommandResult:
     """
     Creates a new Snowpark Container Services service in the current schema.

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import List, Optional
 
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
-from snowflake.cli.plugins.spcs.common import strip_empty_lines
 from snowflake.cli.plugins.object.common import Tag
+from snowflake.cli.plugins.spcs.common import strip_empty_lines
 from snowflake.connector.cursor import SnowflakeCursor
 
 
@@ -13,7 +13,8 @@ class ServiceManager(SqlExecutionMixin):
         service_name: str,
         compute_pool: str,
         spec_path: Path,
-        num_instances: int,
+        min_instances: int,
+        max_instances: int,
         auto_resume: bool,
         external_access_integrations: Optional[List[str]],
         query_warehouse: Optional[str],
@@ -29,8 +30,8 @@ class ServiceManager(SqlExecutionMixin):
             {spec}
             $$
             WITH
-            MIN_INSTANCES = {num_instances}
-            MAX_INSTANCES = {num_instances}
+            MIN_INSTANCES = {min_instances}
+            MAX_INSTANCES = {max_instances}
             AUTO_RESUME = {auto_resume}
             """.splitlines()
 

--- a/tests/object/test_common.py
+++ b/tests/object/test_common.py
@@ -1,0 +1,35 @@
+from snowflake.cli.plugins.object.common import _parse_tag, Tag
+
+import pytest
+
+from click import ClickException
+
+
+INVALID_TAGS = (
+    "123_name=value",  # starts with a digit
+    "tag name=value",  # space in identifier
+    "tag&_name=value",  # special characters in identifier
+    "tag",  # no equals sign
+    "=value",  # empty identifier
+    "a" * 257 + "=value",  # identifier is over 256 characters
+    '"tag"name"=value'  # undoubled quote in tag name
+)
+VALID_TAGS = (
+    ("tag=value", ("tag", "value")),
+    ("_underscore_start=value", ("_underscore_start", "value")),
+    ("a=xyz", ("a", "xyz")),
+    ("A=123", ("A", "123")),
+    ("mixedCase=value", ("mixedCase", "value")),
+    ("_=value", ("_", "value")),
+    ("tag='this is a value'", ("tag", "'this is a value'")),
+    ("\"tag name!@#\"=value", ("\"tag name!@#\"", "value")),  # quoted identifier allows for spaces and special characters
+    ("tag==value", ("tag", "=value"))  # This is a strange case which we may not actually want to support
+)
+
+
+def test_parse_tag():
+    for tag in INVALID_TAGS:
+        with pytest.raises(ClickException):
+            _parse_tag(tag)
+    for tag in VALID_TAGS:
+        assert Tag(*tag[1]) == _parse_tag(tag[0])

--- a/tests/object/test_common.py
+++ b/tests/object/test_common.py
@@ -1,35 +1,46 @@
 from snowflake.cli.plugins.object.common import _parse_tag, Tag
-
+from typing import Tuple
 import pytest
 
 from click import ClickException
 
 
-INVALID_TAGS = (
-    "123_name=value",  # starts with a digit
-    "tag name=value",  # space in identifier
-    "tag&_name=value",  # special characters in identifier
-    "tag",  # no equals sign
-    "=value",  # empty identifier
-    "a" * 257 + "=value",  # identifier is over 256 characters
-    '"tag"name"=value'  # undoubled quote in tag name
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("tag=value", ("tag", "value")),
+        ("_underscore_start=value", ("_underscore_start", "value")),
+        ("a=xyz", ("a", "xyz")),
+        ("A=123", ("A", "123")),
+        ("mixedCase=value", ("mixedCase", "value")),
+        ("_=value", ("_", "value")),
+        ("tag='this is a value'", ("tag", "'this is a value'")),
+        (
+            '"tag name!@#"=value',
+            ('"tag name!@#"', "value"),
+        ),  # quoted identifier allows for spaces and special characters
+        (
+            "tag==value",
+            ("tag", "=value"),
+        ),  # This is a strange case which we may not actually want to support
+    ],
 )
-VALID_TAGS = (
-    ("tag=value", ("tag", "value")),
-    ("_underscore_start=value", ("_underscore_start", "value")),
-    ("a=xyz", ("a", "xyz")),
-    ("A=123", ("A", "123")),
-    ("mixedCase=value", ("mixedCase", "value")),
-    ("_=value", ("_", "value")),
-    ("tag='this is a value'", ("tag", "'this is a value'")),
-    ("\"tag name!@#\"=value", ("\"tag name!@#\"", "value")),  # quoted identifier allows for spaces and special characters
-    ("tag==value", ("tag", "=value"))  # This is a strange case which we may not actually want to support
-)
+def test_parse_tag_valid(value: str, expected: Tuple[str, str]):
+    assert _parse_tag(value) == Tag(*expected)
 
 
-def test_parse_tag():
-    for tag in INVALID_TAGS:
-        with pytest.raises(ClickException):
-            _parse_tag(tag)
-    for tag in VALID_TAGS:
-        assert Tag(*tag[1]) == _parse_tag(tag[0])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "123_name=value",  # starts with a digit
+        "tag name=value",  # space in identifier
+        "tag&_name=value",  # special characters in identifier
+        "tag",  # no equals sign
+        "=value",  # empty identifier
+        "a" * 257 + "=value",  # identifier is over 256 characters
+        '"tag"name"=value',  # undoubled quote in tag name
+    ],
+)
+def test_parse_tag_invalid(value: str):
+    with pytest.raises(ClickException):
+        _parse_tag(value)

--- a/tests/spcs/test_common.py
+++ b/tests/spcs/test_common.py
@@ -1,0 +1,33 @@
+from snowflake.cli.plugins.spcs.common import validate_and_set_instances
+from tests.testing_utils.fixtures import *
+from click import ClickException
+
+
+@pytest.mark.parametrize(
+    "min_instances, max_instances, expected_max",
+    [
+        (2, None, 2),  # max_instances is None, set max_instances to min_instances
+        (
+            5,
+            10,
+            10,
+        ),  # max_instances is valid non-None value, return max_instances unchanged
+    ],
+)
+def test_validate_and_set_instances(min_instances, max_instances, expected_max):
+    assert expected_max == validate_and_set_instances(
+        min_instances, max_instances, "name"
+    )
+
+
+@pytest.mark.parametrize(
+    "min_instances, max_instances",
+    [
+        (0, 1),  # non-positive min_instances
+        (-1, 1),  # negative min_instances
+        (2, 1),  # min_instances > max_instances
+    ],
+)
+def test_validate_and_set_instances_invalid(min_instances, max_instances):
+    with pytest.raises(ClickException):
+        validate_and_set_instances(min_instances, max_instances, "name")

--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -3,48 +3,120 @@ from unittest.mock import Mock, patch
 
 from snowflake.cli.plugins.spcs.compute_pool.manager import ComputePoolManager
 from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.cli.api.project.util import to_string_literal
 
 
-class TestComputePoolManager(unittest.TestCase):
-    def setUp(self):
-        self.compute_pool_manager = ComputePoolManager()
-
-    @patch(
-        "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager._execute_query"
+@patch(
+    "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager._execute_query"
+)
+def test_create(mock_execute_query):
+    pool_name = "test_pool"
+    num_instances = 2
+    instance_family = "test_family"
+    auto_resume = True
+    initially_suspended = False
+    auto_suspend_secs = 7200
+    comment = "'test comment'"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ComputePoolManager().create(
+        pool_name,
+        num_instances,
+        instance_family,
+        auto_resume,
+        initially_suspended,
+        auto_suspend_secs,
+        comment,
     )
-    def test_create(self, mock_execute_query):
-        pool_name = "test_pool"
-        num_instances = 2
-        instance_family = "test_family"
-        cursor = Mock(spec=SnowflakeCursor)
-        mock_execute_query.return_value = cursor
-        result = self.compute_pool_manager.create(
-            pool_name, num_instances, instance_family
-        )
-        expected_query = (
-            "CREATE COMPUTE POOL test_pool "
-            "MIN_NODES = 2 "
-            "MAX_NODES = 2 "
-            "INSTANCE_FAMILY = test_family;"
-        )
-        actual_query = " ".join(
-            mock_execute_query.mock_calls[0].args[0].replace("\n", "").split()
-        )
-        self.assertEqual(expected_query, actual_query)
-        self.assertEqual(result, cursor)
-
-    @patch(
-        "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager._execute_query"
+    expected_query = " ".join(
+        [
+            "CREATE COMPUTE POOL test_pool",
+            "MIN_NODES = 2",
+            "MAX_NODES = 2",
+            "INSTANCE_FAMILY = test_family",
+            "AUTO_RESUME = True",
+            "INITIALLY_SUSPENDED = False",
+            "AUTO_SUSPEND_SECS = 7200",
+            "COMMENT = 'test comment'",
+        ]
     )
-    def test_stop(self, mock_execute_query):
-        pool_name = "test_pool"
-        cursor = Mock(spec=SnowflakeCursor)
-        mock_execute_query.return_value = cursor
-        result = self.compute_pool_manager.stop(pool_name)
-        expected_query = "alter compute pool test_pool stop all;"
-        mock_execute_query.assert_called_once_with(expected_query)
-        self.assertEqual(result, cursor)
+    actual_query = " ".join(mock_execute_query.mock_calls[0].args[0].split())
+    assert expected_query == actual_query
+    assert result == cursor
 
 
-if __name__ == "__main__":
-    unittest.main()
+@patch(
+    "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager.create"
+)
+def test_create_pool_cli_defaults(mock_create, runner):
+    result = runner.invoke(
+        [
+            "spcs",
+            "pool",
+            "create",
+            "--name",
+            "test_pool",
+            "--num-instances",
+            "42",
+            "--family",
+            "test_family",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(
+        pool_name="test_pool",
+        num_instances=42,
+        instance_family="test_family",
+        auto_resume=True,
+        initially_suspended=False,
+        auto_suspend_secs=3600,
+        comment=None,
+    )
+
+
+@patch(
+    "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager.create"
+)
+def test_create_pool_cli(mock_create, runner):
+    result = runner.invoke(
+        [
+            "spcs",
+            "pool",
+            "create",
+            "--name",
+            "test_pool",
+            "--num-instances",
+            "42",
+            "--family",
+            "test_family",
+            "--no-auto-resume",
+            "--init-suspend",
+            "--auto-suspend-secs",
+            "7200",
+            "--comment",
+            "this is a test",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(
+        pool_name="test_pool",
+        num_instances=42,
+        instance_family="test_family",
+        auto_resume=False,
+        initially_suspended=True,
+        auto_suspend_secs=7200,
+        comment=to_string_literal("this is a test"),
+    )
+
+
+@patch(
+    "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager._execute_query"
+)
+def test_stop(mock_execute_query):
+    pool_name = "test_pool"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ComputePoolManager().stop(pool_name)
+    expected_query = "alter compute pool test_pool stop all;"
+    mock_execute_query.assert_called_once_with(expected_query)
+    assert result == cursor

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -10,6 +10,7 @@ from tests.testing_utils.fixtures import *
 from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.plugins.object.common import Tag
 
+
 @patch(
     "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
 )
@@ -35,7 +36,10 @@ def test_create_service(mock_execute_schema_query, other_directory):
         )
     )
     auto_resume = True
-    external_access_integrations = ["google_apis_access_integration", "salesforce_api_access_integration"]
+    external_access_integrations = [
+        "google_apis_access_integration",
+        "salesforce_api_access_integration",
+    ]
     query_warehouse = "test_warehouse"
     tags = [Tag("test_tag", "test value"), Tag("key", "value")]
     comment = "'user\\'s comment'"
@@ -44,31 +48,37 @@ def test_create_service(mock_execute_schema_query, other_directory):
     mock_execute_schema_query.return_value = cursor
 
     result = ServiceManager().create(
-        service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
-        query_warehouse, tags, comment
+        service_name,
+        compute_pool,
+        Path(spec_path),
+        num_instances,
+        auto_resume,
+        external_access_integrations,
+        query_warehouse,
+        tags,
+        comment,
     )
-    expected_query = " ".join([
-        "CREATE SERVICE IF NOT EXISTS test_service",
-        "IN COMPUTE POOL test_pool",
-        'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
-        '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',
-        '"port": 80, "public": true}]}} $$',
-        "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42",
-        "AUTO_RESUME = True",
-        "EXTERNAL_ACCESS_INTEGRATIONS = (google_apis_access_integration,salesforce_api_access_integration)",
-        "QUERY_WAREHOUSE = test_warehouse",
-        "TAG (test_tag='test value',key='value')",
-        "COMMENT = 'user\\'s comment'",
-    ])
-    actual_query = " ".join(
-        mock_execute_schema_query.mock_calls[0].args[0].split()
+    expected_query = " ".join(
+        [
+            "CREATE SERVICE IF NOT EXISTS test_service",
+            "IN COMPUTE POOL test_pool",
+            'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
+            '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',
+            '"port": 80, "public": true}]}} $$',
+            "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42",
+            "AUTO_RESUME = True",
+            "EXTERNAL_ACCESS_INTEGRATIONS = (google_apis_access_integration,salesforce_api_access_integration)",
+            "QUERY_WAREHOUSE = test_warehouse",
+            "TAG (test_tag='test value',key='value')",
+            "COMMENT = 'user\\'s comment'",
+        ]
     )
+    actual_query = " ".join(mock_execute_schema_query.mock_calls[0].args[0].split())
     assert expected_query == actual_query
     assert result == cursor
 
-@patch(
-    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
-)
+
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager.create")
 def test_create_service_cli_defaults(mock_create, other_directory, runner):
     tmp_dir = Path(other_directory)
     spec_path = tmp_dir / "spec.yml"
@@ -87,12 +97,34 @@ def test_create_service_cli_defaults(mock_create, other_directory, runner):
     """
         )
     )
-    result = runner.invoke(["containers", "service", "create", "--name", "test_service", "--compute-pool", "test_pool", "--spec-path", f"{spec_path}"])
+    result = runner.invoke(
+        [
+            "spcs",
+            "service",
+            "create",
+            "--name",
+            "test_service",
+            "--compute-pool",
+            "test_pool",
+            "--spec-path",
+            f"{spec_path}",
+        ]
+    )
     assert result.exit_code == 0, result.output
-    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path, num_instances=1, auto_resume=True, external_access_integrations=[], query_warehouse=None, tags=[], comment=None)
-@patch(
-    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
-)
+    mock_create.assert_called_once_with(
+        service_name="test_service",
+        compute_pool="test_pool",
+        spec_path=spec_path,
+        num_instances=1,
+        auto_resume=True,
+        external_access_integrations=[],
+        query_warehouse=None,
+        tags=[],
+        comment=None,
+    )
+
+
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager.create")
 def test_create_service_cli(mock_create, other_directory, runner):
     tmp_dir = Path(other_directory)
     spec_path = tmp_dir / "spec.yml"
@@ -112,22 +144,46 @@ def test_create_service_cli(mock_create, other_directory, runner):
         )
     )
     result = runner.invoke(
-        ["containers", "service", "create",
-         "--name", "test_service",
-         "--compute-pool", "test_pool",
-         "--spec-path", f"{spec_path}",
-         "--num-instances", "42",
-         "--no-auto-resume",
-         "--eai-name", "google_api", "--eai-name", "salesforce_api",
-         "--query-warehouse", "test_warehouse",
-         "--tag", "name=value", "--tag", "\"$trange name\"=normal value",
-         "--comment", "this is a test"
-    ])
+        [
+            "spcs",
+            "service",
+            "create",
+            "--name",
+            "test_service",
+            "--compute-pool",
+            "test_pool",
+            "--spec-path",
+            f"{spec_path}",
+            "--num-instances",
+            "42",
+            "--no-auto-resume",
+            "--eai-name",
+            "google_api",
+            "--eai-name",
+            "salesforce_api",
+            "--query-warehouse",
+            "test_warehouse",
+            "--tag",
+            "name=value",
+            "--tag",
+            '"$trange name"=normal value',
+            "--comment",
+            "this is a test",
+        ]
+    )
     assert result.exit_code == 0, result.output
     print(mock_create.mock_calls[0])
-    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path,
-                                        num_instances=42, auto_resume=False, external_access_integrations=["google_api", "salesforce_api"],
-                                        query_warehouse="test_warehouse", tags=[Tag("name", "value"), Tag("\"$trange name\"", "normal value")], comment=to_string_literal("this is a test"))
+    mock_create.assert_called_once_with(
+        service_name="test_service",
+        compute_pool="test_pool",
+        spec_path=spec_path,
+        num_instances=42,
+        auto_resume=False,
+        external_access_integrations=["google_api", "salesforce_api"],
+        query_warehouse="test_warehouse",
+        tags=[Tag("name", "value"), Tag('"$trange name"', "normal value")],
+        comment=to_string_literal("this is a test"),
+    )
 
 
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._read_yaml")
@@ -142,9 +198,18 @@ def test_create_service_with_invalid_spec(mock_read_yaml):
 
     with pytest.raises(strictyaml.YAMLError):
         ServiceManager().create(
-            service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
-            query_warehouse, tags, comment
+            service_name,
+            compute_pool,
+            Path(spec_path),
+            num_instances,
+            auto_resume,
+            external_access_integrations,
+            query_warehouse,
+            tags,
+            comment,
         )
+
+
 @patch(
     "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
 )

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock, patch
 
+from click import ClickException
 import pytest
 import strictyaml
 from snowflake.cli.plugins.spcs.services.manager import ServiceManager
-
 from tests.testing_utils.fixtures import *
-
+from snowflake.cli.api.project.util import to_string_literal
+from snowflake.cli.plugins.object.common import Tag
 
 @patch(
     "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
@@ -33,26 +34,100 @@ def test_create_service(mock_execute_schema_query, other_directory):
     """
         )
     )
+    auto_resume = True
+    external_access_integrations = ["google_apis_access_integration", "salesforce_api_access_integration"]
+    query_warehouse = "test_warehouse"
+    tags = [Tag("test_tag", "test value"), Tag("key", "value")]
+    comment = "'user\\'s comment'"
 
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_schema_query.return_value = cursor
 
     result = ServiceManager().create(
-        service_name, compute_pool, Path(spec_path), num_instances
+        service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
+        query_warehouse, tags, comment
     )
-    expected_query = (
-        "CREATE SERVICE IF NOT EXISTS test_service "
-        "IN COMPUTE POOL test_pool "
-        'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image": '
-        '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver", '
-        '"port": 80, "public": true}]}} $$ '
-        "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42"
-    )
+    expected_query = " ".join([
+        "CREATE SERVICE IF NOT EXISTS test_service",
+        "IN COMPUTE POOL test_pool",
+        'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
+        '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',
+        '"port": 80, "public": true}]}} $$',
+        "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42",
+        "AUTO_RESUME = True",
+        "EXTERNAL_ACCESS_INTEGRATIONS = (google_apis_access_integration,salesforce_api_access_integration)",
+        "QUERY_WAREHOUSE = test_warehouse",
+        "TAG (test_tag='test value',key='value')",
+        "COMMENT = 'user\\'s comment'",
+    ])
     actual_query = " ".join(
-        mock_execute_schema_query.mock_calls[0].args[0].replace("\n", "").split()
+        mock_execute_schema_query.mock_calls[0].args[0].split()
     )
     assert expected_query == actual_query
     assert result == cursor
+
+@patch(
+    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
+)
+def test_create_service_cli_defaults(mock_create, other_directory, runner):
+    tmp_dir = Path(other_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            """
+    spec:
+        containers:
+        - name: cloudbeaver
+          image: /spcs_demos_db/cloudbeaver:23.2.1
+        endpoints:
+        - name: cloudbeaver
+          port: 80
+          public: true
+
+    """
+        )
+    )
+    result = runner.invoke(["containers", "service", "create", "--name", "test_service", "--compute-pool", "test_pool", "--spec-path", f"{spec_path}"])
+    assert result.exit_code == 0, result.output
+    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path, num_instances=1, auto_resume=True, external_access_integrations=[], query_warehouse=None, tags=[], comment=None)
+@patch(
+    "snowflake.cli.plugins.containers.services.manager.ServiceManager.create"
+)
+def test_create_service_cli(mock_create, other_directory, runner):
+    tmp_dir = Path(other_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            """
+    spec:
+        containers:
+        - name: cloudbeaver
+          image: /spcs_demos_db/cloudbeaver:23.2.1
+        endpoints:
+        - name: cloudbeaver
+          port: 80
+          public: true
+
+    """
+        )
+    )
+    result = runner.invoke(
+        ["containers", "service", "create",
+         "--name", "test_service",
+         "--compute-pool", "test_pool",
+         "--spec-path", f"{spec_path}",
+         "--num-instances", "42",
+         "--no-auto-resume",
+         "--eai-name", "google_api", "--eai-name", "salesforce_api",
+         "--query-warehouse", "test_warehouse",
+         "--tag", "name=value", "--tag", "\"$trange name\"=normal value",
+         "--comment", "this is a test"
+    ])
+    assert result.exit_code == 0, result.output
+    print(mock_create.mock_calls[0])
+    mock_create.assert_called_once_with(service_name="test_service", compute_pool="test_pool", spec_path=spec_path,
+                                        num_instances=42, auto_resume=False, external_access_integrations=["google_api", "salesforce_api"],
+                                        query_warehouse="test_warehouse", tags=[Tag("name", "value"), Tag("\"$trange name\"", "normal value")], comment=to_string_literal("this is a test"))
 
 
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._read_yaml")
@@ -61,13 +136,15 @@ def test_create_service_with_invalid_spec(mock_read_yaml):
     compute_pool = "test_pool"
     spec_path = "/path/to/spec.yaml"
     num_instances = 42
+    external_access_integrations = query_warehouse = tags = comment = None
+    auto_resume = False
     mock_read_yaml.side_effect = strictyaml.YAMLError("Invalid YAML")
+
     with pytest.raises(strictyaml.YAMLError):
         ServiceManager().create(
-            service_name, compute_pool, Path(spec_path), num_instances
+            service_name, compute_pool, Path(spec_path), num_instances, auto_resume, external_access_integrations,
+            query_warehouse, tags, comment
         )
-
-
 @patch(
     "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
 )

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -17,7 +17,8 @@ from snowflake.cli.plugins.object.common import Tag
 def test_create_service(mock_execute_schema_query, other_directory):
     service_name = "test_service"
     compute_pool = "test_pool"
-    num_instances = 42
+    min_instances = 42
+    max_instances = 43
     tmp_dir = Path(other_directory)
     spec_path = tmp_dir / "spec.yml"
     spec_path.write_text(
@@ -48,15 +49,16 @@ def test_create_service(mock_execute_schema_query, other_directory):
     mock_execute_schema_query.return_value = cursor
 
     result = ServiceManager().create(
-        service_name,
-        compute_pool,
-        Path(spec_path),
-        num_instances,
-        auto_resume,
-        external_access_integrations,
-        query_warehouse,
-        tags,
-        comment,
+        service_name=service_name,
+        compute_pool=compute_pool,
+        spec_path=Path(spec_path),
+        min_instances=min_instances,
+        max_instances=max_instances,
+        auto_resume=auto_resume,
+        external_access_integrations=external_access_integrations,
+        query_warehouse=query_warehouse,
+        tags=tags,
+        comment=comment,
     )
     expected_query = " ".join(
         [
@@ -65,7 +67,7 @@ def test_create_service(mock_execute_schema_query, other_directory):
             'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
             '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',
             '"port": 80, "public": true}]}} $$',
-            "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 42",
+            "WITH MIN_INSTANCES = 42 MAX_INSTANCES = 43",
             "AUTO_RESUME = True",
             "EXTERNAL_ACCESS_INTEGRATIONS = (google_apis_access_integration,salesforce_api_access_integration)",
             "QUERY_WAREHOUSE = test_warehouse",
@@ -115,7 +117,8 @@ def test_create_service_cli_defaults(mock_create, other_directory, runner):
         service_name="test_service",
         compute_pool="test_pool",
         spec_path=spec_path,
-        num_instances=1,
+        min_instances=1,
+        max_instances=1,
         auto_resume=True,
         external_access_integrations=[],
         query_warehouse=None,
@@ -154,8 +157,10 @@ def test_create_service_cli(mock_create, other_directory, runner):
             "test_pool",
             "--spec-path",
             f"{spec_path}",
-            "--num-instances",
+            "--min-instances",
             "42",
+            "--max-instances",
+            "43",
             "--no-auto-resume",
             "--eai-name",
             "google_api",
@@ -177,7 +182,8 @@ def test_create_service_cli(mock_create, other_directory, runner):
         service_name="test_service",
         compute_pool="test_pool",
         spec_path=spec_path,
-        num_instances=42,
+        min_instances=42,
+        max_instances=43,
         auto_resume=False,
         external_access_integrations=["google_api", "salesforce_api"],
         query_warehouse="test_warehouse",
@@ -191,22 +197,24 @@ def test_create_service_with_invalid_spec(mock_read_yaml):
     service_name = "test_service"
     compute_pool = "test_pool"
     spec_path = "/path/to/spec.yaml"
-    num_instances = 42
+    min_instances = 42
+    max_instances = 42
     external_access_integrations = query_warehouse = tags = comment = None
     auto_resume = False
     mock_read_yaml.side_effect = strictyaml.YAMLError("Invalid YAML")
 
     with pytest.raises(strictyaml.YAMLError):
         ServiceManager().create(
-            service_name,
-            compute_pool,
-            Path(spec_path),
-            num_instances,
-            auto_resume,
-            external_access_integrations,
-            query_warehouse,
-            tags,
-            comment,
+            service_name=service_name,
+            compute_pool=compute_pool,
+            spec_path=Path(spec_path),
+            min_instances=min_instances,
+            max_instances=max_instances,
+            auto_resume=auto_resume,
+            external_access_integrations=external_access_integrations,
+            query_warehouse=query_warehouse,
+            tags=tags,
+            comment=comment,
         )
 
 

--- a/tests_integration/spcs/test_cp.py
+++ b/tests_integration/spcs/test_cp.py
@@ -20,7 +20,7 @@ def test_cp(runner, snowflake_session):
             "create",
             "--name",
             cp_name,
-            "--min-instances",
+            "--min-nodes",
             1,
             "--family",
             "STANDARD_1",

--- a/tests_integration/spcs/test_cp.py
+++ b/tests_integration/spcs/test_cp.py
@@ -20,7 +20,7 @@ def test_cp(runner, snowflake_session):
             "create",
             "--name",
             cp_name,
-            "--num-instances",
+            "--min-instances",
             1,
             "--family",
             "STANDARD_1",

--- a/tests_integration/test_cp.py
+++ b/tests_integration/test_cp.py
@@ -20,7 +20,7 @@ def test_cp(runner, snowflake_session):
             "create",
             "--name",
             cp_name,
-            "--num",
+            "--num-instances",
             1,
             "--family",
             "STANDARD_1",


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

Changes description
- Added additional CLI options to snow containers service create and snow containers pool create to match SQL interface.
- Updated unit tests for ServiceManager.create() and ComputePoolManager.create() and CLI interface of snow containers service create and snow containers pool create.
- Added generic CLI options for Comment and Tag options under object/common.py. These can be used for all other CLI commands that take Tag or Comment (e.g. other create commands, alter tag, alter comment, etc.).
- Minor unrelated typo fixes.
- **Duplicate of [PR#674](https://github.com/Snowflake-Labs/snowcli/pull/674) but from a main repository branch instead of a fork**

New Service Options:
![image](https://github.com/Snowflake-Labs/snowcli/assets/156019931/bdfaf0f3-a8d9-4577-b87c-e40fbfa348b3)
New Compute Pool Options:
![image](https://github.com/Snowflake-Labs/snowcli/assets/156019931/ed87dbac-de3c-447b-bbdd-2da4fa674ce8)

Example Output:
<img width="1641" alt="cli_compute_pool_works" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/3da09b2c-bc0e-4349-820e-9682596bd679">
<img width="1639" alt="cli_compute_pool_desc" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/32148374-befd-43e7-848b-69a1274d6d48">
<img width="1415" alt="cli_service_create_noerror" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/3e87ffa8-b8e1-4f43-a3f0-5e1d2209563b">
<img width="1630" alt="cli_service_desc" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/02b42a73-27b2-481f-8f27-106f52ab2741">

**Strangely, there seems to be an error/warning specifically on Mac regarding plist parsing when you enter a command line option in the format '"key"=value' or "\"key\"=value"**. The only relevant use case for this is in specifying tags with quoted identifers (e.g. --tag '"cost center"=finance'). More details in this [https://docs.google.com/document/d/1qsf2igvHGxVFWvN1f52ryrC-6cFrfTSaa84sIXR8nQ0/edit]()
<img width="1629" alt="cli_service_create" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/362b3d57-5531-45ca-80ab-1b41cddd6d83">


