### PR TITLE
SNOW-1011766: Added 'snow spcs image-repository url <repo_name>' command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,7 @@
 ## New additions
 * Added ability to specify scope of the `object list` command with the `--in <scope_type> <scope_name>` option.
 * Introduced `snowflake.cli.api.console.cli_console` object with helper methods for intermediate output.
+* Added convenience function `spcs image-repository url <repo_name>`.
 
 ## Fixes and improvements
 * Restricted permissions of automatically created files

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -145,6 +145,13 @@ def validate_version(version: str):
         )
 
 
-def escape_like_pattern(pattern: str) -> str:
-    pattern = pattern.replace("%", r"\\%").replace("_", r"\\_")
+def escape_like_pattern(pattern: str, escape_sequence: str = r"\\") -> str:
+    """
+    When used with LIKE in Snowflake, '%' and '_' are wildcard characters and must be escaped to be used literally.
+    The escape character is '\\' when used in SHOW LIKE and must be specified when used with string matching using the
+    following syntax: <subject> LIKE <pattern> [ ESCAPE <escape> ].
+    """
+    pattern = pattern.replace("%", rf"{escape_sequence}%").replace(
+        "_", rf"{escape_sequence}_"
+    )
     return pattern

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -146,5 +146,5 @@ def validate_version(version: str):
 
 
 def escape_like_pattern(pattern: str) -> str:
-    pattern = pattern.replace("%", r"\\}%").replace("_", r"\\_")
+    pattern = pattern.replace("%", r"\\%").replace("_", r"\\_")
     return pattern

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -143,3 +143,8 @@ def validate_version(version: str):
         raise ValueError(
             f"Project definition version {version} is not supported by this version of Snowflake CLI. Supported versions: {SUPPORTED_VERSIONS}"
         )
+
+
+def escape_like_pattern(pattern: str) -> str:
+    pattern = pattern.replace("%", r"\\}%").replace("_", r"\\_")
+    return pattern

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -72,9 +72,9 @@ class SqlExecutionMixin:
             if is_different_role:
                 self._execute_query(f"use role {prev_role}")
 
-    def _execute_schema_query(self, query: str):
+    def _execute_schema_query(self, query: str, **kwargs):
         self.check_database_and_schema()
-        return self._execute_query(query)
+        return self._execute_query(query, **kwargs)
 
     def check_database_and_schema(self) -> None:
         database = self._conn.database

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -10,6 +10,7 @@ from snowflake.cli.api.commands.decorators import (
 )
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
 from snowflake.cli.api.output.types import CollectionResult, MessageResult
+from snowflake.cli.api.project.util import is_valid_identifier
 from snowflake.cli.plugins.spcs.image_registry.manager import RegistryManager
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 
@@ -21,13 +22,23 @@ app = typer.Typer(
 )
 
 
+def _repo_name_callback(name: str):
+    if not is_valid_identifier(name):
+        raise ClickException("Repository name must be a valid identifier.")
+    return name
+
+
+REPO_NAME_ARGUMENT = typer.Argument(
+    help="Name of the image repository shown by the `SHOW IMAGE REPOSITORIES` SQL command. Must be run with a specified database and schema.",
+    callback=_repo_name_callback,
+)
+
+
 @app.command("list-images")
 @with_output
 @global_options_with_connection
 def list_images(
-    repo_name: str = typer.Argument(
-        help="Name of the image repository shown by the `SHOW IMAGE REPOSITORIES` SQL command.",
-    ),
+    repo_name: str = REPO_NAME_ARGUMENT,
     **options,
 ) -> CollectionResult:
     """Lists images in given repository."""
@@ -72,9 +83,7 @@ def list_images(
 @with_output
 @global_options_with_connection
 def list_tags(
-    repo_name: str = typer.Argument(
-        help="Name of the image repository shown by the `SHOW IMAGE REPOSITORIES` SQL command.",
-    ),
+    repo_name: str = REPO_NAME_ARGUMENT,
     image_name: str = typer.Option(
         ...,
         "--image_name",
@@ -121,13 +130,11 @@ def list_tags(
     return CollectionResult(tags_list)
 
 
-@app.command()
+@app.command("url")
 @with_output
 @global_options_with_connection
-def url(
-    repo_name: str = typer.Argument(
-        help="Name of the image repository.",
-    ),
+def repo_url(
+    repo_name: str = REPO_NAME_ARGUMENT,
     **options,
 ):
     """Returns the URL for the given repository."""

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -9,7 +9,7 @@ from snowflake.cli.api.commands.decorators import (
     with_output,
 )
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
-from snowflake.cli.api.output.types import CollectionResult
+from snowflake.cli.api.output.types import CollectionResult, MessageResult
 from snowflake.cli.plugins.spcs.image_registry.manager import RegistryManager
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 
@@ -119,3 +119,20 @@ def list_tags(
         tags_list.append({"tag": image_tag})
 
     return CollectionResult(tags_list)
+
+
+@app.command()
+@with_output
+@global_options_with_connection
+def url(
+    repo_name: str = typer.Argument(
+        help="Name of the image repository.",
+    ),
+    **options,
+):
+    """Returns the URL for the given repository."""
+    return MessageResult(
+        ImageRepositoryManager()
+        .get_repository_url(repo_name=repo_name)
+        .replace("https://", "")
+    )

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -139,7 +139,5 @@ def repo_url(
 ):
     """Returns the URL for the given repository."""
     return MessageResult(
-        ImageRepositoryManager()
-        .get_repository_url(repo_name=repo_name)
-        .replace("https://", "")
+        (ImageRepositoryManager().get_repository_url_strip_scheme(repo_name=repo_name))
     )

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -141,5 +141,9 @@ def repo_url(
 ):
     """Returns the URL for the given repository."""
     return MessageResult(
-        (ImageRepositoryManager().get_repository_url_strip_scheme(repo_name=repo_name))
+        (
+            ImageRepositoryManager().get_repository_url(
+                repo_name=repo_name, with_scheme=False
+            )
+        )
     )

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -10,7 +10,7 @@ from snowflake.cli.api.commands.decorators import (
 )
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
 from snowflake.cli.api.output.types import CollectionResult, MessageResult
-from snowflake.cli.api.project.util import is_valid_identifier
+from snowflake.cli.api.project.util import is_valid_unquoted_identifier
 from snowflake.cli.plugins.spcs.image_registry.manager import RegistryManager
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 
@@ -23,13 +23,15 @@ app = typer.Typer(
 
 
 def _repo_name_callback(name: str):
-    if not is_valid_identifier(name):
-        raise ClickException("Repository name must be a valid identifier.")
+    if not is_valid_unquoted_identifier(name):
+        raise ClickException(
+            "Repository name must be a valid unquoted identifier. Quoted names for special characters or case-sensitive names are not supported for image repositories."
+        )
     return name
 
 
 REPO_NAME_ARGUMENT = typer.Argument(
-    help="Name of the image repository shown by the `SHOW IMAGE REPOSITORIES` SQL command. Must be run with a specified database and schema.",
+    help="Name of the image repository. Only unquoted identifiers are supported for image repositories.",
     callback=_repo_name_callback,
 )
 

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -50,13 +50,16 @@ class ImageRepositoryManager(SqlExecutionMixin):
             )
         return results[0]
 
-    def get_repository_url(self, repo_name: str):
+    def get_repository_url(self, repo_name: str, with_scheme: bool = True):
         if not is_valid_unquoted_identifier(repo_name):
             raise ValueError(
                 f"repo_name '{repo_name}' is not a valid unquoted Snowflake identifier"
             )
         repo_row = self.get_repository_row(repo_name)
-        return f"https://{repo_row['repository_url']}"
+        if with_scheme:
+            return f"https://{repo_row['repository_url']}"
+        else:
+            return repo_row["repository_url"]
 
     def get_repository_api_url(self, repo_url):
         """
@@ -70,12 +73,3 @@ class ImageRepositoryManager(SqlExecutionMixin):
         path = parsed_url.path
 
         return f"{scheme}://{host}/v2{path}"
-
-    def _remove_scheme(self, url: str) -> str:
-        if not urlparse(url).scheme and not url.startswith("//"):
-            url = f"//{url}"
-        parsed_url = urlparse(url)
-        return f"{parsed_url.netloc}{parsed_url.path}"
-
-    def get_repository_url_strip_scheme(self, repo_name):
-        return self._remove_scheme(self.get_repository_url(repo_name))

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -42,7 +42,7 @@ class ImageRepositoryManager(SqlExecutionMixin):
         colored_repo_name = click.style(f"'{repo_name}'", fg="green")
         if len(results) == 0:
             raise ClickException(
-                f"Image repository {colored_repo_name} does not exist or not authorized."
+                f"Image repository {colored_repo_name} does not exist in database {self.get_database()} and schema {self.get_schema()} or not authorized."
             )
         elif len(results) > 1:
             raise ClickException(

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -1,7 +1,6 @@
 from typing import Dict
 from urllib.parse import urlparse
 
-import click
 from click import ClickException
 from snowflake.cli.api.project.util import (
     escape_like_pattern,
@@ -39,14 +38,13 @@ class ImageRepositoryManager(SqlExecutionMixin):
         )
         results = result_set.fetchall()
 
-        colored_repo_name = click.style(f"'{repo_name}'", fg="green")
         if len(results) == 0:
             raise ClickException(
-                f"Image repository {colored_repo_name} does not exist in database {self.get_database()} and schema {self.get_schema()} or not authorized."
+                f"Image repository '{repo_name}' does not exist in database '{self.get_database()}' and schema '{self.get_schema()}' or not authorized."
             )
         elif len(results) > 1:
             raise ClickException(
-                f"Found more than one image repository with name matching {colored_repo_name}. This is unexpected."
+                f"Found more than one image repository with name matching '{repo_name}'. This is unexpected."
             )
         return results[0]
 

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from click import ClickException
+from snowflake.cli.api.project.util import escape_like_pattern
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import SnowflakeCursor
 
@@ -16,18 +17,10 @@ class ImageRepositoryManager(SqlExecutionMixin):
         return self._conn.role
 
     def get_repository_url_list(self, repo_name: str) -> SnowflakeCursor:
-        role = self.get_role()
-        database = self.get_database()
-        schema = self.get_schema()
-
-        registry_query = f"""
-            use role {role};
-            use database {database};
-            use schema {schema};
-            show image repositories like '{repo_name}';
-            """
-
-        return self._execute_query(registry_query)
+        repository_query = (
+            f"show image repositories like '{escape_like_pattern(repo_name)}'"
+        )
+        return self._execute_query(repository_query)
 
     def get_repository_url(self, repo_name):
         database = self.get_database()

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -1,9 +1,14 @@
+from typing import Dict
 from urllib.parse import urlparse
 
 from click import ClickException
-from snowflake.cli.api.project.util import escape_like_pattern
+from snowflake.cli.api.project.util import (
+    escape_like_pattern,
+    is_valid_identifier,
+    is_valid_quoted_identifier,
+)
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
-from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.cursor import DictCursor
 
 
 class ImageRepositoryManager(SqlExecutionMixin):
@@ -16,30 +21,43 @@ class ImageRepositoryManager(SqlExecutionMixin):
     def get_role(self):
         return self._conn.role
 
-    def get_repository_url_list(self, repo_name: str) -> SnowflakeCursor:
-        repository_query = (
-            f"show image repositories like '{escape_like_pattern(repo_name)}'"
-        )
-        return self._execute_query(repository_query)
-
-    def get_repository_url(self, repo_name):
+    def get_repository_row(self, repo_name: str) -> Dict:
+        if not is_valid_identifier(repo_name):
+            raise ValueError(
+                f"repo_name '{repo_name}' is not a valid Snowflake identifier"
+            )
         database = self.get_database()
         schema = self.get_schema()
+        name_is_quoted = is_valid_quoted_identifier(repo_name)
 
-        result_set = self.get_repository_url_list(repo_name=repo_name)
-
+        # if repo_name is a quoted identifier, strip quotes before using as pattern
+        repo_name_raw = repo_name[1:-1] if name_is_quoted else repo_name.upper()
+        repository_list_query = (
+            f"show image repositories like '{escape_like_pattern(repo_name_raw)}'"
+        )
+        result_set = self._execute_query(repository_list_query, cursor_class=DictCursor)
         results = result_set.fetchall()
+
+        # because SHOW LIKE uses case-insensitive matching, results may return multiple rows
+        results = [r for r in results if r["name"] == repo_name_raw]
+
         if len(results) == 0:
             raise ClickException(
                 f"Specified repository name {repo_name} not found in database {database} and schema {schema}"
             )
-        else:
-            if len(results) > 1:
-                raise Exception(
-                    f"Found more than one repositories with name {repo_name}. This is unexpected."
-                )
+        elif len(results) > 1:
+            raise Exception(
+                f"Found more than one repositories with name {repo_name}. This is unexpected."
+            )
+        return results[0]
 
-        return f"https://{results[0][4]}"
+    def get_repository_url(self, repo_name: str):
+        if not is_valid_identifier(repo_name):
+            raise ValueError(
+                f"repo_name '{repo_name}' is not a valid Snowflake identifier"
+            )
+        repo_row = self.get_repository_row(repo_name)
+        return f"https://{repo_row['repository_url']}"
 
     def get_repository_api_url(self, repo_url):
         """

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -7,6 +7,7 @@ from snowflake.cli.api.project.util import (
     is_valid_unquoted_identifier,
     to_identifier,
     to_string_literal,
+    escape_like_pattern,
 )
 
 VALID_UNQUOTED_IDENTIFIERS = (
@@ -162,3 +163,17 @@ def test_is_valid_string_literal(literal, valid):
 )
 def test_to_string_literal(raw_string, literal):
     assert to_string_literal(raw_string) == literal
+
+
+@pytest.mark.parametrize(
+    "raw_string, escaped",
+    [
+        (r"underscore_table", r"underscore\\_table"),
+        (r"percent%%table", r"percent\\%\\%table"),
+        (r"__many__under__scores__", r"\\_\\_many\\_\\_under\\_\\_scores\\_\\_"),
+        (r"mixed_underscore%percent", r"mixed\\_underscore\\%percent"),
+        (r"regular$table", r"regular$table"),
+    ],
+)
+def test_escape_like_pattern(raw_string, escaped):
+    assert escape_like_pattern(raw_string) == escaped

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -186,26 +186,15 @@ def test_get_repository_url(mock_get_row, mock_cursor):
 
 
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.get_repository_url"
+    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.get_repository_row"
 )
-@pytest.mark.parametrize(
-    "input_url, expected_url",
-    [
-        ("https://www.example.com", "www.example.com"),
-        ("www.example.com", "www.example.com"),
-        (
-            "http://qa.registry.sfc.com/db/schema/repo",
-            "qa.registry.sfc.com/db/schema/repo",
-        ),
-        ("//qa.registry.sfc.com/db/schema/repo", "qa.registry.sfc.com/db/schema/repo"),
-        ("qa.registry.sfc.com/db/schema/repo", "qa.registry.sfc.com/db/schema/repo"),
-    ],
-)
-def test_get_repository_url_strip_scheme(mock_url, input_url, expected_url):
-    repo_name = "test_repo"
-    mock_url.return_value = input_url
-    assert (
-        ImageRepositoryManager().get_repository_url_strip_scheme(repo_name)
-        == expected_url
+def test_get_repository_url_no_scheme(mock_get_row, mock_cursor):
+    expected_row = MOCK_ROWS_DICT[0]
+    mock_get_row.return_value = expected_row
+    result = ImageRepositoryManager().get_repository_url(
+        repo_name="IMAGES", with_scheme=False
     )
-    mock_url.assert_called_once_with(repo_name)
+    mock_get_row.assert_called_once_with("IMAGES")
+    assert isinstance(expected_row, Dict)
+    assert "repository_url" in expected_row
+    assert result == expected_row["repository_url"]

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -136,44 +136,6 @@ def test_get_repository_url_cli(mock_url, runner):
 @mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_schema_query"
 )
-def test_get_repository_row_quoted_identifier(mock_execute, mock_cursor):
-    mock_row_quoted = [
-        "2023-01-01 00:00:00",
-        "ImAgEs",
-        "DB",
-        "SCHEMA",
-        "orgname-alias.registry.snowflakecomputing.com/DB/SCHEMA/IMAGES",
-        "ROLE",
-        "ROLE",
-        "",
-    ]
-    mock_row_dict_quoted = MOCK_ROWS_DICT + [
-        {col_name: col_val for col_name, col_val in zip(MOCK_COLUMNS, mock_row_quoted)}
-    ]
-
-    # sanity check
-    assert len(mock_row_dict_quoted) == 2
-    assert mock_row_dict_quoted[0]["name"] == "IMAGES"
-    assert mock_row_dict_quoted[1]["name"] == "ImAgEs"
-    assert mock_row_dict_quoted[0] != mock_row_dict_quoted[1]
-
-    mock_execute.return_value = mock_cursor(
-        rows=mock_row_dict_quoted, columns=MOCK_COLUMNS
-    )
-    result = ImageRepositoryManager().get_repository_row("IMAGES")
-    assert result == mock_row_dict_quoted[0]
-    mock_execute.return_value = mock_cursor(
-        rows=mock_row_dict_quoted, columns=MOCK_COLUMNS
-    )
-
-    # note the double quotes around ImAgEs
-    result = ImageRepositoryManager().get_repository_row('"ImAgEs"')
-    assert result == mock_row_dict_quoted[1]
-
-
-@mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_schema_query"
-)
 def test_get_repository_row(mock_execute, mock_cursor):
     mock_execute.return_value = mock_cursor(
         rows=MOCK_ROWS_DICT,

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -140,9 +140,6 @@ def test_list_tags(
     "snowflake.cli.plugins.spcs.image_repository.commands.ImageRepositoryManager._conn"
 )
 def test_get_repository_url_cli(mock_conn, mock_execute_query, runner, mock_cursor):
-    mock_conn.database = "DB"
-    mock_conn.schema = "SCHEMA"
-    mock_conn.role = "MY_ROLE"
     repo_url = "orgname-alias.registry.snowflakecomputing.com/DB/SCHEMA/IMAGES"
     mock_execute_query.return_value = mock_cursor(
         rows=[

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -123,7 +123,7 @@ def test_list_tags(
 
 
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.get_repository_url_strip_scheme"
+    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.get_repository_url"
 )
 def test_get_repository_url_cli(mock_url, runner):
     repo_url = "repotest.registry.snowflakecomputing.com/db/schema/IMAGES"

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -1,3 +1,4 @@
+import snowflake.cli.plugins.spcs.image_repository.manager
 from tests.testing_utils.fixtures import *
 import json
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
@@ -148,7 +149,10 @@ def test_get_repository_row(mock_execute, mock_cursor):
 @mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_schema_query"
 )
-def test_get_repository_row_no_repo_found(mock_execute, mock_cursor):
+@mock.patch(
+    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._conn"
+)
+def test_get_repository_row_no_repo_found(mock_execute, mock_connection, mock_cursor):
     mock_execute.return_value = mock_cursor(
         rows=[],
         columns=MOCK_COLUMNS,
@@ -156,7 +160,7 @@ def test_get_repository_row_no_repo_found(mock_execute, mock_cursor):
 
     with pytest.raises(ClickException) as expected_error:
         ImageRepositoryManager().get_repository_row("IMAGES")
-    assert "does not exist or not authorized" in expected_error.value.message
+    assert "does not exist in database" in expected_error.value.message
 
 
 @mock.patch(

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -152,15 +152,19 @@ def test_get_repository_row(mock_execute, mock_cursor):
 @mock.patch(
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._conn"
 )
-def test_get_repository_row_no_repo_found(mock_execute, mock_connection, mock_cursor):
+def test_get_repository_row_no_repo_found(mock_conn, mock_execute, mock_cursor):
     mock_execute.return_value = mock_cursor(
         rows=[],
         columns=MOCK_COLUMNS,
     )
-
+    mock_conn.database = "DB"
+    mock_conn.schema = "SCHEMA"
     with pytest.raises(ClickException) as expected_error:
         ImageRepositoryManager().get_repository_row("IMAGES")
-    assert "does not exist in database" in expected_error.value.message
+    assert (
+        "Image repository 'IMAGES' does not exist in database 'DB' and schema 'SCHEMA' or not authorized."
+        == expected_error.value.message
+    )
 
 
 @mock.patch(
@@ -173,7 +177,10 @@ def test_get_repository_row_more_than_one_repo(mock_execute, mock_cursor):
     )
     with pytest.raises(ClickException) as expected_error:
         ImageRepositoryManager().get_repository_row("IMAGES")
-    assert "Found more than one image repository" in expected_error.value.message
+    assert (
+        "Found more than one image repository with name matching 'IMAGES'. This is unexpected."
+        == expected_error.value.message
+    )
 
 
 @mock.patch(

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -131,3 +131,43 @@ def test_list_tags(
     assert json.loads(result.output) == [
         {"tag": "/DB/SCHEMA/IMAGES/super-cool-repo:1.2.0"}
     ]
+
+
+@mock.patch(
+    "snowflake.cli.plugins.spcs.image_repository.commands.ImageRepositoryManager._execute_query"
+)
+@mock.patch(
+    "snowflake.cli.plugins.spcs.image_repository.commands.ImageRepositoryManager._conn"
+)
+def test_get_repository_url_cli(mock_conn, mock_execute_query, runner, mock_cursor):
+    mock_conn.database = "DB"
+    mock_conn.schema = "SCHEMA"
+    mock_conn.role = "MY_ROLE"
+    repo_url = "orgname-alias.registry.snowflakecomputing.com/DB/SCHEMA/IMAGES"
+    mock_execute_query.return_value = mock_cursor(
+        rows=[
+            [
+                "2023-01-01 00:00:00",
+                "IMAGES",
+                "DB",
+                "SCHEMA",
+                repo_url,
+                "ROLE",
+                "ROLE",
+                "",
+            ]
+        ],
+        columns=[
+            "date",
+            "name",
+            "db",
+            "schema",
+            "registry",
+            "role",
+            "unknown",
+            "unkown2",
+        ],
+    )
+    result = runner.invoke(["spcs", "image-repository", "url", "IMAGES"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == repo_url

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -11,6 +11,7 @@ INTEGRATION_REPOSITORY = "snowcli_repository"
 
 @pytest.mark.integration
 def test_list_images_tags(runner):
+    # test assumes the testing environment has been set up with /SNOWCLI_DB/PUBLIC/snowcli_repository/snowpark_test:1
     _list_images(runner)
     _list_tags(runner)
 

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -65,7 +65,7 @@ def _list_tags(runner):
 
 @pytest.mark.integration
 def test_get_repo_url(runner, snowflake_session, test_database):
-    repo_name = ObjectNameProvider("Test_Repo").create_and_get_next_object_name()
+    repo_name = ObjectNameProvider("TEST_REPO").create_and_get_next_object_name()
     snowflake_session.execute_string(f"create image repository {repo_name}")
 
     created_repo = snowflake_session.execute_string(
@@ -73,7 +73,7 @@ def test_get_repo_url(runner, snowflake_session, test_database):
     )
     created_row = row_from_snowflake_session(created_repo)[0]
     created_name = created_row["name"]
-    assert created_name.lower() == repo_name.lower()
+    assert created_name == repo_name.upper()
 
     expect_url = created_row["repository_url"]
     result = runner.invoke_with_connection(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added a new convenience command of `snow spcs image-repository url` that returns the full URL given a repository name. Note that image repositories do not allow for quoted identifiers, so I have added checks that repository name inputs must be unquoted identifiers.

**Example Usage**
<img width="1055" alt="get_repo_url" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/f0ae3902-8810-4fce-9754-92f9aca6c339">
