### PR TITLE
SNOW-1039276: Rename `pool` to `compute-pool`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,11 +24,12 @@
   * Coverage commands were removed. To measure coverage of your procedures or functions use coverage locally.
 
 * Snowpark Containers services commands
-  * `compute-pool` commands and its alias `cp` were renamed to `pool` commands.
+  * `cp` alias for `compute-pool` commands was removed.
   * `services` commands were renamed to `service`
-  * `pool`, `service`, and `image-registry` commands were moved from `snowpark` group to a new `spcs` group (`registry` was renamed to `image-registry`).
-  * `snow spcs pool create` and `snow spcs service create` have been updated with new options to match SQL interface
-  * Added new `image-repository` command group under `spcs`. Moved `list-images` and `list-tags` from `registry` to `image-repository`.
+  * `registry` commands were renamed to `image-registry`
+  * `compute-pool`, `service`, and `image-registry` commands were moved from `snowpark` group to a new `spcs` group.
+  * `snow spcs compute-pool create` and `snow spcs service create` have been updated with new options to match SQL interface
+  * Added new `image-repository` command group under `spcs`. Moved `list-images` and `list-tags` from `image-registry` to `image-repository`.
   * Removed `snow snowpark jobs` command.
 
 * Streamlit changes

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -13,7 +13,7 @@ from snowflake.cli.plugins.spcs.compute_pool.manager import ComputePoolManager
 
 app = typer.Typer(
     context_settings=DEFAULT_CONTEXT_SETTINGS,
-    name="pool",
+    name="compute-pool",
     help="Manages compute pools.",
 )
 

--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -51,7 +51,7 @@ def test_create_pool_cli_defaults(mock_create, runner):
     result = runner.invoke(
         [
             "spcs",
-            "pool",
+            "compute-pool",
             "create",
             "--name",
             "test_pool",
@@ -77,7 +77,7 @@ def test_create_pool_cli(mock_create, runner):
     result = runner.invoke(
         [
             "spcs",
-            "pool",
+            "compute-pool",
             "create",
             "--name",
             "test_pool",

--- a/tests_integration/spcs/test_cp.py
+++ b/tests_integration/spcs/test_cp.py
@@ -16,7 +16,7 @@ def test_cp(runner, snowflake_session):
     result = runner.invoke_with_connection_json(
         [
             "spcs",
-            "pool",
+            "compute-pool",
             "create",
             "--name",
             cp_name,
@@ -38,7 +38,9 @@ def test_cp(runner, snowflake_session):
     assert result.json, result.output
     assert contains_row_with(result.json, row_from_snowflake_session(expect)[0])
 
-    result = runner.invoke_with_connection_json(["spcs", "pool", "stop", cp_name])
+    result = runner.invoke_with_connection_json(
+        ["spcs", "compute-pool", "stop", cp_name]
+    )
     assert contains_row_with(
         result.json,
         {"status": "Statement executed successfully."},


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Renaming `spcs pool` command group to `spcs compute-pool` based on following proposal: [SPCS SnowCLI Support](https://docs.google.com/document/d/1GePLNDltNSbu1utuwUx0m7AZEA14fH8HaPAlUIKUXd0/edit#heading=h.wfnqxxuj4vft). Note that this is a partial revert of a previous change that removed `compute-pool` and `cp` in favor of `pool`.

**Usage Examples**:
<img width="1648" alt="image" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/30dcbb59-fa9c-42b1-bc6e-bb017339f414">
<img width="800" alt="image" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/7ef72300-c774-4801-952c-4d0a84c482a9">

