### PR TITLE
SNOW-1011764: Adding image-repository to supported objects.

### DIFF
--- a/src/snowflake/cli/api/constants.py
+++ b/src/snowflake/cli/api/constants.py
@@ -38,6 +38,9 @@ class ObjectType(Enum):
     USER = ObjectNames("user", "user", "users")
     WAREHOUSE = ObjectNames("warehouse", "warehouse", "warehouses")
     VIEW = ObjectNames("view", "view", "views")
+    IMAGE_REPOSITORY = ObjectNames(
+        "image-repository", "image repository", "image repositories"
+    )
 
     def __str__(self):
         """This makes using this Enum easier in formatted string"""

--- a/src/snowflake/cli/plugins/object/commands.py
+++ b/src/snowflake/cli/plugins/object/commands.py
@@ -58,8 +58,14 @@ def drop(object_type: str = ObjectArgument, object_name: str = NameArgument, **o
     return QueryResult(ObjectManager().drop(object_type=object_type, name=object_name))
 
 
+# Image repository is only supported object that does not have a DESCRIBE command.
+DESCRIBE_SUPPORTED_TYPES_MSG = "\n\nSupported types: " + ", ".join(
+    obj for obj in SUPPORTED_OBJECTS if obj != "image-repository"
+)
+
+
 @app.command(
-    help=f"Provides description of an object of given type. {SUPPORTED_TYPES_MSG}"
+    help=f"Provides description of an object of given type. {DESCRIBE_SUPPORTED_TYPES_MSG}"
 )
 @with_output
 @global_options_with_connection

--- a/src/snowflake/cli/plugins/object/commands.py
+++ b/src/snowflake/cli/plugins/object/commands.py
@@ -58,7 +58,7 @@ def drop(object_type: str = ObjectArgument, object_name: str = NameArgument, **o
     return QueryResult(ObjectManager().drop(object_type=object_type, name=object_name))
 
 
-# Image repository is only supported object that does not have a DESCRIBE command.
+# Image repository is the only supported object that does not have a DESCRIBE command.
 DESCRIBE_SUPPORTED_TYPES_MSG = f"\n\nSupported types: {', '.join(obj for obj in SUPPORTED_OBJECTS if obj != 'image-repository')}"
 
 

--- a/src/snowflake/cli/plugins/object/commands.py
+++ b/src/snowflake/cli/plugins/object/commands.py
@@ -59,9 +59,7 @@ def drop(object_type: str = ObjectArgument, object_name: str = NameArgument, **o
 
 
 # Image repository is only supported object that does not have a DESCRIBE command.
-DESCRIBE_SUPPORTED_TYPES_MSG = "\n\nSupported types: " + ", ".join(
-    obj for obj in SUPPORTED_OBJECTS if obj != "image-repository"
-)
+DESCRIBE_SUPPORTED_TYPES_MSG = f"\n\nSupported types: {', '.join(obj for obj in SUPPORTED_OBJECTS if obj != 'image-repository')}"
 
 
 @app.command(

--- a/src/snowflake/cli/plugins/object/manager.py
+++ b/src/snowflake/cli/plugins/object/manager.py
@@ -28,7 +28,7 @@ class ObjectManager(SqlExecutionMixin):
         return self._execute_query(f"drop {object_name} {name}")
 
     def describe(self, *, object_type: str, name: str):
-        # Image repository is only supported object that does not have a DESCRIBE command.
+        # Image repository is the only supported object that does not have a DESCRIBE command.
         if object_type == "image-repository":
             raise ClickException(
                 f"Describe is currently not supported for object of type image-repository"

--- a/src/snowflake/cli/plugins/object/manager.py
+++ b/src/snowflake/cli/plugins/object/manager.py
@@ -28,5 +28,10 @@ class ObjectManager(SqlExecutionMixin):
         return self._execute_query(f"drop {object_name} {name}")
 
     def describe(self, *, object_type: str, name: str):
+        # Image repository is only supported object that does not have a DESCRIBE command.
+        if object_type == "image-repository":
+            raise ClickException(
+                f"Describe is currently not supported for object of type image-repository"
+            )
         object_name = _get_object_names(object_type).sf_name
         return self._execute_query(f"describe {object_name} {name}")

--- a/tests/object/__snapshots__/test_object.ambr
+++ b/tests/object/__snapshots__/test_object.ambr
@@ -227,6 +227,14 @@
   
   '''
 # ---
+# name: test_describe_fails_image_repository
+  '''
+  ╭─ Error ──────────────────────────────────────────────────────────────────────╮
+  │ Object of type image_repository is not supported.                            │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
 # name: test_drop[compute-pool-compute-pool-example]
   '''
   SELECT A MOCK QUERY

--- a/tests/object/__snapshots__/test_object.ambr
+++ b/tests/object/__snapshots__/test_object.ambr
@@ -230,7 +230,7 @@
 # name: test_describe_fails_image_repository
   '''
   ╭─ Error ──────────────────────────────────────────────────────────────────────╮
-  │ Object of type image_repository is not supported.                            │
+  │ Describe is currently not supported for object of type image-repository      │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   
   '''

--- a/tests/object/__snapshots__/test_object.ambr
+++ b/tests/object/__snapshots__/test_object.ambr
@@ -260,6 +260,17 @@
   
   '''
 # ---
+# name: test_drop[image-repository-image-repository-example]
+  '''
+  SELECT A MOCK QUERY
+  +--------+
+  | status |
+  |--------|
+  | i      |
+  +--------+
+  
+  '''
+# ---
 # name: test_drop[integration-integration]
   '''
   SELECT A MOCK QUERY

--- a/tests/object/test_object.py
+++ b/tests/object/test_object.py
@@ -116,7 +116,8 @@ def test_that_objects_list_is_in_help(command, runner):
     for obj in SUPPORTED_OBJECTS:
         if command == "describe" and obj == "image-repository":
             assert obj not in result.output, f"{obj} should not be in help message"
-        assert obj in result.output, f"{obj} in help message"
+        else:
+            assert obj in result.output, f"{obj} in help message"
 
 
 @pytest.mark.parametrize(

--- a/tests/object/test_object.py
+++ b/tests/object/test_object.py
@@ -81,6 +81,13 @@ def test_describe(
     assert result.output == snapshot
 
 
+@mock.patch("snowflake.connector")
+def test_describe_fails_image_repository(mock_cursor, runner, snapshot):
+    result = runner.invoke(["object", "describe", "image_repository", "test_repo"])
+    assert result.exit_code == 1, result.output
+    assert result.output == snapshot
+
+
 DROP_TEST_OBJECTS = [
     *DESCRIBE_TEST_OBJECTS,
     ("image-repository", "image-repository-example"),
@@ -108,7 +115,7 @@ def test_that_objects_list_is_in_help(command, runner):
     result = runner.invoke(["object", command, "--help"])
     for obj in SUPPORTED_OBJECTS:
         if command == "describe" and obj == "image-repository":
-            continue
+            assert obj not in result.output, f"{obj} should not be in help message"
         assert obj in result.output, f"{obj} in help message"
 
 

--- a/tests/object/test_object.py
+++ b/tests/object/test_object.py
@@ -83,7 +83,7 @@ def test_describe(
 
 @mock.patch("snowflake.connector")
 def test_describe_fails_image_repository(mock_cursor, runner, snapshot):
-    result = runner.invoke(["object", "describe", "image_repository", "test_repo"])
+    result = runner.invoke(["object", "describe", "image-repository", "test_repo"])
     assert result.exit_code == 1, result.output
     assert result.output == snapshot
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added image-repository to the supported objects for `snow object`. Note that DESCRIBE IMAGE REPOSITORY currently doesn't exist in SQL, thus `snow object describe` explicitly excludes image-repository for alignment.

Sample Output:
<img width="738" alt="object drop image-repo" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/be645d7b-5f40-4332-822d-5a56073ce98f">
<img width="1673" alt="object list image-repo" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/64845939-d5d6-4ce4-9105-666f16f12544">

