### PR TITLE
Remote Dev Plugin Part 2 - Add basic remote commands

### DIFF
--- a/src/snowflake/cli/_plugins/remote/commands.py
+++ b/src/snowflake/cli/_plugins/remote/commands.py
@@ -15,36 +15,163 @@
 from __future__ import annotations
 
 import logging
+from typing import List, Optional
 
+import typer
+from snowflake.cli._plugins.remote.manager import RemoteManager
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.console import cli_console as cc
+from snowflake.cli.api.output.types import (
+    CommandResult,
+    QueryResult,
+    SingleQueryResult,
+)
 
-log = logging.getLogger(__name__)
 app = SnowTyperFactory(
     name="remote",
-    help="Manages remote development environments.",
+    help="Manages remote development environments on top of Snowpark Container Service.",
+    short_help="Manages remote development environments.",
+)
+
+log = logging.getLogger(__name__)
+
+# Define argument for remote service names (accepts both customer names and full service names)
+RemoteNameArgument = typer.Argument(
+    help="Remote service name. Can be either a customer name (e.g., 'myproject') or full service name (e.g., 'SNOW_REMOTE_admin_myproject')",
+    show_default=False,
 )
 
 
 @app.command("start", requires_connection=True)
-def start_service(**options) -> None:
+def start(
+    name: Optional[str] = typer.Argument(
+        None,
+        help="Service name to resume, or leave empty to create a new service with auto-generated name",
+    ),
+    compute_pool: Optional[str] = typer.Option(
+        None,
+        "--compute-pool",
+        help="Name of the compute pool to use (required for new service creation)",
+        show_default=False,
+    ),
+    eai_name: Optional[List[str]] = typer.Option(
+        None,
+        "--eai-name",
+        help="List of external access integration names to enable network access to external resources",
+    ),
+    stage: Optional[str] = typer.Option(
+        None,
+        "--stage",
+        help="Internal Snowflake stage to mount (e.g., @my_stage or @my_stage/folder).",
+    ),
+    image: Optional[str] = typer.Option(
+        None,
+        "--image",
+        help="Custom image to use (can be full path like 'repo/image:tag' or just tag like '1.7.1')",
+    ),
+    **options,
+) -> None:
     """
-    Start a remote development environment.
+    Starts a remote development environment.
 
-    This is a placeholder command for the remote plugin.
-    Full functionality will be implemented in subsequent PRs.
+    This command creates a new VS Code Server remote development environment if it doesn't exist,
+    or starts an existing one if it's suspended. If the environment is already running, it's a no-op.
+    The environment is deployed as a Snowpark Container Service that provides
+    a web-based development environment.
+
+    Usage examples:
+    - Resume existing service: snow remote start myproject
+    - Create new service: snow remote start --compute-pool my_pool
+    - Create named service: snow remote start myproject --compute-pool my_pool
+
+    The --compute-pool parameter is only required when creating a new service. For resuming
+    existing services, the compute pool is not needed.
     """
-    log.info("Start command called - functionality coming soon!")
-    log.info("Full functionality will be available in upcoming releases.")
+    try:
+        manager = RemoteManager()
+
+        service_name, url, status = manager.start(
+            name=name,
+            compute_pool=compute_pool,
+            external_access=eai_name,
+            stage=stage,
+            image=image,
+        )
+
+        # Display appropriate success message based on what happened
+        if status == "created":
+            cc.message(
+                f"✓ Remote Development Environment {service_name} created successfully!"
+            )
+        elif status == "resumed":
+            cc.message(
+                f"✓ Remote Development Environment {service_name} resumed successfully!"
+            )
+        elif status == "running":
+            cc.message(
+                f"✓ Remote Development Environment {service_name} is already running."
+            )
+
+        cc.message(f"VS Code Server URL: {url}")
+
+        # Log detailed information at debug level
+        if stage:
+            log.debug("Stage '%s' mounted:", stage)
+            log.debug(
+                "  - Workspace: '%s/user-default' → '%s'",
+                stage,
+                "/home/user/workspace",
+            )
+            log.debug(
+                "  - VS Code data: '%s/.vscode-server/data' → '%s'",
+                stage,
+                "/home/user/.vscode-server",
+            )
+        if eai_name:
+            log.debug("External access integrations: %s", ", ".join(eai_name))
+        if image:
+            log.debug("Using custom image: %s", image)
+
+    except ValueError as e:
+        cc.warning(f"Error: {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        cc.warning(f"Error starting remote environment: {e}")
+        raise typer.Exit(code=1)
 
 
 @app.command("list", requires_connection=True)
-def list_services(**options) -> None:
+def list_services(**options) -> CommandResult:
     """
-    List remote development environments.
+    Lists all remote development environments.
+    """
+    cursor = RemoteManager().list_services()
+    return QueryResult(cursor)
 
-    This is a placeholder command for the remote plugin.
-    Full functionality will be implemented in subsequent PRs.
+
+@app.command("stop", requires_connection=True)
+def stop(
+    name: str = RemoteNameArgument,
+    **options,
+) -> CommandResult:
     """
-    log.info("Remote plugin registered successfully")
-    log.info("Remote development environments plugin is registered.")
-    log.info("Full functionality will be available in upcoming releases.")
+    Suspends a remote development environment.
+    """
+    manager = RemoteManager()
+    cursor = manager.stop(name)
+    cc.message(f"Remote environment '{name}' suspended successfully.")
+    return SingleQueryResult(cursor)
+
+
+@app.command("delete", requires_connection=True)
+def delete(
+    name: str = RemoteNameArgument,
+    **options,
+) -> CommandResult:
+    """
+    Deletes a remote development environment.
+    """
+    manager = RemoteManager()
+    cursor = manager.delete(name)
+    cc.message(f"Remote environment '{name}' deleted successfully.")
+    return SingleQueryResult(cursor)

--- a/src/snowflake/cli/_plugins/remote/constants.py
+++ b/src/snowflake/cli/_plugins/remote/constants.py
@@ -54,24 +54,31 @@ USER_VSCODE_DATA_VOLUME_MOUNT_PATH = "/root/.vscode-server"
 # Service naming constants
 SERVICE_NAME_PREFIX = "SNOW_REMOTE"
 
-# Service status constants
-SERVICE_STATUS_READY = "READY"
-SERVICE_STATUS_SUSPENDED = "SUSPENDED"
-SERVICE_STATUS_SUSPENDING = "SUSPENDING"
-SERVICE_STATUS_PENDING = "PENDING"
-SERVICE_STATUS_STARTING = "STARTING"
-SERVICE_STATUS_FAILED = "FAILED"
-SERVICE_STATUS_ERROR = "ERROR"
-SERVICE_STATUS_UNKNOWN = "UNKNOWN"
 
-# Service operation result constants
-SERVICE_RESULT_CREATED = "created"
-SERVICE_RESULT_RESUMED = "resumed"
-SERVICE_RESULT_RUNNING = "running"
+class ServiceStatus(enum.Enum):
+    """Service status values returned by SHOW SERVICES and SPCS_WAIT_FOR (service-level)."""
+
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    FAILED = "FAILED"
+    DONE = "DONE"
+    SUSPENDING = "SUSPENDING"
+    SUSPENDED = "SUSPENDED"
+    DELETING = "DELETING"
+    DELETED = "DELETED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+class ServiceResult(enum.Enum):
+    """Service operation result values."""
+
+    CREATED = "created"
+    RESUMED = "resumed"
+    RUNNING = "running"
+
 
 # Default timeout for service operations
 DEFAULT_SERVICE_TIMEOUT_MINUTES = 10
-STATUS_CHECK_INTERVAL_SECONDS = 10
 
 # Default container image information
 DEFAULT_IMAGE_REPO = "/snowflake/images/snowflake_images"

--- a/src/snowflake/cli/_plugins/remote/manager.py
+++ b/src/snowflake/cli/_plugins/remote/manager.py
@@ -1,0 +1,466 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, NamedTuple, Optional, Tuple
+
+from snowflake.cli._plugins.remote.constants import (
+    DEFAULT_SERVICE_TIMEOUT_MINUTES,
+    SERVER_UI_ENDPOINT_NAME,
+    SERVICE_NAME_PREFIX,
+    ServiceResult,
+    ServiceStatus,
+)
+from snowflake.cli._plugins.remote.container_spec import generate_service_spec_yaml
+from snowflake.cli._plugins.spcs.services.manager import ServiceManager
+from snowflake.cli.api.console import cli_console as cc
+from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from snowflake.connector.cursor import DictCursor, SnowflakeCursor
+
+log = logging.getLogger(__name__)
+
+
+class ServiceOperationResult(NamedTuple):
+    """Result of a service operation containing service details."""
+
+    service_name: Optional[str]
+    url: Optional[str]
+    status: Optional[str]
+
+
+class RemoteManager(SqlExecutionMixin):
+    """Manager for remote development environments using Snowpark Container Services."""
+
+    def _get_current_snowflake_user(self) -> str:
+        """Get the current Snowflake username from the connection."""
+        result = self.execute_query("SELECT CURRENT_USER()").fetchone()
+        return result[0] if result else "unknown"
+
+    def _get_service_status(self, service_name: str) -> Tuple[bool, Optional[str]]:
+        """
+        Get service status using DESC SERVICE.
+
+        Returns:
+            Tuple of (service_exists, current_status)
+        """
+        try:
+            log.debug("Checking service status for %s using DESC SERVICE", service_name)
+
+            # Use DESC SERVICE to get service information
+            # This returns exactly one row with service details, or none if service doesn't exist
+            desc_query = f"DESC SERVICE {service_name}"
+            cursor = self.execute_query(desc_query, cursor_class=DictCursor)
+            result = cursor.fetchone()
+
+            if result:
+                # DESC SERVICE returns columns similar to SHOW SERVICES
+                # Access status by column name for robustness
+                current_status = result.get("status")
+                log.debug(
+                    "Found service %s with status: %s", service_name, current_status
+                )
+                return True, current_status
+            else:
+                log.debug("DESC SERVICE returned no result for %s", service_name)
+                return False, None
+
+        except Exception as e:
+            log.debug("Error checking service status for %s: %s", service_name, e)
+            # Service doesn't exist or other error
+            return False, None
+
+    def _resolve_service_name(self, name_input: str) -> str:
+        """
+        Resolve the service name from user input.
+
+        Accepts either:
+        1. Full service name (SNOW_REMOTE_{snowflake_username}_{name})
+        2. Customer input name (which gets prefixed)
+
+        Args:
+            name_input: Either customer name or full service name
+
+        Returns:
+            Full service name (SNOW_REMOTE_{snowflake_username}_{name})
+        """
+        # If it already starts with SNOW_REMOTE_, use as-is (case-insensitive)
+        if name_input.upper().startswith(f"{SERVICE_NAME_PREFIX}_"):
+            return name_input
+
+        # Otherwise, treat as customer input name and add prefix with Snowflake username
+        snowflake_username = self._get_current_snowflake_user()
+        # Convert to uppercase to match Snowflake service naming convention
+        return f"{SERVICE_NAME_PREFIX}_{snowflake_username}_{name_input}".upper()
+
+    def _handle_existing_service(
+        self, service_name: str, current_status: str
+    ) -> Optional[ServiceOperationResult]:
+        """
+        Handle an existing service based on its current service status.
+
+        Note: current_status is always service status (from DESC SERVICE).
+
+        Returns:
+            ServiceOperationResult with service details, or None if service needs recreation
+        """
+        # Handle service statuses (from DESC SERVICE)
+        if current_status == ServiceStatus.RUNNING.value:
+            log.debug("Service %s is already running", service_name)
+            url = self.get_server_ui_url(service_name)
+            return ServiceOperationResult(
+                service_name, url, ServiceResult.RUNNING.value
+            )
+        elif current_status in [
+            ServiceStatus.SUSPENDED.value,
+            ServiceStatus.SUSPENDING.value,
+        ]:
+            log.debug(
+                "Service %s is suspended/suspending, resuming...",
+                service_name,
+            )
+            service_manager = ServiceManager()
+            service_manager.resume(service_name)
+            self.wait_for_service_ready(service_name)
+            url = self.get_server_ui_url(service_name)
+            return ServiceOperationResult(
+                service_name, url, ServiceResult.RESUMED.value
+            )
+        elif current_status == ServiceStatus.PENDING.value:
+            log.debug(
+                "Service %s is pending, waiting for it to be ready...",
+                service_name,
+            )
+            self.wait_for_service_ready(service_name)
+            url = self.get_server_ui_url(service_name)
+            return ServiceOperationResult(
+                service_name, url, ServiceResult.RUNNING.value
+            )
+        elif current_status in [
+            ServiceStatus.FAILED.value,
+            ServiceStatus.INTERNAL_ERROR.value,
+            ServiceStatus.DELETING.value,
+            ServiceStatus.DELETED.value,
+        ]:
+            log.debug(
+                "Service %s is in failed/error/deleting state (%s), will recreate...",
+                service_name,
+                current_status,
+            )
+            return None
+        else:
+            log.debug(
+                "Service %s has unknown status '%s', will recreate...",
+                service_name,
+                current_status,
+            )
+            return None
+
+    def _create_new_service(
+        self,
+        service_name: str,
+        compute_pool: Optional[str],
+        external_access: Optional[List[str]],
+        stage: Optional[str],
+        image: Optional[str],
+    ) -> ServiceOperationResult:
+        """
+        Create a new service or recreate a failed one.
+
+        Returns:
+            ServiceOperationResult with service details
+        """
+        # Validate compute pool is provided for service creation
+        if not compute_pool:
+            raise ValueError("compute_pool is required for creating a new service")
+
+        cc.step(f"Creating remote development environment '{service_name}'...")
+
+        # Generate container service specification as YAML
+        spec_content = generate_service_spec_yaml(
+            session=self.snowpark_session,
+            compute_pool=compute_pool,
+            stage=stage,
+            image=image,
+            ssh_public_key=None,  # SSH key support will be added in later PR
+        )
+
+        # Create the service directly with spec content
+        self._create_service_with_spec(
+            service_name=service_name,
+            compute_pool=compute_pool,
+            spec_content=spec_content,
+            external_access_integrations=external_access,
+        )
+
+        # Wait for service to be ready
+        self.wait_for_service_ready(service_name)
+
+        # Get the service endpoint URL
+        url = self.get_server_ui_url(service_name)
+
+        log.debug(
+            "✓ Remote Development Environment %s created successfully!", service_name
+        )
+        return ServiceOperationResult(service_name, url, ServiceResult.CREATED.value)
+
+    def start(
+        self,
+        name: Optional[str] = None,
+        compute_pool: Optional[str] = None,
+        external_access: Optional[List[str]] = None,
+        stage: Optional[str] = None,
+        image: Optional[str] = None,
+    ) -> ServiceOperationResult:
+        """
+        Starts a remote development environment with VS Code Server.
+
+        This method is idempotent and handles various service states:
+        - If service doesn't exist: creates it
+        - If service exists but is suspended: resumes it
+        - If service exists and is running: returns existing URL
+        - If service is starting: waits for it to be ready
+        - If service is failed: recreates it
+
+        Args:
+            name: Custom name for the service. If None, generates timestamp-based name.
+                 Can be either a short name (e.g., 'myproject') or full service name
+                 (e.g., 'SNOW_REMOTE_admin_myproject').
+            compute_pool: Name of the compute pool to use. Required only for new service
+                         creation, not needed for resuming existing services.
+            external_access: List of external access integration names to enable network
+                           access to external resources.
+            stage: Internal Snowflake stage to mount for persistent storage
+                  (e.g., '@my_stage' or '@my_stage/folder').
+            image: Custom image to use for the remote development environment.
+                   Can be either a full image path (e.g., 'repo/image:tag') or just a tag (e.g., '1.7.1').
+                   If not provided, uses the default image.
+
+        Returns:
+            ServiceOperationResult with:
+            - service_name: Full resolved service name
+            - url: VS Code Server URL for accessing the environment
+            - status: One of 'created', 'resumed', or 'running'
+
+        Raises:
+            ValueError: If neither name nor compute_pool is provided, or if compute_pool
+                       is missing for new service creation.
+            RuntimeError: If service fails to start or become ready within timeout.
+
+        Examples:
+            # Resume existing service (tuple unpacking still works)
+            service_name, url, status = manager.start(name="myproject")
+
+            # Create new service with auto-generated name (using named fields)
+            result = manager.start(compute_pool="my_pool")
+
+            # Create named service with stage mount
+            result = manager.start(
+                name="myproject",
+                compute_pool="my_pool",
+                stage="@my_stage"
+            )
+        """
+        # Validate that either name (for resume) or compute_pool (for creation) is provided
+        if not name and not compute_pool:
+            raise ValueError(
+                "Either 'name' (for service resumption) or 'compute_pool' (for service creation) must be provided"
+            )
+
+        # Resolve service name (handles both custom names and existing service names)
+        if not name:
+            name = datetime.now().strftime("%y%m%d%H%M")
+        service_name = self._resolve_service_name(name)
+
+        # Check if service already exists and its status
+        service_exists, current_status = self._get_service_status(service_name)
+
+        # Handle existing service based on status
+        if service_exists and current_status:
+            result = self._handle_existing_service(service_name, current_status)
+            if result is not None:  # Service was handled successfully
+                return result
+            # If result is None, service needs recreation - continue to creation
+        else:
+            log.debug("Service %s does not exist, creating...", service_name)
+
+        # Create the service (either new or recreating failed one)
+        return self._create_new_service(
+            service_name=service_name,
+            compute_pool=compute_pool,
+            external_access=external_access,
+            stage=stage,
+            image=image,
+        )
+
+    def _create_service_with_spec(
+        self,
+        service_name: str,
+        compute_pool: str,
+        spec_content: str,
+        external_access_integrations: Optional[List[str]] = None,
+    ) -> None:
+        """Create a service directly with spec content (avoiding temporary files).
+
+        This method constructs and executes a CREATE SERVICE SQL statement with the
+        provided YAML specification embedded directly in the query.
+
+        Args:
+            service_name: Full name of the service to create (e.g., 'SNOW_REMOTE_admin_myproject')
+            compute_pool: Name of the compute pool to run the service on
+            spec_content: Complete YAML specification content as string
+            external_access_integrations: Optional list of external access integration names
+                                        to enable network access to external resources
+
+        Raises:
+            Exception: If service creation fails due to SQL execution errors
+        """
+
+        # Build the CREATE SERVICE SQL query
+        query_parts = [
+            f"CREATE SERVICE {service_name}",
+            f"IN COMPUTE POOL {compute_pool}",
+            f"FROM SPECIFICATION $$---",
+            spec_content,
+            "$$",
+            "MIN_INSTANCES = 1",
+            "MAX_INSTANCES = 1",
+            "AUTO_RESUME = true",
+        ]
+
+        if external_access_integrations:
+            eai_list = ",".join(f"{e}" for e in external_access_integrations)
+            query_parts.append(f"EXTERNAL_ACCESS_INTEGRATIONS = ({eai_list})")
+
+        query_parts.append(
+            "COMMENT = 'Remote development environment created by Snowflake CLI'"
+        )
+
+        query = "\n".join(query_parts)
+        self.execute_query(query)
+
+    def wait_for_service_ready(
+        self, service_name: str, timeout_minutes: int = DEFAULT_SERVICE_TIMEOUT_MINUTES
+    ) -> None:
+        """Wait for service to be in RUNNING state using Snowflake's native SPCS_WAIT_FOR function."""
+        cc.step(f"Waiting for service {service_name} to be ready...")
+
+        timeout_seconds = timeout_minutes * 60
+
+        try:
+            # Use Snowflake's native SPCS_WAIT_FOR function
+            # Reference: https://docs.snowflake.com/en/sql-reference/functions/spcs_wait_for
+            wait_query = f"CALL {service_name}!SPCS_WAIT_FOR('{ServiceStatus.RUNNING.value}', {timeout_seconds})"
+
+            log.debug("Executing SPCS_WAIT_FOR: %s", wait_query)
+            result = self.execute_query(wait_query).fetchone()
+
+            if result:
+                log.debug(
+                    "✓ Service %s completed waiting! Result: %s",
+                    service_name,
+                    result[0],
+                )
+            else:
+                log.debug("✓ Service %s completed waiting!", service_name)
+
+        except Exception as e:
+            # SPCS_WAIT_FOR returns an error if timeout is reached or status can't be achieved
+            error_msg = str(e)
+            log.debug("SPCS_WAIT_FOR failed: %s", error_msg)
+
+            # Re-raise with a more user-friendly message
+            if "timeout" in error_msg.lower():
+                raise RuntimeError(
+                    f"Service {service_name} did not become ready within {timeout_minutes} minutes. "
+                    f"Check service status with 'snow remote list' for more details."
+                ) from e
+            else:
+                raise RuntimeError(
+                    f"Service {service_name} failed to start. Error: {error_msg}"
+                ) from e
+
+    def get_server_ui_url(self, service_name: str) -> str:
+        """Get the VS Code server UI endpoint URL for a service.
+
+        Args:
+            service_name: Full name of the service to get URL for
+
+        Returns:
+            Public URL for accessing the VS Code Server UI
+
+        Raises:
+            RuntimeError: If no VS Code endpoint is found for the service
+        """
+        service_manager = ServiceManager()
+        endpoints = service_manager.list_endpoints(service_name)
+
+        # Look for the server-ui endpoint
+        for row in endpoints:
+            # Assuming the row format is [name, port, public, protocol, host, url]
+            if len(row) >= 6 and row[0] == SERVER_UI_ENDPOINT_NAME:
+                return row[5]  # Return the URL
+
+        raise RuntimeError(f"No VS Code endpoint found for service {service_name}")
+
+    def list_services(self) -> SnowflakeCursor:
+        """List all remote development environment services.
+
+        Returns:
+            Cursor containing service information including name, status, database,
+            schema, compute pool, external access integrations, and timestamps.
+        """
+        # Use SQL to list services with the SNOW_CR prefix
+        query = f"""
+        SHOW SERVICES EXCLUDE JOBS
+        LIKE '{SERVICE_NAME_PREFIX}_%';
+        """
+        cur = self.execute_query(query)
+        qid = cur.sfqid
+        return cur.execute(
+            f"""
+            select "name", "status", "database_name", "schema_name", "compute_pool", "external_access_integrations", "created_on", "updated_on", "resumed_on", "suspended_on", "comment"
+            FROM TABLE(RESULT_SCAN('{qid}'))
+        """
+        )
+
+    def stop(self, name_input: str) -> SnowflakeCursor:
+        """Stop (suspend) a remote development service.
+
+        Args:
+            name_input: Service name (can be short name or full service name)
+
+        Returns:
+            Cursor from the suspend operation
+        """
+        service_name = self._resolve_service_name(name_input)
+        service_manager = ServiceManager()
+        return service_manager.suspend(service_name)
+
+    def delete(self, name_input: str) -> SnowflakeCursor:
+        """Delete a remote development service.
+
+        Args:
+            name_input: Service name (can be short name or full service name)
+
+        Returns:
+            Cursor from the drop service operation
+
+        Warning:
+            This permanently deletes the service and all associated data.
+        """
+        service_name = self._resolve_service_name(name_input)
+        return self.execute_query(f"DROP SERVICE {service_name}")

--- a/src/snowflake/cli/_plugins/remote/utils.py
+++ b/src/snowflake/cli/_plugins/remote/utils.py
@@ -159,3 +159,45 @@ def format_stage_path(stage_path: str) -> str:
         raise ValueError("Stage path cannot be empty")
 
     return f"@{path}"
+
+
+def parse_image_string(image_string: str) -> tuple[str, str, str]:
+    """
+    Parse an image string to extract repository, image name, and tag.
+
+    Docker image naming rules:
+    - Repository names can contain lowercase letters, digits, and separators (., -, _)
+    - Tags can contain lowercase/uppercase letters, digits, underscores, periods, and dashes
+    - Colons (:) are only valid as tag separators, not within names
+    - Forward slashes (/) are only valid as repository separators
+
+    Args:
+        image_string: Either a full image path (repo/image:tag) or just a tag
+
+    Returns:
+        Tuple of (repo, image_name, tag)
+
+    Examples:
+        parse_image_string("1.7.1") -> ("", "", "1.7.1")  # Just a tag
+        parse_image_string("myimage:latest") -> ("", "myimage", "latest")
+        parse_image_string("myrepo/myimage:v1.0") -> ("myrepo", "myimage", "v1.0")
+        parse_image_string("registry.com/myrepo/myimage:v1.0") -> ("registry.com/myrepo", "myimage", "v1.0")
+    """
+    # Split on the last colon to separate tag (if present)
+    if ":" in image_string:
+        image_path, tag = image_string.rsplit(":", 1)
+    else:
+        image_path, tag = image_string, ""
+
+    # Split on the last slash to separate repo from image name (if present)
+    if "/" in image_path:
+        repo, image_name = image_path.rsplit("/", 1)
+    else:
+        repo, image_name = "", image_path
+
+    # Special case: if we have no repo, no slash, and no colon, treat as just a tag
+    # This handles cases like "1.7.1" which should be treated as a tag, not an image name
+    if not repo and not "/" in image_string and not ":" in image_string:
+        return "", "", image_string
+
+    return repo, image_name, tag

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -11819,15 +11819,148 @@
   
   '''
 # ---
+# name: test_help_messages[remote.delete]
+  '''
+                                                                                  
+   Usage: root remote delete [OPTIONS] NAME                                       
+                                                                                  
+   Deletes a remote development environment.                                      
+                                                                                  
+                                                                                  
+  +- Arguments ------------------------------------------------------------------+
+  | *    name      TEXT  Remote service name. Can be either a customer name      |
+  |                      (e.g., 'myproject') or full service name (e.g.,         |
+  |                      'SNOW_REMOTE_admin_myproject')                          |
+  |                      [required]                                              |
+  +------------------------------------------------------------------------------+
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment    -c      TEXT     Name of the connection, as    |
+  |                                                defined in your config.toml   |
+  |                                                file. Default: default.       |
+  | --host                                TEXT     Host address for the          |
+  |                                                connection. Overrides the     |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --account,--accountname               TEXT     Name assigned to your         |
+  |                                                Snowflake account. Overrides  |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --user,--username                     TEXT     Username to connect to        |
+  |                                                Snowflake. Overrides the      |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --password                            TEXT     Snowflake password. Overrides |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --authenticator                       TEXT     Snowflake authenticator.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --workload-identity-provider          TEXT     Workload identity provider    |
+  |                                                (AWS, AZURE, GCP, OIDC).      |
+  |                                                Overrides the value specified |
+  |                                                for the connection            |
+  | --private-key-file,--privat…          TEXT     Snowflake private key file    |
+  |                                                path. Overrides the value     |
+  |                                                specified for the connection. |
+  | --token                               TEXT     OAuth token to use when       |
+  |                                                connecting to Snowflake.      |
+  | --token-file-path                     TEXT     Path to file with an OAuth    |
+  |                                                token to use when connecting  |
+  |                                                to Snowflake.                 |
+  | --database,--dbname                   TEXT     Database to use. Overrides    |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --schema,--schemaname                 TEXT     Database schema to use.       |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --role,--rolename                     TEXT     Role to use. Overrides the    |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --warehouse                           TEXT     Warehouse to use. Overrides   |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --temporary-connection        -x               Uses a connection defined     |
+  |                                                with command line parameters, |
+  |                                                instead of one defined in     |
+  |                                                config                        |
+  | --mfa-passcode                        TEXT     Token to use for multi-factor |
+  |                                                authentication (MFA)          |
+  | --enable-diag                                  Whether to generate a         |
+  |                                                connection diagnostic report. |
+  | --diag-log-path                       TEXT     Path for the generated        |
+  |                                                report. Defaults to system    |
+  |                                                temporary directory.          |
+  | --diag-allowlist-path                 TEXT     Path to a JSON file that      |
+  |                                                contains allowlist            |
+  |                                                parameters.                   |
+  | --oauth-client-id                     TEXT     Value of client id provided   |
+  |                                                by the Identity Provider for  |
+  |                                                Snowflake integration.        |
+  | --oauth-client-secret                 TEXT     Value of the client secret    |
+  |                                                provided by the Identity      |
+  |                                                Provider for Snowflake        |
+  |                                                integration.                  |
+  | --oauth-authorization-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the authorization   |
+  |                                                code to the driver.           |
+  | --oauth-token-request-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the access tokens   |
+  |                                                to the driver.                |
+  | --oauth-redirect-uri                  TEXT     URI to use for authorization  |
+  |                                                code redirection.             |
+  | --oauth-scope                         TEXT     Scope requested in the        |
+  |                                                Identity Provider             |
+  |                                                authorization request.        |
+  | --oauth-disable-pkce                           Disables Proof Key for Code   |
+  |                                                Exchange (PKCE). Default:     |
+  |                                                False.                        |
+  | --oauth-enable-refresh-toke…                   Enables a silent              |
+  |                                                re-authentication when the    |
+  |                                                actual access token becomes   |
+  |                                                outdated. Default: False.     |
+  | --oauth-enable-single-use-r…                   Whether to opt-in to          |
+  |                                                single-use refresh token      |
+  |                                                semantics. Default: False.    |
+  | --client-store-temporary-cr…                   Store the temporary           |
+  |                                                credential.                   |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
+  |                                CSV]                   format.                |
+  |                                                       [default: TABLE]       |
+  | --verbose              -v                             Displays log entries   |
+  |                                                       for log levels info    |
+  |                                                       and higher.            |
+  | --debug                                               Displays log entries   |
+  |                                                       for log levels debug   |
+  |                                                       and higher; debug logs |
+  |                                                       contain additional     |
+  |                                                       information.           |
+  | --silent                                              Turns off intermediate |
+  |                                                       output to console.     |
+  | --enhanced-exit-codes                                 Differentiate exit     |
+  |                                                       error codes based on   |
+  |                                                       failure type.          |
+  |                                                       [env var:              |
+  |                                                       SNOWFLAKE_ENHANCED_EX… |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[remote.list]
   '''
                                                                                   
    Usage: root remote list [OPTIONS]                                              
                                                                                   
-   List remote development environments.                                          
+   Lists all remote development environments.                                     
                                                                                   
-   This is a placeholder command for the remote plugin. Full functionality will   
-   be implemented in subsequent PRs.                                              
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -11953,13 +12086,171 @@
 # name: test_help_messages[remote.start]
   '''
                                                                                   
-   Usage: root remote start [OPTIONS]                                             
+   Usage: root remote start [OPTIONS] [NAME]                                      
                                                                                   
-   Start a remote development environment.                                        
+   Starts a remote development environment.                                       
                                                                                   
-   This is a placeholder command for the remote plugin. Full functionality will   
-   be implemented in subsequent PRs.                                              
+   This command creates a new VS Code Server remote development environment if it 
+   doesn't exist, or starts an existing one if it's suspended. If the environment 
+   is already running, it's a no-op. The environment is deployed as a Snowpark    
+   Container Service that provides a web-based development environment. Usage     
+   examples: - Resume existing service: snow remote start myproject - Create new  
+   service: snow remote start --compute-pool my_pool - Create named service: snow 
+   remote start myproject --compute-pool my_pool The --compute-pool parameter is  
+   only required when creating a new service. For resuming existing services, the 
+   compute pool is not needed.                                                    
                                                                                   
+  +- Arguments ------------------------------------------------------------------+
+  |   name      [NAME]  Service name to resume, or leave empty to create a new   |
+  |                     service with auto-generated name                         |
+  |                     [default: None]                                          |
+  +------------------------------------------------------------------------------+
+  +- Options --------------------------------------------------------------------+
+  | --compute-pool          TEXT  Name of the compute pool to use (required for  |
+  |                               new service creation)                          |
+  | --eai-name              TEXT  List of external access integration names to   |
+  |                               enable network access to external resources    |
+  |                               [default: None]                                |
+  | --stage                 TEXT  Internal Snowflake stage to mount (e.g.,       |
+  |                               @my_stage or @my_stage/folder).                |
+  |                               [default: None]                                |
+  | --image                 TEXT  Custom image to use (can be full path like     |
+  |                               'repo/image:tag' or just tag like '1.7.1')     |
+  |                               [default: None]                                |
+  | --help          -h            Show this message and exit.                    |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment    -c      TEXT     Name of the connection, as    |
+  |                                                defined in your config.toml   |
+  |                                                file. Default: default.       |
+  | --host                                TEXT     Host address for the          |
+  |                                                connection. Overrides the     |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --account,--accountname               TEXT     Name assigned to your         |
+  |                                                Snowflake account. Overrides  |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --user,--username                     TEXT     Username to connect to        |
+  |                                                Snowflake. Overrides the      |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --password                            TEXT     Snowflake password. Overrides |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --authenticator                       TEXT     Snowflake authenticator.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --workload-identity-provider          TEXT     Workload identity provider    |
+  |                                                (AWS, AZURE, GCP, OIDC).      |
+  |                                                Overrides the value specified |
+  |                                                for the connection            |
+  | --private-key-file,--privat…          TEXT     Snowflake private key file    |
+  |                                                path. Overrides the value     |
+  |                                                specified for the connection. |
+  | --token                               TEXT     OAuth token to use when       |
+  |                                                connecting to Snowflake.      |
+  | --token-file-path                     TEXT     Path to file with an OAuth    |
+  |                                                token to use when connecting  |
+  |                                                to Snowflake.                 |
+  | --database,--dbname                   TEXT     Database to use. Overrides    |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --schema,--schemaname                 TEXT     Database schema to use.       |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --role,--rolename                     TEXT     Role to use. Overrides the    |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --warehouse                           TEXT     Warehouse to use. Overrides   |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --temporary-connection        -x               Uses a connection defined     |
+  |                                                with command line parameters, |
+  |                                                instead of one defined in     |
+  |                                                config                        |
+  | --mfa-passcode                        TEXT     Token to use for multi-factor |
+  |                                                authentication (MFA)          |
+  | --enable-diag                                  Whether to generate a         |
+  |                                                connection diagnostic report. |
+  | --diag-log-path                       TEXT     Path for the generated        |
+  |                                                report. Defaults to system    |
+  |                                                temporary directory.          |
+  | --diag-allowlist-path                 TEXT     Path to a JSON file that      |
+  |                                                contains allowlist            |
+  |                                                parameters.                   |
+  | --oauth-client-id                     TEXT     Value of client id provided   |
+  |                                                by the Identity Provider for  |
+  |                                                Snowflake integration.        |
+  | --oauth-client-secret                 TEXT     Value of the client secret    |
+  |                                                provided by the Identity      |
+  |                                                Provider for Snowflake        |
+  |                                                integration.                  |
+  | --oauth-authorization-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the authorization   |
+  |                                                code to the driver.           |
+  | --oauth-token-request-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the access tokens   |
+  |                                                to the driver.                |
+  | --oauth-redirect-uri                  TEXT     URI to use for authorization  |
+  |                                                code redirection.             |
+  | --oauth-scope                         TEXT     Scope requested in the        |
+  |                                                Identity Provider             |
+  |                                                authorization request.        |
+  | --oauth-disable-pkce                           Disables Proof Key for Code   |
+  |                                                Exchange (PKCE). Default:     |
+  |                                                False.                        |
+  | --oauth-enable-refresh-toke…                   Enables a silent              |
+  |                                                re-authentication when the    |
+  |                                                actual access token becomes   |
+  |                                                outdated. Default: False.     |
+  | --oauth-enable-single-use-r…                   Whether to opt-in to          |
+  |                                                single-use refresh token      |
+  |                                                semantics. Default: False.    |
+  | --client-store-temporary-cr…                   Store the temporary           |
+  |                                                credential.                   |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
+  |                                CSV]                   format.                |
+  |                                                       [default: TABLE]       |
+  | --verbose              -v                             Displays log entries   |
+  |                                                       for log levels info    |
+  |                                                       and higher.            |
+  | --debug                                               Displays log entries   |
+  |                                                       for log levels debug   |
+  |                                                       and higher; debug logs |
+  |                                                       contain additional     |
+  |                                                       information.           |
+  | --silent                                              Turns off intermediate |
+  |                                                       output to console.     |
+  | --enhanced-exit-codes                                 Differentiate exit     |
+  |                                                       error codes based on   |
+  |                                                       failure type.          |
+  |                                                       [env var:              |
+  |                                                       SNOWFLAKE_ENHANCED_EX… |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
+# name: test_help_messages[remote.stop]
+  '''
+                                                                                  
+   Usage: root remote stop [OPTIONS] NAME                                         
+                                                                                  
+   Suspends a remote development environment.                                     
+                                                                                  
+                                                                                  
+  +- Arguments ------------------------------------------------------------------+
+  | *    name      TEXT  Remote service name. Can be either a customer name      |
+  |                      (e.g., 'myproject') or full service name (e.g.,         |
+  |                      'SNOW_REMOTE_admin_myproject')                          |
+  |                      [required]                                              |
+  +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
@@ -12086,14 +12377,16 @@
                                                                                   
    Usage: root remote [OPTIONS] COMMAND [ARGS]...                                 
                                                                                   
-   Manages remote development environments.                                       
+   Manages remote development environments on top of Snowpark Container Service.  
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | list    List remote development environments.                                |
-  | start   Start a remote development environment.                              |
+  | delete   Deletes a remote development environment.                           |
+  | list     Lists all remote development environments.                          |
+  | start    Starts a remote development environment.                            |
+  | stop     Suspends a remote development environment.                          |
   +------------------------------------------------------------------------------+
   
   
@@ -22536,14 +22829,16 @@
                                                                                   
    Usage: root remote [OPTIONS] COMMAND [ARGS]...                                 
                                                                                   
-   Manages remote development environments.                                       
+   Manages remote development environments on top of Snowpark Container Service.  
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | list    List remote development environments.                                |
-  | start   Start a remote development environment.                              |
+  | delete   Deletes a remote development environment.                           |
+  | list     Lists all remote development environments.                          |
+  | start    Starts a remote development environment.                            |
+  | stop     Suspends a remote development environment.                          |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/remote/test_commands.py
+++ b/tests/remote/test_commands.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+from snowflake.cli._plugins.remote.manager import RemoteManager
+from snowflake.connector.cursor import SnowflakeCursor
+
+
+def create_mock_cursor(columns=None, rows=None):
+    """Helper function to create a properly mocked cursor."""
+    if columns is None:
+        columns = ["status"]
+    if rows is None:
+        rows = [("Success",)]
+
+    mock_cursor = Mock(spec=SnowflakeCursor)
+    mock_cursor.description = [Mock(name=col) for col in columns]
+    mock_cursor.fetchall.return_value = rows
+    mock_cursor.__iter__ = Mock(return_value=iter(rows))
+    mock_cursor.query = "MOCK QUERY"  # Add query attribute
+    return mock_cursor
+
+
+class TestRemoteCommands:
+    @patch.object(RemoteManager, "start")
+    def test_start_command_success(self, mock_start, runner):
+        """Test successful start command."""
+        mock_start.return_value = ("test_service", "https://test.url", "created")
+
+        result = runner.invoke(
+            ["remote", "start", "test_service", "--compute-pool", "test_pool"]
+        )
+
+        assert result.exit_code == 0
+        assert (
+            "✓ Remote Development Environment test_service created successfully!"
+            in result.output
+        )
+        assert "VS Code Server URL: https://test.url" in result.output
+
+        mock_start.assert_called_once_with(
+            name="test_service",
+            compute_pool="test_pool",
+            external_access=None,
+            stage=None,
+            image=None,
+        )
+
+    @patch.object(RemoteManager, "start")
+    def test_start_command_with_all_parameters(self, mock_start, runner):
+        """Test start command with all possible parameters."""
+        mock_start.return_value = (
+            "SNOW_REMOTE_user_test",
+            "https://example.com/ui",
+            "created",
+        )
+
+        result = runner.invoke(
+            [
+                "remote",
+                "start",
+                "test_service",
+                "--compute-pool",
+                "test_pool",
+                "--stage",
+                "@my_stage",
+                "--image",
+                "custom_tag",
+                "--eai-name",
+                "eai1",
+                "--eai-name",
+                "eai2",
+                "--database",
+                "test_db",
+                "--schema",
+                "test_schema",
+            ]
+        )
+
+        assert result.exit_code == 0
+        mock_start.assert_called_once()
+        call_kwargs = mock_start.call_args.kwargs
+        assert call_kwargs["name"] == "test_service"
+        assert call_kwargs["compute_pool"] == "test_pool"
+        assert call_kwargs["stage"] == "@my_stage"
+        assert call_kwargs["image"] == "custom_tag"
+        assert call_kwargs["external_access"] == ["eai1", "eai2"]
+
+    @patch.object(RemoteManager, "start")
+    def test_start_command_idempotent_behavior(self, mock_start, runner):
+        """Test that start command handles idempotent scenarios."""
+        test_cases = [
+            ("created", "✓ Remote Development Environment"),
+            ("running", "already running"),
+            ("resumed", "resumed successfully"),
+        ]
+
+        for status, expected_output in test_cases:
+            mock_start.return_value = (
+                "SNOW_REMOTE_user_test",
+                "https://example.com/ui",
+                status,
+            )
+
+            result = runner.invoke(
+                [
+                    "remote",
+                    "start",
+                    "test_service",
+                    "--compute-pool",
+                    "test_pool",
+                ]
+            )
+
+            assert result.exit_code == 0
+            # Check for success indicators
+            assert "VS Code Server URL:" in result.output
+
+    @patch.object(RemoteManager, "list_services")
+    def test_list_command(self, mock_list, runner):
+        """Test list command."""
+        mock_cursor = create_mock_cursor(columns=["name", "status"], rows=[])
+        mock_list.return_value = mock_cursor
+
+        result = runner.invoke(["remote", "list"])
+
+        assert result.exit_code == 0
+        mock_list.assert_called_once()
+
+    @patch.object(RemoteManager, "stop")
+    def test_stop_command(self, mock_stop, runner):
+        """Test stop command."""
+        mock_cursor = create_mock_cursor(rows=[("Service suspended successfully",)])
+        mock_stop.return_value = mock_cursor
+
+        result = runner.invoke(["remote", "stop", "test_service"])
+
+        assert result.exit_code == 0
+        assert (
+            "Remote environment 'test_service' suspended successfully." in result.output
+        )
+        mock_stop.assert_called_once_with("test_service")
+
+    @patch.object(RemoteManager, "delete")
+    def test_delete_command(self, mock_delete, runner):
+        """Test delete command."""
+        mock_cursor = create_mock_cursor(rows=[("Service deleted successfully",)])
+        mock_delete.return_value = mock_cursor
+
+        result = runner.invoke(["remote", "delete", "test_service"])
+
+        assert result.exit_code == 0
+        assert (
+            "Remote environment 'test_service' deleted successfully." in result.output
+        )
+        mock_delete.assert_called_once_with("test_service")

--- a/tests/remote/test_container_spec.py
+++ b/tests/remote/test_container_spec.py
@@ -114,7 +114,7 @@ class TestContainerSpec:
     def test_generate_spec_with_custom_image_tag(self, mock_session):
         """Test generating spec with custom image tag."""
         spec = generate_service_spec(
-            session=mock_session, compute_pool="test_pool", image_tag="v1.2.3"
+            session=mock_session, compute_pool="test_pool", image="v1.2.3"
         )
 
         container = spec["spec"]["containers"][0]
@@ -122,6 +122,28 @@ class TestContainerSpec:
             "/snowflake/images/snowflake_images/st_plat/runtime/x86/runtime_image/snowbooks:v1.2.3"
             in container["image"]
         )
+
+    def test_generate_spec_with_full_image_path(self, mock_session):
+        """Test generating spec with full image path."""
+        spec = generate_service_spec(
+            session=mock_session,
+            compute_pool="test_pool",
+            image="myrepo/myimage:custom",
+        )
+
+        container = spec["spec"]["containers"][0]
+        assert container["image"] == "myrepo/myimage:custom"
+
+    def test_generate_spec_with_registry_image_path(self, mock_session):
+        """Test generating spec with registry/repo/image:tag format."""
+        spec = generate_service_spec(
+            session=mock_session,
+            compute_pool="test_pool",
+            image="registry.com/myrepo/myimage:v1.0",
+        )
+
+        container = spec["spec"]["containers"][0]
+        assert container["image"] == "registry.com/myrepo/myimage:v1.0"
 
     def test_generate_spec_with_ssh_key(self, mock_session):
         """Test generating spec with SSH public key."""

--- a/tests/remote/test_manager.py
+++ b/tests/remote/test_manager.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import pytest
+from snowflake.cli._plugins.remote.constants import SERVICE_NAME_PREFIX
+from snowflake.cli._plugins.remote.manager import RemoteManager
+
+
+class TestRemoteManager:
+    """Test general RemoteManager functionality."""
+
+    def test_get_current_snowflake_user(self):
+        """Test getting current Snowflake user from connection."""
+        manager = RemoteManager()
+
+        with patch.object(manager, "execute_query") as mock_execute:
+            from unittest.mock import Mock
+
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = ["JOHN_DOE"]
+            mock_execute.return_value = mock_cursor
+
+            result = manager._get_current_snowflake_user()  # noqa: SLF001
+            assert result == "JOHN_DOE"
+            mock_execute.assert_called_once_with("SELECT CURRENT_USER()")
+
+    def test_get_current_snowflake_user_fallback(self):
+        """Test fallback when getting current Snowflake user fails."""
+        manager = RemoteManager()
+
+        with patch.object(manager, "execute_query") as mock_execute:
+            from unittest.mock import Mock
+
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = None
+            mock_execute.return_value = mock_cursor
+
+            result = manager._get_current_snowflake_user()  # noqa: SLF001
+            assert result == "unknown"
+            mock_execute.assert_called_once_with("SELECT CURRENT_USER()")
+
+    def test_resolve_service_name_with_customer_name(self):
+        """Test resolving customer input name to full service name."""
+        manager = RemoteManager()
+
+        with patch.object(
+            manager, "_get_current_snowflake_user", return_value="SNOWFLAKE_USER"
+        ):
+            result = manager._resolve_service_name("myproject")  # noqa: SLF001
+        assert result == f"{SERVICE_NAME_PREFIX}_SNOWFLAKE_USER_MYPROJECT"
+
+    def test_resolve_service_name_with_full_service_name(self):
+        """Test that full service names are passed through unchanged."""
+        manager = RemoteManager()
+
+        result = manager._resolve_service_name(  # noqa: SLF001
+            f"{SERVICE_NAME_PREFIX}_admin_myproject"
+        )
+        assert result == f"{SERVICE_NAME_PREFIX}_admin_myproject"
+
+    def test_create_service_with_spec_sql_generation(self):
+        """Test that _create_service_with_spec generates correct SQL."""
+        manager = RemoteManager()
+
+        with patch.object(manager, "execute_query") as mock_execute:
+            manager._create_service_with_spec(  # noqa: SLF001
+                service_name="test_service",
+                compute_pool="test_pool",
+                spec_content="spec:\n  containers:\n  - name: main",
+                external_access_integrations=["eai1", "eai2"],
+            )
+
+            # Verify the SQL query was called
+            mock_execute.assert_called_once()
+            call_args = mock_execute.call_args[0][0]
+
+            # Check key components of the generated SQL
+            assert "CREATE SERVICE test_service" in call_args
+            assert "IN COMPUTE POOL test_pool" in call_args
+            assert "FROM SPECIFICATION $$" in call_args
+            assert "MIN_INSTANCES = 1" in call_args
+            assert "MAX_INSTANCES = 1" in call_args
+            assert "AUTO_RESUME = true" in call_args
+            assert "EXTERNAL_ACCESS_INTEGRATIONS = (eai1,eai2)" in call_args
+            assert (
+                "COMMENT = 'Remote development environment created by Snowflake CLI'"
+                in call_args
+            )
+
+    def test_create_service_with_spec_no_external_access(self):
+        """Test _create_service_with_spec without external access integrations."""
+        manager = RemoteManager()
+
+        with patch.object(manager, "execute_query") as mock_execute:
+            manager._create_service_with_spec(  # noqa: SLF001
+                service_name="test_service",
+                compute_pool="test_pool",
+                spec_content="spec:\n  containers:\n  - name: main",
+            )
+
+            call_args = mock_execute.call_args[0][0]
+            assert "EXTERNAL_ACCESS_INTEGRATIONS" not in call_args
+
+    def test_list_services_query_format(self):
+        """Test that list_services generates correct SQL query."""
+        from snowflake.cli._plugins.remote.constants import SERVICE_NAME_PREFIX
+
+        manager = RemoteManager()
+
+        with patch.object(manager, "execute_query") as mock_execute:
+            # Mock the first query (SHOW SERVICES)
+            mock_cursor1 = Mock()
+            mock_cursor1.sfqid = "query_id_123"
+            mock_execute.return_value = mock_cursor1
+
+            # Mock the second query (SELECT from RESULT_SCAN)
+            mock_cursor2 = Mock()
+            mock_cursor1.execute.return_value = mock_cursor2
+
+            result = manager.list_services()
+
+            # Verify the SHOW SERVICES query
+            first_call = mock_execute.call_args_list[0][0][0]
+            assert f"LIKE '{SERVICE_NAME_PREFIX}_%'" in first_call
+            assert "SHOW SERVICES EXCLUDE JOBS" in first_call
+
+            # Verify the RESULT_SCAN query
+            second_call = mock_cursor1.execute.call_args[0][0]
+            assert "RESULT_SCAN('query_id_123')" in second_call
+            assert result == mock_cursor2
+
+    def test_start_uses_name_resolution(self):
+        """Test that start method uses _resolve_service_name for name resolution."""
+        manager = RemoteManager()
+
+        # Test that _resolve_service_name is called with the provided name
+        with patch.object(manager, "_resolve_service_name") as mock_resolve:
+            mock_resolve.return_value = "SNOW_REMOTE_user_myproject"
+
+            # Mock the service status check to avoid complex mocking
+            with patch(
+                "snowflake.cli._plugins.spcs.services.manager.ServiceManager"
+            ) as mock_service_manager_class:
+                mock_service_manager = Mock()
+                mock_service_manager_class.return_value = mock_service_manager
+                mock_service_manager.status.side_effect = Exception("Service not found")
+
+                # Should raise the compute pool error, but we verify name resolution was called
+                with pytest.raises(
+                    ValueError,
+                    match="compute_pool is required for creating a new service",
+                ):
+                    manager.start(name="myproject", compute_pool=None)
+
+                # Verify name resolution was called with the provided name
+                mock_resolve.assert_called_once_with("myproject")
+
+    def test_start_compute_pool_validation_for_new_service(self):
+        """Test that compute pool is required only for new service creation."""
+        manager = RemoteManager()
+
+        with patch.object(
+            manager, "_resolve_service_name", return_value="SNOW_REMOTE_user_newservice"
+        ):
+            with patch(
+                "snowflake.cli._plugins.spcs.services.manager.ServiceManager"
+            ) as mock_service_manager_class:
+                mock_service_manager = Mock()
+                mock_service_manager_class.return_value = mock_service_manager
+
+                # Mock service doesn't exist (will try to create new service)
+                mock_service_manager.status.side_effect = Exception("Service not found")
+
+                # Should raise error when compute_pool is None for new service
+                with pytest.raises(
+                    ValueError,
+                    match="compute_pool is required for creating a new service",
+                ):
+                    manager.start(name="newservice", compute_pool=None)
+
+    def test_start_validation_requires_name_or_compute_pool(self):
+        """Test that either name or compute_pool must be provided."""
+        manager = RemoteManager()
+
+        # Should raise error when both name and compute_pool are None
+        with pytest.raises(
+            ValueError,
+            match="Either 'name' \\(for service resumption\\) or 'compute_pool' \\(for service creation\\) must be provided",
+        ):
+            manager.start(name=None, compute_pool=None)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description

This PR adds several new basic commands to `remote` plugin, to create, manage, and connect to remote development environments running on SPCS Services. The plugin provides the following commands:

- `snow remote start`: Creates a new VS Code Server remote development environment or resumes an existing one
- `snow remote list`: Lists all remote development environments
- `snow remote stop`: Suspends a remote development environment
- `snow remote delete`: Deletes a remote development environment

The remote environments are deployed as SPCS Services with a web-based VS Code Server interface, allowing users to develop directly in Snowflake without local setup requirements. More details can be found in https://docs.google.com/document/d/1M0gV7soTy3dOadwgaUQrdKdkgR6YEUiwmBgMPlj_h5I/edit?usp=sharing