### PR TITLE
SNOW-1039187: Renaming `spcs pool stop` to `stop-all`.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,6 +38,7 @@ arguments](https://docs.snowflake.com/en/developer-guide/udf/udf-calling-sql#cal
   * Added new `image-repository` command group under `spcs`. Moved `list-images` and `list-tags` from `image-registry` to `image-repository`.
   * Removed `snow snowpark jobs` command.
   * `list-images` and `list-tags` now outputs image names with a slash at the beginning (e.g. /db/schema/repo/image). Image name input to `list-tags` requires new format.
+  * `snow spcs compute-pool stop` has been removed in favor of `snow spcs compute-pool stop-all`.
 
 * Streamlit changes
   * `snow streamlit deploy` is requiring `snowflake.yml` project file with a Streamlit definition.

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -69,10 +69,10 @@ def create(
     return SingleQueryResult(cursor)
 
 
-@app.command()
+@app.command("stop-all")
 @with_output
 @global_options_with_connection
-def stop(
+def stop_all(
     name: str = typer.Argument(..., help="Name of the compute pool."), **options
 ) -> CommandResult:
     """

--- a/tests_integration/spcs/test_cp.py
+++ b/tests_integration/spcs/test_cp.py
@@ -39,7 +39,7 @@ def test_cp(runner, snowflake_session):
     assert contains_row_with(result.json, row_from_snowflake_session(expect)[0])
 
     result = runner.invoke_with_connection_json(
-        ["spcs", "compute-pool", "stop", cp_name]
+        ["spcs", "compute-pool", "stop-all", cp_name]
     )
     assert contains_row_with(
         result.json,


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Renamed `spcs pool stop` to `spcs pool stop-all`.**(Behavior Change)**. 

**Is it possible to include this change in 2.0RC? If not, I could deprecate `spcs pool stop` instead of removing it and make it a hidden alias for `spcs pool stop-all` to release after 2.0**.


