### PR TITLE
SNOW-2229491 Fixed flaky test for Native Apps teardown

### DIFF
--- a/tests_integration/nativeapp/test_post_deploy.py
+++ b/tests_integration/nativeapp/test_post_deploy.py
@@ -99,79 +99,75 @@ def test_nativeapp_post_deploy(
     pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
     with nativeapp_project_directory(test_project):
-        try:
-            # first run, application is created
-            run(runner, base_command, [])
+        # first run, application is created
+        run(runner, base_command, [])
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
 
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-            # Second run, application is upgraded
-            run(runner, base_command, [])
+        # Second run, application is upgraded
+        run(runner, base_command, [])
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-            deploy(runner, base_command, [])
+        deploy(runner, base_command, [])
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
-
-        finally:
-            teardown(runner, [])
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
 
 @pytest.mark.integration
@@ -198,82 +194,79 @@ def test_nativeapp_post_deploy_versioned(
     with nativeapp_project_directory(test_project):
         version_run_args = ["--version", version]
 
-        try:
-            # first run, application is created
-            create_version(runner, version, [])
-            run(runner, base_command, version_run_args)
+        # first run, application is created
+        create_version(runner, version, [])
+        run(runner, base_command, version_run_args)
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
 
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-            # Second run, application is upgraded
-            create_version(runner, version, [])
-            run(runner, base_command, version_run_args)
+        # Second run, application is upgraded
+        create_version(runner, version, [])
+        run(runner, base_command, version_run_args)
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-            deploy(runner, base_command, [])
+        deploy(runner, base_command, [])
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-        finally:
-            drop_version(runner, version, [])
-            teardown(runner, [])
+        drop_version(runner, version, [])
 
 
 @pytest.mark.integration
@@ -302,79 +295,75 @@ def test_nativeapp_post_deploy_with_project_flag(
         working_directory_changer = WorkingDirectoryChanger()
         working_directory_changer.change_working_directory_to("app")
 
-        try:
-            # first run, application is created
-            run(runner, base_command, project_args)
+        # first run, application is created
+        run(runner, base_command, project_args)
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
 
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-            # Second run, application is upgraded
-            run(runner, base_command, project_args)
+        # Second run, application is upgraded
+        run(runner, base_command, project_args)
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
-            deploy(runner, base_command, project_args)
+        deploy(runner, base_command, project_args)
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
-
-        finally:
-            teardown(runner, project_args)
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
 
 @pytest.mark.integration
@@ -401,18 +390,17 @@ def test_nativeapp_post_deploy_with_windows_path(
     pkg_name = f"{project_name}_pkg_{default_username}{resource_suffix}"
 
     with nativeapp_project_directory(test_project) as tmp_dir:
-        try:
-            snowflake_yml_path = tmp_dir / "snowflake.yml"
-            with open(snowflake_yml_path, "r", encoding="utf-8") as file:
-                yml = yaml.safe_load(file)
-                if yml["definition_version"] >= 2:
-                    artifact = yml["entities"]["pkg"]["artifacts"][0]
-                    pkg_scripts = yml["entities"]["pkg"]["meta"]["post_deploy"]
-                    app_scripts = yml["entities"]["app"]["meta"]["post_deploy"]
-                else:
-                    artifact = yml["native_app"]["artifacts"][0]
-                    pkg_scripts = yml["native_app"]["package"]["post_deploy"]
-                    app_scripts = yml["native_app"]["application"]["post_deploy"]
+        snowflake_yml_path = tmp_dir / "snowflake.yml"
+        with open(snowflake_yml_path, "r", encoding="utf-8") as file:
+            yml = yaml.safe_load(file)
+            if yml["definition_version"] >= 2:
+                artifact = yml["entities"]["pkg"]["artifacts"][0]
+                pkg_scripts = yml["entities"]["pkg"]["meta"]["post_deploy"]
+                app_scripts = yml["entities"]["app"]["meta"]["post_deploy"]
+            else:
+                artifact = yml["native_app"]["artifacts"][0]
+                pkg_scripts = yml["native_app"]["package"]["post_deploy"]
+                app_scripts = yml["native_app"]["application"]["post_deploy"]
 
                 # use backslashes in artifacts src
                 artifact["src"] = artifact["src"].replace("/", "\\")
@@ -433,31 +421,28 @@ def test_nativeapp_post_deploy_with_windows_path(
                     (tmp_dir / app_scripts[1]["sql_script"]).absolute()
                 )
 
-            with open(snowflake_yml_path, "w", encoding="utf-8") as file:
-                yaml.dump(yml, file)
+        with open(snowflake_yml_path, "w", encoding="utf-8") as file:
+            yaml.dump(yml, file)
 
-            run(runner, base_command, [])
+        run(runner, base_command, [])
 
-            verify_app_post_deploy_log(
-                snowflake_session,
-                app_name,
-                [
-                    {"TEXT": "app-post-deploy-part-1"},
-                    {"TEXT": "app-post-deploy-part-2"},
-                ],
-            )
+        verify_app_post_deploy_log(
+            snowflake_session,
+            app_name,
+            [
+                {"TEXT": "app-post-deploy-part-1"},
+                {"TEXT": "app-post-deploy-part-2"},
+            ],
+        )
 
-            verify_pkg_post_deploy_log(
-                snowflake_session,
-                pkg_name,
-                [
-                    {"TEXT": "package-post-deploy-part-1"},
-                    {"TEXT": "package-post-deploy-part-2"},
-                ],
-            )
-
-        finally:
-            teardown(runner, [])
+        verify_pkg_post_deploy_log(
+            snowflake_session,
+            pkg_name,
+            [
+                {"TEXT": "package-post-deploy-part-1"},
+                {"TEXT": "package-post-deploy-part-2"},
+            ],
+        )
 
 
 @pytest.mark.integration

--- a/tests_integration/nativeapp/test_project_templating.py
+++ b/tests_integration/nativeapp/test_project_templating.py
@@ -364,29 +364,22 @@ def test_nativeapp_templates_processor_with_run(
         if with_project_flag:
             working_directory_changer = WorkingDirectoryChanger()
             working_directory_changer.change_working_directory_to("app")
-        try:
-            result = runner.invoke_with_connection_json(
-                ["app", "run"] + project_args,
-                env={
-                    "schema_name": "test_schema",
-                    "table_name": "test_table",
-                    "value": "test_value",
-                },
-            )
-            assert result.exit_code == 0
+        result = runner.invoke_with_connection_json(
+            ["app", "run"] + project_args,
+            env={
+                "schema_name": "test_schema",
+                "table_name": "test_table",
+                "value": "test_value",
+            },
+        )
+        assert result.exit_code == 0
 
-            result = row_from_snowflake_session(
-                snowflake_session.execute_string(
-                    f"select * from {app_name}.test_schema.test_table",
-                )
+        result = row_from_snowflake_session(
+            snowflake_session.execute_string(
+                f"select * from {app_name}.test_schema.test_table",
             )
-            assert result == [{"NAME": "test_value"}]
-
-        finally:
-            result = runner.invoke_with_connection_json(
-                ["app", "teardown", "--force"] + project_args
-            )
-            assert result.exit_code == 0
+        )
+        assert result == [{"NAME": "test_value"}]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Fix flaky integration test by removing redundant manual teardown calls that caused state leaking between test runs. The manual teardown used incomplete `--force` cleanup while the automatic fixture-based teardown uses comprehensive `--force --cascade` cleanup, ensuring complete removal of application objects and preventing "Insufficient privileges" errors in subsequent tests.

Closes: #2508

