### PR TITLE
SNOW-2229498 rename show versions to show deployments in dcm

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -185,12 +185,12 @@ def create(
 
 
 @app.command(requires_connection=True)
-def list_versions(
+def list_deployments(
     identifier: FQN = dcm_identifier,
     **options,
 ):
     """
-    Lists versions of given DCM Project.
+    Lists deployments of given DCM Project.
     """
     pm = DCMProjectManager()
     results = pm.list_versions(project_name=identifier)

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -7712,12 +7712,12 @@
   
   '''
 # ---
-# name: test_help_messages[dcm.list-versions]
+# name: test_help_messages[dcm.list-deployments]
   '''
                                                                                   
-   Usage: root dcm list-versions [OPTIONS] IDENTIFIER                             
+   Usage: root dcm list-deployments [OPTIONS] IDENTIFIER                          
                                                                                   
-   Lists versions of given DCM Project.                                           
+   Lists deployments of given DCM Project.                                        
                                                                                   
                                                                                   
   +- Arguments ------------------------------------------------------------------+
@@ -8125,15 +8125,15 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | create          Creates a DCM Project in Snowflake.                          |
-  | deploy          Applies changes defined in DCM Project to Snowflake.         |
-  | describe        Provides description of DCM Project.                         |
-  | drop            Drops DCM Project with given name.                           |
-  | drop-version    Drops a version from the DCM Project.                        |
-  | list            Lists all available DCM Projects.                            |
-  | list-versions   Lists versions of given DCM Project.                         |
-  | plan            Plans a DCM Project deployment (validates without            |
-  |                 executing).                                                  |
+  | create             Creates a DCM Project in Snowflake.                       |
+  | deploy             Applies changes defined in DCM Project to Snowflake.      |
+  | describe           Provides description of DCM Project.                      |
+  | drop               Drops DCM Project with given name.                        |
+  | drop-version       Drops a version from the DCM Project.                     |
+  | list               Lists all available DCM Projects.                         |
+  | list-deployments   Lists deployments of given DCM Project.                   |
+  | plan               Plans a DCM Project deployment (validates without         |
+  |                    executing).                                               |
   +------------------------------------------------------------------------------+
   
   
@@ -20772,15 +20772,15 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | create          Creates a DCM Project in Snowflake.                          |
-  | deploy          Applies changes defined in DCM Project to Snowflake.         |
-  | describe        Provides description of DCM Project.                         |
-  | drop            Drops DCM Project with given name.                           |
-  | drop-version    Drops a version from the DCM Project.                        |
-  | list            Lists all available DCM Projects.                            |
-  | list-versions   Lists versions of given DCM Project.                         |
-  | plan            Plans a DCM Project deployment (validates without            |
-  |                 executing).                                                  |
+  | create             Creates a DCM Project in Snowflake.                       |
+  | deploy             Applies changes defined in DCM Project to Snowflake.      |
+  | describe           Provides description of DCM Project.                      |
+  | drop               Drops DCM Project with given name.                        |
+  | drop-version       Drops a version from the DCM Project.                     |
+  | list               Lists all available DCM Projects.                         |
+  | list-deployments   Lists deployments of given DCM Project.                   |
+  | plan               Plans a DCM Project deployment (validates without         |
+  |                    executing).                                               |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -239,8 +239,8 @@ def test_list_command_alias(mock_connect, runner):
 
 
 @mock.patch(DCMProjectManager)
-def test_list_versions(mock_pm, runner):
-    result = runner.invoke(["dcm", "list-versions", "fooBar"])
+def test_list_deployments(mock_pm, runner):
+    result = runner.invoke(["dcm", "list-deployments", "fooBar"])
 
     assert result.exit_code == 0, result.output
 

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -24,7 +24,9 @@ def _assert_project_has_versions(
     runner, project_name: str, expected_versions: Set[Tuple[str, Optional[str]]]
 ) -> None:
     """Check whether the project versions (in [name,alias] format) are present in Snowflake."""
-    result = runner.invoke_with_connection_json(["dcm", "list-versions", project_name])
+    result = runner.invoke_with_connection_json(
+        ["dcm", "list-deployments", project_name]
+    )
     assert result.exit_code == 0, result.output
     versions = {(version["name"], version["alias"]) for version in result.json}
     assert versions == expected_versions


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
This PR renames `snow dcm list-versions` to `snow dcm list-deployments`. So far the SQL remains unchanged as this change will be rolled out in 9.23
