### PR TITLE
Add streamlit and snowpark as default streamlit environment.yml packages

### DIFF
--- a/src/snowflake/cli/templates/default_streamlit/environment.yml
+++ b/src/snowflake/cli/templates/default_streamlit/environment.yml
@@ -2,4 +2,5 @@ name: sf_env
 channels:
   - snowflake
 dependencies:
-  - pandas
+  - streamlit
+  - snowflake-snowpark-python


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

Even though SiS will automatically install streamlit when the app is deployed, if users are using this environment locally, it won't include essential packages like streamlit and snowpark. This seems like a sensible, minimal set of dependencies to me.