### PR TITLE
SNOW-1011779: Changing SPCS services integration test to use persistent service instead of job.

### DIFF
--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -12,7 +12,6 @@ from tests.spcs.test_common import SPCS_OBJECT_EXISTS_ERROR
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.plugins.spcs.common import (
     NoPropertiesProvidedError,
-    strip_empty_lines,
 )
 
 

--- a/tests_integration/spcs/docker/bootstrap_containers_setup.sh
+++ b/tests_integration/spcs/docker/bootstrap_containers_setup.sh
@@ -1,5 +1,6 @@
 set -e
+export SF_REGISTRY="$(snow spcs image-registry url -c int)"
 echo "Using registry: ${SF_REGISTRY}"
-docker build --platform linux/amd64 -t "${SF_REGISTRY}.registry.snowflakecomputing.com/snowcli_db/public/snowcli_repository/snowpark_test:1" .
-snow registry token --format=json -c int | docker login "${SF_REGISTRY}.registry.snowflakecomputing.com/snowcli_db/public/snowcli_repository" -u 0sessiontoken --password-stdin
-docker push "${SF_REGISTRY}.registry.snowflakecomputing.com/snowcli_db/public/snowcli_repository/snowpark_test:1"
+docker build --platform linux/amd64 -t "${SF_REGISTRY}/snowcli_db/public/snowcli_repository/snowpark_test_echo:1" .
+snow spcs image-registry token --format=json -c int | docker login "${SF_REGISTRY}/snowcli_db/public/snowcli_repository" -u 0sessiontoken --password-stdin
+docker push "${SF_REGISTRY}/snowcli_db/public/snowcli_repository/snowpark_test_echo:1"

--- a/tests_integration/spcs/spec/spec.yml
+++ b/tests_integration/spcs/spec/spec.yml
@@ -1,4 +1,9 @@
 spec:
   containers:
-    - name: hello-world
-      image: /snowcli_db/public/snowcli_repository/snowpark_test:1
+  - name: echo-test
+    image: /snowcli_db/public/snowcli_repository/snowpark_test_echo:1
+    env:
+      SERVER_PORT: 8000
+    readinessProbe:
+      port: 8000
+      path: /healthcheck

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -11,7 +11,7 @@ INTEGRATION_REPOSITORY = "snowcli_repository"
 
 @pytest.mark.integration
 def test_list_images_tags(runner):
-    # test assumes the testing environment has been set up with /SNOWCLI_DB/PUBLIC/snowcli_repository/snowpark_test:1
+    # test assumes the testing environment has been set up with /SNOWCLI_DB/PUBLIC/snowcli_repository/snowpark_test_echo:1
     _list_images(runner)
     _list_tags(runner)
 

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -33,7 +33,7 @@ def _list_images(runner):
     assert contains_row_with(
         result.json,
         {
-            "image": f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test"
+            "image": f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo"
         },
     )
 
@@ -46,7 +46,7 @@ def _list_tags(runner):
             "list-tags",
             "snowcli_repository",
             "--image_name",
-            f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test",
+            f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo",
             "--database",
             INTEGRATION_DATABASE,
             "--schema",
@@ -57,7 +57,7 @@ def _list_tags(runner):
     assert contains_row_with(
         result.json,
         {
-            "tag": f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test:1"
+            "tag": f"/{INTEGRATION_DATABASE}/{INTEGRATION_SCHEMA}/{INTEGRATION_REPOSITORY}/snowpark_test_echo:1"
         },
     )
 

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -1,8 +1,8 @@
+import uuid
 from typing import Tuple
 
 import pytest
 
-from tests_integration.testing_utils.naming_utils import ObjectNameProvider
 from tests_integration.testing_utils.snowpark_services_utils import (
     SnowparkServicesTestSetup,
     SnowparkServicesTestSteps,
@@ -40,7 +40,7 @@ def _test_setup(
 
 @pytest.fixture
 def _test_steps(_test_setup):
-    service_name = ObjectNameProvider("spcs_service").create_and_get_next_object_name()
+    service_name = f"spcs_service_{uuid.uuid4().hex}"
     test_steps = SnowparkServicesTestSteps(_test_setup)
 
     yield test_steps, service_name

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Tuple
 
 import pytest
 
@@ -9,17 +10,18 @@ from tests_integration.testing_utils.snowpark_services_utils import (
 
 
 @pytest.mark.integration
-def test_services(_test_steps: SnowparkServicesTestSteps):
-    service_name = f"snowpark_service_{uuid.uuid4().hex}"
+def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
 
-    _test_steps.create_service(service_name)
-    _test_steps.status_should_return_service(service_name)
-    _test_steps.list_should_return_service(service_name)
-    _test_steps.wait_until_service_will_be_finish(service_name)
-    _test_steps.logs_should_return_service_logs(service_name)
-    _test_steps.describe_should_return_service(service_name)
-    _test_steps.drop_service(service_name)
-    _test_steps.list_should_not_return_service(service_name)
+    test_steps, service_name = _test_steps
+
+    test_steps.create_service(service_name)
+    test_steps.status_should_return_service(service_name)
+    test_steps.list_should_return_service(service_name)
+    test_steps.wait_until_service_is_ready(service_name)
+    test_steps.logs_should_return_service_logs(service_name)
+    test_steps.describe_should_return_service(service_name)
+    test_steps.drop_service(service_name)
+    test_steps.list_should_not_return_service(service_name)
 
 
 @pytest.fixture
@@ -38,4 +40,12 @@ def _test_setup(
 
 @pytest.fixture
 def _test_steps(_test_setup):
-    yield SnowparkServicesTestSteps(_test_setup)
+    service_name = f"snowpark_service_{uuid.uuid4().hex}"
+    test_steps = SnowparkServicesTestSteps(_test_setup)
+
+    yield test_steps, service_name
+
+    service_fqn = f"{test_steps.database}.{test_steps.schema}.{service_name}"
+    _test_setup.snowflake_session.execute_string(
+        f"drop service if exists {service_fqn}"
+    )

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -1,8 +1,8 @@
-import uuid
 from typing import Tuple
 
 import pytest
 
+from tests_integration.testing_utils.naming_utils import ObjectNameProvider
 from tests_integration.testing_utils.snowpark_services_utils import (
     SnowparkServicesTestSetup,
     SnowparkServicesTestSteps,
@@ -40,7 +40,7 @@ def _test_setup(
 
 @pytest.fixture
 def _test_steps(_test_setup):
-    service_name = f"snowpark_service_{uuid.uuid4().hex}"
+    service_name = ObjectNameProvider("spcs_service").create_and_get_next_object_name()
     test_steps = SnowparkServicesTestSteps(_test_setup)
 
     yield test_steps, service_name

--- a/tests_integration/testing_utils/snowpark_services_utils.py
+++ b/tests_integration/testing_utils/snowpark_services_utils.py
@@ -118,27 +118,14 @@ class SnowparkServicesTestSteps:
             status = self._execute_status(service_name)
             if contains_row_with(status.json, target_status):
                 return
-            elif contains_row_with(status.json, {"status": "FAILED"}):
-                logs = self._execute_logs(service_name, 20)
-                pytest.fail(
-                    dedent(
-                        f"""
-                        {service_name} service failed before reaching target state.
-                        target:
-                        {json.dumps(target_status)}
-                        {self._current_state_and_describe_str(service_name)}
-                        logs (last 20 lines):
-                        {logs.output}
-                        """
-                    ).strip()
-                )
             time.sleep(10)
         error_message = dedent(
             f"""
             {service_name} service didn't reach target state in {max_duration} seconds.
             target:
             {json.dumps(target_status)}
-            {self._current_state_and_describe_str(service_name)}
+            
+            {self._current_state_describe_logs_str(service_name)}
             """
         ).strip()
         pytest.fail(error_message)
@@ -196,15 +183,18 @@ class SnowparkServicesTestSteps:
             ],
         )
 
-    def _current_state_and_describe_str(self, service_name: str) -> str:
+    def _current_state_describe_logs_str(self, service_name: str) -> str:
         status = self._execute_status(service_name)
         describe = self._execute_describe(service_name)
+        logs = self._execute_logs(service_name, 20)
         return dedent(
             f"""
             current state:
             {json.dumps(status.json)}
             current describe:
             {json.dumps(describe.json)}
+            logs:
+            {logs.output if logs.exit_code == 0 else "No logs available."}
             """
         ).strip()
 

--- a/tests_integration/testing_utils/snowpark_services_utils.py
+++ b/tests_integration/testing_utils/snowpark_services_utils.py
@@ -119,7 +119,7 @@ class SnowparkServicesTestSteps:
         }
 
     def wait_until_service_is_ready(self, service_name: str) -> None:
-        self._wait_until_service_reaches_state(service_name, "READY", 300)
+        self._wait_until_service_reaches_state(service_name, "READY", 900)
 
     def _wait_until_service_reaches_state(
         self, service_name: str, target_status: Union[str, dict], max_duration: int

--- a/tests_integration/testing_utils/snowpark_services_utils.py
+++ b/tests_integration/testing_utils/snowpark_services_utils.py
@@ -1,6 +1,7 @@
 import json
 import math
 import time
+from textwrap import dedent
 from typing import Union
 
 import pytest
@@ -133,8 +134,20 @@ class SnowparkServicesTestSteps:
             if contains_row_with(status.json, target_status):
                 return
             elif contains_row_with(status.json, {"status": "FAILED"}):
+                describe = self._setup.runner.invoke_with_connection_json(
+                    ["object", "describe", "service", service_name]
+                )
                 pytest.fail(
-                    f"{service_name} service failed before reaching target state:\n{json.dumps(target_status)}"
+                    dedent(
+                        f"""
+                    {service_name} service failed before reaching target state:
+                    {json.dumps(target_status)}
+                    current state:
+                    {json.dumps(status)}
+                    current describe:
+                    {json.dumps(describe)}
+                    """
+                    )
                 )
             time.sleep(10)
         status = self._execute_status(service_name)

--- a/tests_integration/testing_utils/snowpark_services_utils.py
+++ b/tests_integration/testing_utils/snowpark_services_utils.py
@@ -1,10 +1,17 @@
+import json
+import math
 import time
+from typing import Union
 
 import pytest
 from snowflake.connector import SnowflakeConnection
 
 from tests_integration.conftest import SnowCLIRunner
 from tests_integration.test_utils import contains_row_with, not_contains_row_with
+from tests_integration.testing_utils.assertions.test_result_assertions import (
+    assert_that_result_is_successful_and_output_json_contains,
+    assert_that_result_is_successful_and_output_json_equals,
+)
 
 
 class SnowparkServicesTestSetup:
@@ -23,6 +30,7 @@ class SnowparkServicesTestSteps:
     compute_pool = "snowcli_compute_pool"
     database = "snowcli_db"
     schema = "public"
+    container_name = "echo-test"
 
     def __init__(self, setup: SnowparkServicesTestSetup):
         self._setup = setup
@@ -37,22 +45,22 @@ class SnowparkServicesTestSteps:
                 "--compute-pool",
                 self.compute_pool,
                 "--spec-path",
-                f"{self._setup.test_root_path}/spcs/spec/spec.yml",
+                self._get_spec_path(),
                 "--database",
                 self.database,
                 "--schema",
                 self.schema,
             ],
         )
-        assert result.json == {
-            "status": f"Service {service_name.upper()} successfully created."
-        }, result.output
+        assert_that_result_is_successful_and_output_json_equals(
+            result, {"status": f"Service {service_name.upper()} successfully created."}
+        )
 
     def status_should_return_service(self, service_name: str) -> None:
         result = self._execute_status(service_name)
-        assert contains_row_with(
-            result.json,
-            {"containerName": "hello-world", "serviceName": service_name.upper()},
+        assert_that_result_is_successful_and_output_json_contains(
+            result,
+            {"containerName": self.container_name, "serviceName": service_name.upper()},
         )
 
     def logs_should_return_service_logs(self, service_name: str) -> None:
@@ -63,7 +71,7 @@ class SnowparkServicesTestSteps:
                 "logs",
                 service_name,
                 "--container-name",
-                "hello-world",
+                self.container_name,
                 "--instance-id",
                 "0",
                 "--database",
@@ -75,7 +83,7 @@ class SnowparkServicesTestSteps:
         assert result.output
         # Assert this instead of full payload due to log coloring
         assert service_name in result.output
-        assert "Hello World!" in result.output
+        assert '"GET /healthcheck HTTP/1.1" 200 -' in result.output
 
     def list_should_return_service(self, service_name: str) -> None:
         result = self._execute_list()
@@ -110,23 +118,35 @@ class SnowparkServicesTestSteps:
             "status": f"{service_name.upper()} successfully dropped."
         }
 
-    def wait_until_service_will_be_finish(self, service_name: str) -> None:
-        wait_counter = 0
-        max_counter = 90
-        while wait_counter < max_counter:
+    def wait_until_service_is_ready(self, service_name: str) -> None:
+        self._wait_until_service_reaches_state(service_name, "READY", 300)
+
+    def _wait_until_service_reaches_state(
+        self, service_name: str, target_status: Union[str, dict], max_duration: int
+    ):
+        assert max_duration > 0
+        max_counter = math.ceil(max_duration / 10)
+        if isinstance(target_status, str):
+            target_status = {"status": target_status}
+        for i in range(max_counter):
             status = self._execute_status(service_name)
-            if contains_row_with(
-                status.json,
-                {
-                    "serviceName": service_name.upper(),
-                    "status": "DONE",
-                    "message": "Completed successfully",
-                },
-            ):
+            if contains_row_with(status.json, target_status):
                 return
+            elif contains_row_with(status.json, {"status": "FAILED"}):
+                pytest.fail(
+                    f"{service_name} service failed before reaching target state:\n{json.dumps(target_status)}"
+                )
             time.sleep(10)
-            wait_counter += 1
-        pytest.fail(f"{service_name} service didn't finish in 15 minutes")
+        status = self._execute_status(service_name)
+
+        error_message = f"""
+{service_name} service didn't reach target state in {max_duration} seconds.
+target:
+{json.dumps(target_status)}
+current:
+{json.dumps(status.json)}
+"""
+        pytest.fail(error_message)
 
     def _execute_status(self, service_name: str):
         return self._setup.runner.invoke_with_connection_json(
@@ -150,3 +170,6 @@ class SnowparkServicesTestSteps:
                 "service",
             ],
         )
+
+    def _get_spec_path(self):
+        return f"{self._setup.test_root_path}/spcs/spec/spec.yml"

--- a/tests_integration/testing_utils/snowpark_services_utils.py
+++ b/tests_integration/testing_utils/snowpark_services_utils.py
@@ -85,7 +85,7 @@ class SnowparkServicesTestSteps:
                 "object",
                 "describe",
                 "service",
-                f"{self.database}.{self.schema}.{service_name}",
+                self._get_fqn(service_name),
             ],
         )
         assert result.json
@@ -97,7 +97,7 @@ class SnowparkServicesTestSteps:
                 "object",
                 "drop",
                 "service",
-                f"{self.database}.{self.schema}.{service_name}",
+                self._get_fqn(service_name),
             ],
         )
         assert result.json[0] == {  # type: ignore
@@ -208,5 +208,8 @@ class SnowparkServicesTestSteps:
             """
         ).strip()
 
-    def _get_spec_path(self):
+    def _get_spec_path(self) -> str:
         return f"{self._setup.test_root_path}/spcs/spec/spec.yml"
+
+    def _get_fqn(self, service_name) -> str:
+        return f"{self.database}.{self.schema}.{service_name}"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Currently integration tests for SPCS services simply execute 'hello world' then terminate. This makes it difficult to test lifecycle methods such as `suspend` and `resume`. Furthermore, services are meant to be persistent, not single-execution (that's what jobs are for). In fact, our integration tests currently check that our service reaches a DONE state, which is not technically a supported state for services ([reference](https://docs.snowflake.com/en/sql-reference/functions/system_get_service_status?utm_source=snowscope&utm_medium=serp&utm_term=service+status)).

I propose that for our integration tests we deploy a service that echos whatever is sent to it. This is the service created in the [SPCS tutorial.](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/tutorials/tutorial-1). Later on, this will also let us test functions like SHOW ENDPOINTS.
