### PR TITLE
SNOW-3022692 Support DCM Project name with spaces

### DIFF
--- a/src/snowflake/cli/api/identifiers.py
+++ b/src/snowflake/cli/api/identifiers.py
@@ -27,6 +27,7 @@ from snowflake.cli.api.project.schemas.v1.identifier_model import (
 from snowflake.cli.api.project.util import (
     VALID_IDENTIFIER_REGEX,
     identifier_for_url,
+    sanitize_identifier,
     unquote_identifier,
 )
 
@@ -179,9 +180,10 @@ class FQN:
     ) -> "FQN":
         """Create an instance related to another Snowflake resource."""
         unquoted_name = unquote_identifier(resource_fqn.name)
+        safe_name = sanitize_identifier(unquoted_name)
         safe_cli_name = resource_type.value.cli_name.upper().replace("-", "_")
         return cls.from_string(
-            f"{safe_cli_name}_{unquoted_name}_{int(time.time())}_{purpose.upper()}"
+            f"{safe_cli_name}_{safe_name}_{int(time.time())}_{purpose.upper()}"
         ).using_context()
 
     def set_database(self, database: str | None) -> "FQN":


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
https://snowflakecomputing.atlassian.net/browse/SNOW-3022692

This PR adds support for whitespace characters in the DCM Project name.