### PR TITLE
SNOW-1037643: Adding slash before output of list-images

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,7 @@
   * `snow spcs pool create` and `snow spcs service create` have been updated with new options to match SQL interface
   * Added new `image-repository` command group under `spcs`. Moved `list-images` and `list-tags` from `registry` to `image-repository`.
   * Removed `snow snowpark jobs` command.
+  * `list-images` and `list-tags` now outputs image names with a slash at the beginning (e.g. /db/schema/repo/image). Image name input to `list-tags` requires new format.
 
 * Streamlit changes
   * `snow streamlit deploy` is requiring `snowflake.yml` project file with a Streamlit definition.

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -91,7 +91,6 @@ def list_tags(
     bearer_login = RegistryManager().login_to_registry(api_url)
 
     image_realname = "/".join(image_name.split("/")[4:])
-
     tags = []
     query: Optional[str] = f"{api_url}/{image_realname}/tags/list?n=10"
 

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -61,7 +61,7 @@ def list_images(
 
     images = []
     for repo in repos:
-        prefix = f"{database}/{schema}/{repo_name}/"
+        prefix = f"/{database}/{schema}/{repo_name}/"
         repo = repo.replace("baserepo/", prefix)
         images.append({"image": repo})
 
@@ -79,7 +79,7 @@ def list_tags(
         ...,
         "--image_name",
         "-i",
-        help="Name of the image as shown in the output of list-images",
+        help="Fully qualified name of the image as shown in the output of list-images",
     ),
     **options,
 ) -> CollectionResult:
@@ -90,7 +90,7 @@ def list_tags(
     api_url = repository_manager.get_repository_api_url(url)
     bearer_login = RegistryManager().login_to_registry(api_url)
 
-    image_realname = "/".join(image_name.split("/")[3:])
+    image_realname = "/".join(image_name.split("/")[4:])
 
     tags = []
     query: Optional[str] = f"{api_url}/{image_realname}/tags/list?n=10"

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -58,7 +58,7 @@ def test_list_images(
     )
 
     assert result.exit_code == 0, result.output
-    assert json.loads(result.output) == [{"image": "DB/SCHEMA/IMAGES/super-cool-repo"}]
+    assert json.loads(result.output) == [{"image": "/DB/SCHEMA/IMAGES/super-cool-repo"}]
 
 
 @mock.patch("snowflake.cli.plugins.spcs.image_repository.commands.requests.get")
@@ -121,7 +121,7 @@ def test_list_tags(
             "list-tags",
             "IMAGES",
             "--image_name",
-            "DB/SCHEMA/IMAGES/super-cool-repo",
+            "/DB/SCHEMA/IMAGES/super-cool-repo",
             "--format",
             "JSON",
         ]
@@ -129,5 +129,5 @@ def test_list_tags(
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == [
-        {"tag": "DB/SCHEMA/IMAGES/super-cool-repo:1.2.0"}
+        {"tag": "/DB/SCHEMA/IMAGES/super-cool-repo:1.2.0"}
     ]

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -31,7 +31,7 @@ def _list_images(runner):
     assert contains_row_with(
         result.json,
         {
-            "image": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test"
+            "image": f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test"
         },
     )
 
@@ -45,7 +45,7 @@ def _list_tags(runner):
             "list-tags",
             "snowcli_repository",
             "--image_name",
-            f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test",
+            f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test",
             "--database",
             INTEGRATION_DATABASE,
             "--schema",
@@ -56,6 +56,6 @@ def _list_tags(runner):
     assert contains_row_with(
         result.json,
         {
-            "tag": f"{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test:1"
+            "tag": f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test:1"
         },
     )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
(Requested by Native Apps)
Previously, the output of list images was formatted as DATABASE/SCHEMA/REPOSITORY/IMAGE. However, the (fully qualified) image name that users would actually use in account or in service specifications is **/** DATABASE/SCHEMA/REPOSITORY/IMAGE. Changed output of list images to add this slash.

**Example Usage**:
<img width="892" alt="list_images_slash" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/00722d11-c704-46be-9770-a0f1eb145a05">
<img width="1645" alt="list_tags_slash" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/9df5aeb5-7b24-421a-9ba6-6f5ad6def2e6">

