### PR TITLE
Fix GRANT statement signature during generation

### DIFF
--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/extension_function_utils.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/extension_function_utils.py
@@ -50,6 +50,15 @@ def get_sql_argument_signature(arg: Argument) -> str:
     return formatted
 
 
+def get_function_type_signature_for_grant(
+    extension_fn: NativeAppExtensionFunction,
+) -> str:
+    """
+    Returns the type signature for the specified function, e.g. "int, varchar", suitable for inclusion in a GRANT statement.
+    """
+    return ", ".join([arg.arg_type for arg in extension_fn.signature])
+
+
 def get_qualified_object_name(extension_fn: NativeAppExtensionFunction) -> str:
     qualified_name = to_identifier(extension_fn.name)
     if extension_fn.schema_name:

--- a/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
+++ b/src/snowflake/cli/plugins/nativeapp/codegen/snowpark/python_processor.py
@@ -29,6 +29,7 @@ from snowflake.cli.plugins.nativeapp.codegen.snowpark.extension_function_utils i
     deannotate_module_source,
     ensure_all_string_literals,
     ensure_string_literal,
+    get_function_type_signature_for_grant,
     get_qualified_object_name,
     get_sql_argument_signature,
     get_sql_object_type,
@@ -431,7 +432,7 @@ def generate_grant_sql_ddl_statements(
     for app_role in extension_fn.application_roles:
         grant_sql_statement = dedent(
             f"""\
-            GRANT USAGE ON {get_sql_object_type(extension_fn)} {get_qualified_object_name(extension_fn)}
+            GRANT USAGE ON {get_sql_object_type(extension_fn)} {get_qualified_object_name(extension_fn)}({get_function_type_signature_for_grant(extension_fn)})
             TO APPLICATION ROLE {app_role};
             """
         ).strip()

--- a/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
+++ b/tests/nativeapp/codegen/snowpark/__snapshots__/test_python_processor.ambr
@@ -1,10 +1,4 @@
 # serializer version: 1
-# name: test_create_and_write_to_sql_files_no_existing_generate
-  dict({
-    PosixPath('moduleA/main.py'): PosixPath('__generated/moduleA/main.sql'),
-    PosixPath('moduleB/main.py'): PosixPath('__generated/moduleB/main.sql'),
-  })
-# ---
 # name: test_edit_setup_script_with_exec_imm_sql
   '''
   
@@ -69,9 +63,9 @@
 # ---
 # name: test_generate_grant_sql_ddl_statements
   '''
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_ADMIN;
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_VIEWER;
   '''
 # ---
@@ -93,9 +87,9 @@
   HANDLER='main.my_function_handler'
   EXECUTE AS OWNER;
   
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_ADMIN;
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_VIEWER;
   -- stagepath/data.py
   CREATE OR REPLACE
@@ -110,9 +104,9 @@
   HANDLER='data.my_function_handler'
   EXECUTE AS OWNER;
   
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_ADMIN;
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_VIEWER;
   '''
 # ---
@@ -145,9 +139,9 @@
   HANDLER='main.my_function_handler'
   EXECUTE AS OWNER;
   
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_ADMIN;
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_VIEWER;
   '''
 # ---
@@ -166,9 +160,9 @@
   HANDLER='data.my_function_handler'
   EXECUTE AS OWNER;
   
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_ADMIN;
-  GRANT USAGE ON PROCEDURE DATA.my_function
+  GRANT USAGE ON PROCEDURE DATA.my_function(int)
   TO APPLICATION ROLE APP_VIEWER;
   '''
 # ---

--- a/tests/nativeapp/codegen/snowpark/test_extension_function_utils.py
+++ b/tests/nativeapp/codegen/snowpark/test_extension_function_utils.py
@@ -72,6 +72,28 @@ def test_get_qualified_object_name(native_app_extension_function):
     )
 
 
+def test_get_function_type_signature_for_grant(native_app_extension_function):
+    assert (
+        ef_utils.get_function_type_signature_for_grant(native_app_extension_function)
+        == "int"
+    )
+
+    native_app_extension_function.signature = []
+    assert (
+        ef_utils.get_function_type_signature_for_grant(native_app_extension_function)
+        == ""
+    )
+
+    native_app_extension_function.signature = [
+        Argument(name="foo", type="int", default="42"),
+        Argument(name="bar", type="varchar"),
+    ]
+    assert (
+        ef_utils.get_function_type_signature_for_grant(native_app_extension_function)
+        == "int, varchar"
+    )
+
+
 def test_ensure_string_literal():
     assert ef_utils.ensure_string_literal("") == "''"
     assert ef_utils.ensure_string_literal("abc") == "'abc'"


### PR DESCRIPTION
### Pre-review checklist
   * [X] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [X] I've added or updated automated unit tests to verify correctness of my new code.
   * N/A I've added or updated integration tests to verify correctness of my new code.
   * [X] I've confirmed that my changes are working by executing CLI's commands manually.
   * [X] I've confirmed that my changes are up-to-date with the target branch.
   * N/A I've described my changes in the release notes.
   * [X] I've described my changes in the section below.

### Changes description

The generated GRANT statements for Snowpark functions don't include the (required) type signature of the function. This change adds it.

### Testing

- Added unit tests for the functionality
- Updated test snapshots
- Manually verified that a sample app using Snowpark annotations can successfully be created after this change