### PR TITLE
SNOW-1011767: Adding 'spcs image-registry login' command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,7 @@
 * Added new convenience command `spcs image-registry url` to get the URL for your account image registry.
 * Added convenience function `spcs image-repository url <repo_name>`.
 * Added `set (property)`, `unset (property)`, `suspend` and `resume` commands for `spcs compute-pool`.
+* Added `login` command for `spcs image-registry` to fetch authentication token and log in to image registry in one command.
 * Added `create` command to `spcs image-repository`.
 * Added new `--mfa-passcode` flag to support MFA.
 

--- a/src/snowflake/cli/plugins/spcs/__init__.py
+++ b/src/snowflake/cli/plugins/spcs/__init__.py
@@ -11,7 +11,7 @@ from snowflake.cli.plugins.spcs.services.commands import app as services_app
 
 app = SnowTyper(
     name="spcs",
-    help="Manages Snowpark services, pools, jobs, image registries, and image repositories.",
+    help="Manages Snowpark services, pools, image registries, and image repositories.",
 )
 
 app.add_typer(compute_pools_app)  # type: ignore

--- a/src/snowflake/cli/plugins/spcs/image_registry/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_registry/commands.py
@@ -1,11 +1,6 @@
-import subprocess
-
-import typer
-from click import ClickException
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import MessageResult, ObjectResult
 from snowflake.cli.plugins.spcs.image_registry.manager import (
-    NoImageRepositoriesFoundError,
     RegistryManager,
 )
 
@@ -30,22 +25,10 @@ def url(**options) -> MessageResult:
     Gets the image registry URL for the current account. Must be called from a
     role that can view at least one image repository in the image registry.
     """
-    try:
-        return MessageResult(RegistryManager().get_registry_url())
-    except NoImageRepositoriesFoundError:
-        raise ClickException(
-            "No image repository found. To get the registry url, please switch to a role with read access to at least one image repository or create a new image repository first."
-        )
+    return MessageResult(RegistryManager().get_registry_url())
 
 
 @app.command(requires_connection=True)
 def login(**options) -> MessageResult:
     """Logs in to the account image registry with the current user's credentials. Must be called from a role that can view at least one image repository in the image registry."""
-    try:
-        return MessageResult(RegistryManager().docker_registry_login().strip())
-    except NoImageRepositoriesFoundError:
-        raise ClickException(
-            "No image repository found. To login to your image registry, please switch to a role with read access to at least one image repository or create a new image repository first."
-        )
-    except subprocess.CalledProcessError as e:
-        raise ClickException(f"Login Failed: {e.stderr}".strip())
+    return MessageResult(RegistryManager().docker_registry_login().strip())

--- a/src/snowflake/cli/plugins/spcs/image_registry/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_registry/commands.py
@@ -6,7 +6,7 @@ from snowflake.cli.plugins.spcs.image_registry.manager import (
 
 app = SnowTyper(
     name="image-registry",
-    help="Manages SPCS image registries.",
+    help="Manages Snowpark registries.",
 )
 
 

--- a/src/snowflake/cli/plugins/spcs/image_registry/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_registry/manager.py
@@ -10,9 +10,8 @@ from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import DictCursor
 
 
-class NoImageRepositoriesFoundError(ClickException):
-    def __init__(self, msg: str = "No image repository found."):
-        super().__init__(msg)
+class NoImageRepositoriesFoundError(Exception):
+    pass
 
 
 class RegistryManager(SqlExecutionMixin):

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -2284,6 +2284,68 @@
   
   '''
 # ---
+# name: test_help_messages[spcs.image-registry.login]
+  '''
+                                                                                  
+   Usage: default spcs image-registry login [OPTIONS]                             
+                                                                                  
+   Logs in to the account image registry with the current user's credentials.     
+   Must be called from a role that can view at least one image repository in the  
+   image registry.                                                                
+                                                                                  
+  ╭─ Options ────────────────────────────────────────────────────────────────────╮
+  │ --help  -h        Show this message and exit.                                │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Connection configuration ───────────────────────────────────────────────────╮
+  │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
+  │                                           in your `config.toml`. Default:    │
+  │                                           `default`.                         │
+  │ --account,--accountname             TEXT  Name assigned to your Snowflake    │
+  │                                           account. Overrides the value       │
+  │                                           specified for the connection.      │
+  │ --user,--username                   TEXT  Username to connect to Snowflake.  │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --password                          TEXT  Snowflake password. Overrides the  │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --authenticator                     TEXT  Snowflake authenticator. Overrides │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --private-key-path                  TEXT  Snowflake private key path.        │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --database,--dbname                 TEXT  Database to use. Overrides the     │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --schema,--schemaname               TEXT  Database schema to use. Overrides  │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --role,--rolename                   TEXT  Role to use. Overrides the value   │
+  │                                           specified for the connection.      │
+  │ --warehouse                         TEXT  Warehouse to use. Overrides the    │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --temporary-connection      -x            Uses connection defined with       │
+  │                                           command line parameters, instead   │
+  │                                           of one defined in config           │
+  │ --mfa-passcode                      TEXT  Token to use for multi-factor      │
+  │                                           authentication (MFA)               │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Global configuration ───────────────────────────────────────────────────────╮
+  │ --format           [TABLE|JSON]  Specifies the output format.                │
+  │                                  [default: TABLE]                            │
+  │ --verbose  -v                    Displays log entries for log levels `info`  │
+  │                                  and higher.                                 │
+  │ --debug                          Displays log entries for log levels `debug` │
+  │                                  and higher; debug logs contains additional  │
+  │                                  information.                                │
+  │ --silent                         Turns off intermediate output to console.   │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  
+  '''
+# ---
 # name: test_help_messages[spcs.image-registry.token]
   '''
                                                                                   
@@ -2418,6 +2480,9 @@
   │ --help  -h        Show this message and exit.                                │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Commands ───────────────────────────────────────────────────────────────────╮
+  │ login  Logs in to the account image registry with the current user's         │
+  │        credentials. Must be called from a role that can view at least one    │
+  │        image repository in the image registry.                               │
   │ token  Gets the token from environment to use for authenticating with the    │
   │        registry. Note that this token is specific to your current user and   │
   │        will not grant access to any repositories that your current user      │
@@ -3204,8 +3269,7 @@
                                                                                   
    Usage: default spcs [OPTIONS] COMMAND [ARGS]...                                
                                                                                   
-   Manages Snowpark services, pools, jobs, image registries, and image            
-   repositories.                                                                  
+   Manages Snowpark services, pools, image registries, and image repositories.    
                                                                                   
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --help  -h        Show this message and exit.                                │

--- a/tests/spcs/__snapshots__/test_registry.ambr
+++ b/tests/spcs/__snapshots__/test_registry.ambr
@@ -1,4 +1,28 @@
 # serializer version: 1
+# name: test_docker_registry_login_cli
+  '''
+  Login Succeeded
+  
+  '''
+# ---
+# name: test_docker_registry_login_cli_no_repositories
+  '''
+  ╭─ Error ──────────────────────────────────────────────────────────────────────╮
+  │ No image repository found. To login to your image registry, please switch to │
+  │ a role with read access to at least one image repository or create a new     │
+  │ image repository first.                                                      │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
+# name: test_docker_registry_login_cli_subprocess_error
+  '''
+  ╭─ Error ──────────────────────────────────────────────────────────────────────╮
+  │ Login Failed: Docker Failed                                                  │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
 # name: test_get_registry_url_no_repositories_cli
   '''
   ╭─ Error ──────────────────────────────────────────────────────────────────────╮

--- a/tests/spcs/__snapshots__/test_registry.ambr
+++ b/tests/spcs/__snapshots__/test_registry.ambr
@@ -8,26 +8,21 @@
 # name: test_docker_registry_login_cli_no_repositories
   '''
   ╭─ Error ──────────────────────────────────────────────────────────────────────╮
-  │ No image repository found. To login to your image registry, please switch to │
-  │ a role with read access to at least one image repository or create a new     │
-  │ image repository first.                                                      │
+  │ No image repository found. To run this command, please switch to a role with │
+  │ read access to at least one image repository or create a new image           │
+  │ repository first.                                                            │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   
   '''
 # ---
-# name: test_docker_registry_login_cli_subprocess_error
-  '''
-  ╭─ Error ──────────────────────────────────────────────────────────────────────╮
-  │ Login Failed: Docker Failed                                                  │
-  ╰──────────────────────────────────────────────────────────────────────────────╯
-  
-  '''
+# name: test_docker_registry_login_subprocess_error
+  'Login Failed: Docker Failed'
 # ---
 # name: test_get_registry_url_no_repositories_cli
   '''
   ╭─ Error ──────────────────────────────────────────────────────────────────────╮
-  │ No image repository found. To get the registry url, please switch to a role  │
-  │ with read access to at least one image repository or create a new image      │
+  │ No image repository found. To run this command, please switch to a role with │
+  │ read access to at least one image repository or create a new image           │
   │ repository first.                                                            │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   

--- a/tests_e2e/__snapshots__/test_installation.ambr
+++ b/tests_e2e/__snapshots__/test_installation.ambr
@@ -33,8 +33,8 @@
   │ connection  Manages connections to Snowflake.                                │
   │ object      Manages Snowflake objects like warehouses and stages             │
   │ snowpark    Manage procedures and functions.                                 │
-  │ spcs        Manages Snowpark services, pools, jobs, image registries, and    │
-  │             image repositories.                                              │
+  │ spcs        Manages Snowpark services, pools, image registries, and image    │
+  │             repositories.                                                    │
   │ sql         Executes Snowflake query.                                        │
   │ streamlit   Manages Streamlit in Snowflake.                                  │
   ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/tests_integration/spcs/test_registry.py
+++ b/tests_integration/spcs/test_registry.py
@@ -1,6 +1,9 @@
 import pytest
 
 from tests_integration.test_utils import row_from_snowflake_session
+from tests_integration.testing_utils.assertions.test_result_assertions import (
+    assert_that_result_is_successful_and_output_json_equals,
+)
 from tests_integration.testing_utils.naming_utils import ObjectNameProvider
 
 
@@ -44,3 +47,11 @@ def test_get_registry_url(test_database, test_role, runner, snowflake_session):
     )
     assert success_result.exit_code == 0, success_result.output
     assert success_result.output.strip() == expected_registry_url
+
+
+@pytest.mark.integration
+def test_registry_login(runner):
+    result = runner.invoke_with_connection_json(["spcs", "image-registry", "login"])
+    assert_that_result_is_successful_and_output_json_equals(
+        result, {"message": "Login Succeeded"}
+    )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added `snow spcs image-registry login` command that automatically fetches your account token and registry URL and tries to login with `docker login`.

**Usage**:
<img width="678" alt="login-succeeded" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/41c9dd8a-7d17-40ce-a879-d961df69b80d">

**Errors**:
<img width="1629" alt="no-repository" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/958657e0-9df4-4672-b357-e111f64a9caa">
<img width="1630" alt="docker-login-error" src="https://github.com/Snowflake-Labs/snowcli/assets/156019931/d0e2237a-eb13-4f1d-ab96-71c9fce65cff">

