### PR TITLE
chore: [NOSNOW] pin hatch version in build scripts

### DIFF
--- a/scripts/packaging/Dockerfile
+++ b/scripts/packaging/Dockerfile
@@ -42,6 +42,6 @@ ENV PATH="/usr/local/bin:$PATH"
 
 # Install build tools - these are not embedded in final binary so can use pre-built wheels
 # pinning click to 8.2.1 due to issues with 8.3.0 https://github.com/pypa/hatch/issues/2050
-RUN python -m pip install -U click==8.2.1 uv hatch
+RUN python -m pip install -U click==8.2.1 uv hatch==1.15.1
 
 WORKDIR /snowflake-cli

--- a/scripts/packaging/build_darwin_package.sh
+++ b/scripts/packaging/build_darwin_package.sh
@@ -11,7 +11,7 @@ python3.11 -m venv venv
 python --version
 
 echo "--- installing dependencies ---"
-pip install click==8.2.1 hatch
+pip install click==8.2.1 hatch==1.15.1
 
 # install cargo
 if [[ ${MACHINE} == "arm64" ]]; then

--- a/scripts/packaging/win/build_installer.bat
+++ b/scripts/packaging/win/build_installer.bat
@@ -5,7 +5,7 @@ set PATH=C:\Program Files\7-Zip;C:\Users\jenkins\AppData\Local\Programs\Python\P
 python.exe --version
 python.exe -c "import platform as p; print(f'{p.system()=}, {p.architecture()=}')"
 
-python.exe -m pip install click==8.2.1 hatch
+python.exe -m pip install click==8.2.1 hatch==1.15.1
 FOR /F "delims=" %%I IN ('hatch run packaging:win-build-version') DO SET CLI_VERSION=%%I
 FOR /F "delims=" %%I IN ('git rev-parse %svnRevision%') DO SET REVISION=%%I
 FOR /F "delims=" %%I IN ('echo %releaseType%') DO SET RELEASE_TYPE=%%I

--- a/scripts/packaging/win/build_snowflake_cli.bat
+++ b/scripts/packaging/win/build_snowflake_cli.bat
@@ -4,7 +4,7 @@ set PATH=C:\Program Files\Python310\;c:\Program Files (x86)\Windows Kits\8.1\bin
 python.exe --version
 python.exe -c "import platform as p; print(f'{p.system()=}, {p.architecture()=}')"
 
-python.exe -m pip install --upgrade pip uv click==8.2.1 hatch
+python.exe -m pip install --upgrade pip uv click==8.2.1 hatch==1.15.1
 
 curl -o rustup-init.exe https://win.rustup.rs/
 rustup-init.exe -y


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
I believe that [hatch 1.16.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.0) introduced breaking changes for us with `Environment type plugins are now no longer expected to support a pseudo-build environment as any environment now may be used for building. The following methods have been removed: build_environment, build_environment_exists, run_builder, construct_build_command`. For now I want to only unblock building binaries and upgrade hatch in a separate issue.
