### PR TITLE
SNOW-1011761: Adding `image-repository create` command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@
 * Added `create` command to `spcs image-repository`.
 ## Fixes and improvements
 * Restricted permissions of automatically created files
+* Fixed bug where `spcs service create` would not throw error if service with specified name already exists.
 
 
 # v2.0.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@
 * Added convenience function `spcs image-repository url <repo_name>`.
 * Added `suspend` and `resume` commands for `spcs compute-pool`.
 
+* Added `create` command to `spcs image-repository`.
 ## Fixes and improvements
 * Restricted permissions of automatically created files
 

--- a/src/snowflake/cli/plugins/spcs/common.py
+++ b/src/snowflake/cli/plugins/spcs/common.py
@@ -74,4 +74,4 @@ def handle_object_already_exists(
             name=unquote_identifier(object_name),
         )
     else:
-        raise
+        raise error

--- a/src/snowflake/cli/plugins/spcs/common.py
+++ b/src/snowflake/cli/plugins/spcs/common.py
@@ -4,6 +4,10 @@ import sys
 from typing import TextIO
 
 from click import ClickException
+from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.exceptions import ObjectAlreadyExistsError
+from snowflake.cli.api.project.util import unquote_identifier
+from snowflake.connector.errors import ProgrammingError
 
 if not sys.stdout.closed and sys.stdout.isatty():
     GREEN = "\033[32m"
@@ -59,3 +63,15 @@ def validate_and_set_instances(min_instances, max_instances, instance_name):
             f"max_{instance_name} must be greater or equal to min_{instance_name}"
         )
     return max_instances
+
+
+def handle_object_already_exists(
+    error: ProgrammingError, object_type: ObjectType, object_name: str
+):
+    if error.errno == 2002:
+        raise ObjectAlreadyExistsError(
+            object_type=object_type,
+            name=unquote_identifier(object_name),
+        )
+    else:
+        raise

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -9,7 +9,7 @@ from snowflake.cli.api.commands.decorators import (
     with_output,
 )
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
-from snowflake.cli.api.output.types import CollectionResult, MessageResult
+from snowflake.cli.api.output.types import CollectionResult, SingleQueryResult, MessageResult
 from snowflake.cli.api.project.util import is_valid_unquoted_identifier
 from snowflake.cli.plugins.spcs.image_registry.manager import RegistryManager
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
@@ -34,6 +34,19 @@ REPO_NAME_ARGUMENT = typer.Argument(
     help="Name of the image repository. Only unquoted identifiers are supported for image repositories.",
     callback=_repo_name_callback,
 )
+
+
+@app.command()
+@with_output
+@global_options_with_connection
+def create(
+    name: str = REPO_NAME_ARGUMENT,
+    **options,
+):
+    """
+    Creates a new image repository in the current schema.
+    """
+    return SingleQueryResult(ImageRepositoryManager().create(name=name))
 
 
 @app.command("list-images")

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -9,7 +9,11 @@ from snowflake.cli.api.commands.decorators import (
     with_output,
 )
 from snowflake.cli.api.commands.flags import DEFAULT_CONTEXT_SETTINGS
-from snowflake.cli.api.output.types import CollectionResult, SingleQueryResult, MessageResult
+from snowflake.cli.api.output.types import (
+    CollectionResult,
+    MessageResult,
+    SingleQueryResult,
+)
 from snowflake.cli.api.project.util import is_valid_unquoted_identifier
 from snowflake.cli.plugins.spcs.image_registry.manager import RegistryManager
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -3,15 +3,13 @@ from urllib.parse import urlparse
 
 from click import ClickException
 from snowflake.cli.api.constants import ObjectType
-from snowflake.cli.api.exceptions import ObjectAlreadyExistsError
 from snowflake.cli.api.project.util import (
     escape_like_pattern,
     is_valid_unquoted_identifier,
-    unquote_identifier
 )
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.spcs.common import handle_object_already_exists
-from snowflake.connector.cursor import SnowflakeCursor, DictCursor
+from snowflake.connector.cursor import DictCursor
 from snowflake.connector.errors import ProgrammingError
 
 

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -10,8 +10,9 @@ from snowflake.cli.api.project.util import (
     unquote_identifier
 )
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.cli.plugins.spcs.common import handle_object_already_exists
+from snowflake.connector.cursor import SnowflakeCursor, DictCursor
 from snowflake.connector.errors import ProgrammingError
-from snowflake.connector.cursor import DictCursor
 
 
 class ImageRepositoryManager(SqlExecutionMixin):
@@ -80,10 +81,4 @@ class ImageRepositoryManager(SqlExecutionMixin):
         try:
             return self._execute_query(f"create image repository {name}")
         except ProgrammingError as e:
-            if e.errno == 2002:
-                raise ObjectAlreadyExistsError(
-                    object_type=ObjectType.IMAGE_REPOSITORY,
-                    name=unquote_identifier(name),
-                )
-            else:
-                raise
+            handle_object_already_exists(e, ObjectType.IMAGE_REPOSITORY, name)

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -79,6 +79,6 @@ class ImageRepositoryManager(SqlExecutionMixin):
 
     def create(self, name: str):
         try:
-            return self._execute_query(f"create image repository {name}")
+            return self._execute_schema_query(f"create image repository {name}")
         except ProgrammingError as e:
             handle_object_already_exists(e, ObjectType.IMAGE_REPOSITORY, name)

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -71,3 +71,6 @@ class ImageRepositoryManager(SqlExecutionMixin):
         path = parsed_url.path
 
         return f"{scheme}://{host}/v2{path}"
+
+    def create(self, name: str):
+        return self._execute_query(f"create image repository {name}")

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -62,7 +62,7 @@ class ServiceManager(SqlExecutionMixin):
         except ProgrammingError as e:
             if e.errno == 2002:
                 raise ObjectAlreadyExistsError(
-                    object_type=ObjectType.IMAGE_REPOSITORY,
+                    object_type=ObjectType.SERVICE,
                     name=unquote_identifier(service_name),
                 )
             else:

--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -8,6 +8,8 @@ import json
 import pytest
 
 from click import ClickException
+from tests.spcs.test_common import SPCS_OBJECT_EXISTS_ERROR
+from snowflake.cli.api.constants import ObjectType
 
 
 @patch(
@@ -108,6 +110,28 @@ def test_create_pool_cli(mock_create, runner):
         initially_suspended=True,
         auto_suspend_secs=7200,
         comment=to_string_literal("this is a test"),
+    )
+
+
+@patch(
+    "snowflake.cli.plugins.spcs.compute_pool.manager.ComputePoolManager._execute_query"
+)
+@patch("snowflake.cli.plugins.spcs.compute_pool.manager.handle_object_already_exists")
+def test_create_repository_already_exists(mock_handle, mock_execute):
+    pool_name = "test_object"
+    mock_execute.side_effect = SPCS_OBJECT_EXISTS_ERROR
+    ComputePoolManager().create(
+        pool_name=pool_name,
+        min_nodes=1,
+        max_nodes=1,
+        instance_family="test_family",
+        auto_resume=False,
+        initially_suspended=True,
+        auto_suspend_secs=7200,
+        comment=to_string_literal("this is a test"),
+    )
+    mock_handle.assert_called_once_with(
+        SPCS_OBJECT_EXISTS_ERROR, ObjectType.COMPUTE_POOL, pool_name
     )
 
 

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -36,7 +36,7 @@ MOCK_ROWS_DICT = [
 
 
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_query"
+    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_schema_query"
 )
 def test_create(
     mock_execute,

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.errors import ProgrammingError
 from snowflake.cli.api.constants import ObjectType
+from tests.spcs.test_common import SPCS_OBJECT_EXISTS_ERROR
 
 MOCK_ROWS = [
     [
@@ -74,17 +75,14 @@ def test_create_cli(mock_create, mock_cursor, runner):
     "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_schema_query"
 )
 @mock.patch(
-    "snowflake.cli.plugins.spcs.image_repository.common.handle_object_already_exists"
+    "snowflake.cli.plugins.spcs.image_repository.manager.handle_object_already_exists"
 )
-def test_create_repository_exists(mock_execute, mock_handle):
-    repo_name = "test_repo"
-    object_exists_error = ProgrammingError(
-        msg="Object 'TEST_REPO' already exists.", errno=2002
-    )
-    mock_execute.side_effect = object_exists_error
+def test_create_repository_already_exists(mock_handle, mock_execute):
+    repo_name = "test_object"
+    mock_execute.side_effect = SPCS_OBJECT_EXISTS_ERROR
     ImageRepositoryManager().create(repo_name)
     mock_handle.assert_called_once_with(
-        object_exists_error, ObjectType.IMAGE_REPOSITORY, repo_name
+        SPCS_OBJECT_EXISTS_ERROR, ObjectType.IMAGE_REPOSITORY, repo_name
     )
 
 

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -1,10 +1,10 @@
-import snowflake.cli.plugins.spcs.image_repository.manager
 from tests.testing_utils.fixtures import *
 import json
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 from typing import Dict
 from click import ClickException
-
+from unittest.mock import Mock
+from snowflake.connector.cursor import SnowflakeCursor
 
 MOCK_ROWS = [
     [
@@ -33,6 +33,39 @@ MOCK_ROWS_DICT = [
     {col_name: col_val for col_name, col_val in zip(MOCK_COLUMNS, row)}
     for row in MOCK_ROWS
 ]
+
+
+@mock.patch(
+    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager._execute_query"
+)
+def test_create(
+    mock_execute,
+):
+    repo_name = "test_repo"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute.return_value = cursor
+    result = ImageRepositoryManager().create(name=repo_name)
+    expected_query = "create image repository test_repo"
+    mock_execute.assert_called_once_with(expected_query)
+    assert result == cursor
+
+
+@mock.patch(
+    "snowflake.cli.plugins.spcs.image_repository.manager.ImageRepositoryManager.create"
+)
+def test_create_cli(mock_create, mock_cursor, runner):
+    repo_name = "test_repo"
+    cursor = mock_cursor(
+        rows=[[f"Image Repository {repo_name.upper()} successfully created."]],
+        columns=["status"],
+    )
+    mock_create.return_value = cursor
+    result = runner.invoke(["spcs", "image-repository", "create", repo_name])
+    mock_create.assert_called_once_with(name=repo_name)
+    assert result.exit_code == 0, result.output
+    assert (
+        f"Image Repository {repo_name.upper()} successfully created." in result.output
+    )
 
 
 @mock.patch("snowflake.cli.plugins.spcs.image_repository.commands.requests.get")

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -62,7 +62,7 @@ def test_create_service(mock_execute_schema_query, other_directory):
     )
     expected_query = " ".join(
         [
-            "CREATE SERVICE IF NOT EXISTS test_service",
+            "CREATE SERVICE test_service",
             "IN COMPUTE POOL test_pool",
             'FROM SPECIFICATION $$ {"spec": {"containers": [{"name": "cloudbeaver", "image":',
             '"/spcs_demos_db/cloudbeaver:23.2.1"}], "endpoints": [{"name": "cloudbeaver",',

--- a/tests_integration/spcs/test_image_repository.py
+++ b/tests_integration/spcs/test_image_repository.py
@@ -2,7 +2,7 @@ import pytest
 from snowflake.cli.api.project.util import escape_like_pattern
 
 from tests_integration.test_utils import contains_row_with, row_from_snowflake_session
-from tests_integration.testing_utils.naming_utils import ObjectNameProvider
+from tests_integration.testing_utils import ObjectNameProvider
 
 INTEGRATION_DATABASE = "SNOWCLI_DB"
 INTEGRATION_SCHEMA = "PUBLIC"
@@ -80,3 +80,15 @@ def test_get_repo_url(runner, snowflake_session, test_database):
     )
     assert isinstance(result.output, str), result.output
     assert result.output.strip() == expect_url
+
+
+@pytest.mark.integration
+def test_create_image_repository(runner, test_database):
+    repo_name = ObjectNameProvider("test_repo").create_and_get_next_object_name()
+    result = runner.invoke_with_connection_json(
+        ["spcs", "image-repository", "create", repo_name]
+    )
+    assert isinstance(result.json, dict), result.output
+    assert result.json == {
+        "status": f"Image Repository {repo_name.upper()} successfully created."
+    }


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added a command for `spcs image-repository create <repo_name>`. Added some new error messages for `spcs image-repository create` and `spcs compute-pool create` to identify when an object already exists.


**Usage:**
<img width="814" alt="create-image-repo" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/c0c943b3-48bc-49e1-a561-37257fceac1d">

**New Error Messages:**
<img width="791" alt="image-repo-exists" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/1d0f5797-e713-44d1-b967-604688c36b40">
<img width="1039" alt="compute-pool-exists" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/1eca49ee-c1de-4f28-9af3-d6f2c1d6f1bb">
