### PR TITLE
SNOW-3006577 Support Remote File Path

### DIFF
--- a/src/snowflake/cli/_plugins/spark/commands.py
+++ b/src/snowflake/cli/_plugins/spark/commands.py
@@ -156,8 +156,6 @@ def submit(
         # validate required arguments
         if not entrypoint_file:
             raise ClickException("Entrypoint file path is required")
-        if not snow_file_stage:
-            raise ClickException(f"--snow-file-stage is required")
 
         file_name = manager.upload_file_to_stage(entrypoint_file, snow_file_stage)
 

--- a/src/snowflake/cli/_plugins/spark/manager.py
+++ b/src/snowflake/cli/_plugins/spark/manager.py
@@ -22,7 +22,18 @@ log = logging.getLogger(__name__)
 
 
 class SubmitQueryBuilder:
-    def __init__(self, file_on_stage: str, scls_file_stage: str):
+    file_stage_path = "/tmp/entrypoint"
+
+    def _get_file_stage_path(self, file_path: str) -> str:
+        # if the file path is a remote path, return the file path as is
+        if "://" in file_path:
+            return file_path
+        # file path should never start with a slash
+        if file_path.startswith("/"):
+            raise ClickException("Absolute file paths are not supported")
+        return f"{self.file_stage_path}/{file_path}"
+
+    def __init__(self, file_on_stage: str, scls_file_stage: Optional[str]):
         self.file_on_stage = file_on_stage
         self.snow_file_stage = scls_file_stage
         self.spark_configurations: dict[str, str] = {}
@@ -60,7 +71,7 @@ class SubmitQueryBuilder:
         self.jars = jars
         if jars and len(jars) > 0:
             self.spark_configurations["spark.jars"] = ",".join(
-                f"/tmp/entrypoint/{jar}" for jar in jars
+                self._get_file_stage_path(jar) for jar in jars
             )
         return self
 
@@ -68,7 +79,7 @@ class SubmitQueryBuilder:
         self.py_files = py_files
         if py_files and len(py_files) > 0:
             self.spark_configurations["spark.submit.pyFiles"] = ",".join(
-                f"/tmp/entrypoint/{py_file}" for py_file in py_files
+                self._get_file_stage_path(py_file) for py_file in py_files
             )
         return self
 
@@ -149,13 +160,13 @@ class SubmitQueryBuilder:
         return self
 
     def build(self) -> str:
-        stage_name = (
-            self.snow_file_stage
-            if not self.snow_file_stage.endswith("/")
-            else f"@{self.snow_file_stage.rstrip('/')}"
-        )
-
-        self.snow_stage_mount[stage_name] = "/tmp/entrypoint"
+        if self.snow_file_stage:
+            stage_name = (
+                self.snow_file_stage
+                if not self.snow_file_stage.endswith("/")
+                else f"@{self.snow_file_stage.rstrip('/')}"
+            )
+            self.snow_stage_mount[stage_name] = self.file_stage_path
 
         query_parts = [
             "EXECUTE SPARK APPLICATION",
@@ -167,7 +178,9 @@ class SubmitQueryBuilder:
         )
         query_parts.append(f"STAGE_MOUNTS=({mount_str})")
 
-        query_parts.append(f"ENTRYPOINT_FILE='/tmp/entrypoint/{self.file_on_stage}'")
+        query_parts.append(
+            f"ENTRYPOINT_FILE='{self._get_file_stage_path(self.file_on_stage)}'"
+        )
 
         # Scala/Java applications require a main class name
         if self.file_on_stage.endswith(".jar"):
@@ -242,8 +255,22 @@ class SparkManager(SqlExecutionMixin):
         except Exception as e:
             raise ClickException(f"Failed to submit Spark application: {e}")
 
-    def upload_file_to_stage(self, entrypoint_file: str, scls_file_stage: str):
-        query = f"PUT file://{entrypoint_file} {scls_file_stage} AUTO_COMPRESS=FALSE OVERWRITE=TRUE"
+    def upload_file_to_stage(
+        self, entrypoint_file: str, scls_file_stage: Optional[str]
+    ):
+        if not self._is_local_file(entrypoint_file):
+            log.debug("File %s is a remote file, skipping upload", entrypoint_file)
+            return entrypoint_file
+
+        if not scls_file_stage:
+            raise ClickException(f"--snow-file-stage is required")
+
+        # Strip file:// prefix if present to avoid double-prefixing
+        file_path = entrypoint_file
+        if file_path.lower().startswith("file://"):
+            file_path = file_path[7:]
+
+        query = f"PUT file://{file_path} {scls_file_stage} AUTO_COMPRESS=FALSE OVERWRITE=TRUE"
         log.debug("Uploading %s to %s", entrypoint_file, scls_file_stage)
         try:
             result = self.execute_query(query).fetchone()
@@ -288,3 +315,6 @@ class SparkManager(SqlExecutionMixin):
             return result[0]
         except Exception as e:
             raise ClickException(f"Failed to kill {spark_application_id}: {e}")
+
+    def _is_local_file(self, file_path: str) -> bool:
+        return file_path.lower().startswith("file://") or "://" not in file_path

--- a/tests/spark/test_manager.py
+++ b/tests/spark/test_manager.py
@@ -114,6 +114,90 @@ class TestSclsManager:
         assert "Stage not found" in str(exc_info.value.message)
 
     @mock.patch(f"{SCLS_MANAGER}.execute_query")
+    def test_upload_file_to_stage_skips_remote_s3_file(self, mock_execute_query):
+        """Test that upload_file_to_stage skips upload for s3:// remote files."""
+        manager = SparkManager()
+        result = manager.upload_file_to_stage(
+            "s3://bucket/path/to/app.jar", "@my_stage/jars"
+        )
+
+        assert result == "s3://bucket/path/to/app.jar"
+        mock_execute_query.assert_not_called()
+
+    @mock.patch(f"{SCLS_MANAGER}.execute_query")
+    def test_upload_file_to_stage_skips_remote_https_file(self, mock_execute_query):
+        """Test that upload_file_to_stage skips upload for https:// remote files."""
+        manager = SparkManager()
+        result = manager.upload_file_to_stage(
+            "https://example.com/app.jar", "@my_stage/jars"
+        )
+
+        assert result == "https://example.com/app.jar"
+        mock_execute_query.assert_not_called()
+
+    @mock.patch(f"{SCLS_MANAGER}.execute_query")
+    def test_upload_file_to_stage_skips_remote_hdfs_file(self, mock_execute_query):
+        """Test that upload_file_to_stage skips upload for hdfs:// remote files."""
+        manager = SparkManager()
+        result = manager.upload_file_to_stage(
+            "hdfs://cluster/path/to/app.jar", "@my_stage/jars"
+        )
+
+        assert result == "hdfs://cluster/path/to/app.jar"
+        mock_execute_query.assert_not_called()
+
+    @mock.patch(f"{SCLS_MANAGER}.execute_query")
+    def test_upload_file_to_stage_skips_local_protocol_file(self, mock_execute_query):
+        """Test that upload_file_to_stage skips upload for local:// files (container path)."""
+        manager = SparkManager()
+        result = manager.upload_file_to_stage(
+            "local://path/to/app.jar", "@my_stage/jars"
+        )
+
+        assert result == "local://path/to/app.jar"
+        mock_execute_query.assert_not_called()
+
+    @mock.patch(f"{SCLS_MANAGER}.execute_query")
+    def test_upload_file_to_stage_uploads_file_protocol(
+        self, mock_execute_query, mock_cursor
+    ):
+        """Test that upload_file_to_stage uploads files with file:// protocol."""
+        mock_execute_query.return_value = mock_cursor(
+            rows=[
+                (
+                    "file:///path/to/app.jar",
+                    "app.jar",
+                    1024,
+                    1024,
+                    "none",
+                    "none",
+                    "UPLOADED",
+                    "",
+                )
+            ],
+            columns=[
+                "source",
+                "target",
+                "source_size",
+                "target_size",
+                "source_compression",
+                "target_compression",
+                "status",
+                "message",
+            ],
+        )
+
+        manager = SparkManager()
+        result = manager.upload_file_to_stage(
+            "file:///path/to/app.jar", "@my_stage/jars"
+        )
+
+        assert result == "app.jar"
+        mock_execute_query.assert_called_once_with(
+            "PUT file:///path/to/app.jar @my_stage/jars AUTO_COMPRESS=FALSE OVERWRITE=TRUE"
+        )
+
+    @mock.patch(f"{SCLS_MANAGER}.execute_query")
     def test_check_status_success(self, mock_execute_query, mock_cursor):
         """Test successful status check of a Spark application."""
         expected_cursor = mock_cursor(
@@ -276,3 +360,26 @@ class TestSclsManager:
         mock_execute_query.assert_called_once_with(
             "SELECT * FROM TABLE(snowflake.spark.GET_SPARK_APPLICATION_HISTORY()) WHERE ID = 'app-123'"
         )
+
+    @pytest.mark.parametrize(
+        "file_path,expected",
+        [
+            ("file:///path/to/file.jar", True),
+            ("FILE:///path/to/file.jar", True),
+            ("File:///path/to/file.jar", True),
+            ("FiLe:///path/to/file.jar", True),
+            ("/path/to/file.jar", True),
+            ("./relative/path/file.jar", True),
+            ("relative/path/file.jar", True),
+            ("@stage/path/file.jar", True),
+            ("s3://bucket/path/file.jar", False),
+            ("https://example.com/file.jar", False),
+            ("hdfs://cluster/path/file.jar", False),
+            ("gs://bucket/path/file.jar", False),
+            ("local://path/to/file.jar", False),
+        ],
+    )
+    def test_is_local_file(self, file_path, expected):
+        """Test _is_local_file returns correct value for various file paths."""
+        manager = SparkManager()
+        assert manager._is_local_file(file_path) == expected  # noqa: SLF001

--- a/tests/spark/test_submit.py
+++ b/tests/spark/test_submit.py
@@ -501,3 +501,39 @@ class TestSclsSubmit:
             "SECRETS=('secret1' = secret1_value, 'secret2' = secret2_value)"
             in submit_query
         )
+
+    @mock.patch(SCLS_MANAGER)
+    def test_load_entrypoint_file_from_stage(self, mock_manager, runner, tmp_path):
+        """Test loading an entrypoint file from a stage."""
+
+        mock_manager().upload_file_to_stage.side_effect = [
+            "local:///tmp/path1/app.jar",
+            "local:///tmp/path1/common.jar",
+            "local:///tmp/path1/lib.jar",
+        ]
+        mock_manager().submit.return_value = (
+            "Spark Application ID: app-with-entrypoint-from-stage"
+        )
+
+        result = runner.invoke(
+            [
+                "spark",
+                "submit",
+                "--snow-stage-mount",
+                "@my_stage:/tmp/path1",
+                "--jars",
+                "local:///tmp/path1/common.jar,local:///tmp/path1/lib.jar",
+                "--class",
+                "com.example.Main",
+                "local:///tmp/path1/app.jar",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Spark Application ID: app-with-entrypoint-from-stage" in result.output
+        submit_query = mock_manager().submit.call_args[0][0]
+        assert "ENTRYPOINT_FILE='local:///tmp/path1/app.jar'" in submit_query
+        assert (
+            "'spark.jars' = 'local:///tmp/path1/common.jar,local:///tmp/path1/lib.jar'"
+            in submit_query
+        )
+        assert "STAGE_MOUNTS=('@my_stage:/tmp/path1')" in submit_query

--- a/tests/spark/test_submit_query_builder.py
+++ b/tests/spark/test_submit_query_builder.py
@@ -474,3 +474,122 @@ class TestSubmitQueryBuilder:
 
         query = builder.build()
         assert "SECRETS" not in query
+
+    @pytest.mark.parametrize(
+        "file_path,expected",
+        [
+            ("s3://bucket/path/to/file.jar", "s3://bucket/path/to/file.jar"),
+            ("https://example.com/file.jar", "https://example.com/file.jar"),
+            ("hdfs://cluster/path/file.jar", "hdfs://cluster/path/file.jar"),
+            ("gs://bucket/path/file.jar", "gs://bucket/path/file.jar"),
+            ("local://path/to/file.jar", "local://path/to/file.jar"),
+            ("file:///path/to/file.jar", "file:///path/to/file.jar"),
+        ],
+    )
+    def test_get_file_stage_path_returns_remote_path_as_is(self, file_path, expected):
+        """Test that _get_file_stage_path returns remote paths unchanged."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="app.py", scls_file_stage="@my_stage"
+        )
+        assert builder._get_file_stage_path(file_path) == expected  # noqa: SLF001
+
+    @pytest.mark.parametrize(
+        "file_path,expected",
+        [
+            ("app.jar", "/tmp/entrypoint/app.jar"),
+            ("app.py", "/tmp/entrypoint/app.py"),
+            ("subdir/app.jar", "/tmp/entrypoint/subdir/app.jar"),
+            ("my-app-1.0.jar", "/tmp/entrypoint/my-app-1.0.jar"),
+            ("libs/dependency.jar", "/tmp/entrypoint/libs/dependency.jar"),
+        ],
+    )
+    def test_get_file_stage_path_prepends_stage_path_for_local_files(
+        self, file_path, expected
+    ):
+        """Test that _get_file_stage_path prepends file_stage_path for local paths."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="app.py", scls_file_stage="@my_stage"
+        )
+        assert builder._get_file_stage_path(file_path) == expected  # noqa: SLF001
+
+    def test_build_with_local_protocol_entrypoint_file(self):
+        """Test that entrypoint_file with local:// prefix is used as-is."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="local://container/path/app.py", scls_file_stage="@my_stage"
+        )
+
+        query = builder.build()
+
+        assert "ENTRYPOINT_FILE='local://container/path/app.py'" in query
+
+    def test_build_with_local_protocol_jar_entrypoint(self):
+        """Test that JAR entrypoint_file with local:// prefix is used as-is."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="local://container/path/app.jar", scls_file_stage="@my_stage"
+        )
+        builder.with_class_name("com.example.Main")
+
+        query = builder.build()
+
+        assert "ENTRYPOINT_FILE='local://container/path/app.jar'" in query
+        assert "CLASS = 'com.example.Main'" in query
+
+    def test_build_with_local_protocol_jars(self):
+        """Test that jars with local:// prefix are used as-is in spark.jars config."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="app.py", scls_file_stage="@my_stage"
+        )
+        builder.with_jars(
+            ["local://container/libs/dep1.jar", "local://container/libs/dep2.jar"]
+        )
+
+        query = builder.build()
+
+        assert (
+            "'spark.jars' = 'local://container/libs/dep1.jar,local://container/libs/dep2.jar'"
+            in query
+        )
+
+    def test_build_with_local_protocol_py_files(self):
+        """Test that py_files with local:// prefix are used as-is in spark.submit.pyFiles config."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="app.py", scls_file_stage="@my_stage"
+        )
+        builder.with_py_files(
+            ["local://container/libs/utils.py", "local://container/libs/helpers.py"]
+        )
+
+        query = builder.build()
+
+        assert (
+            "'spark.submit.pyFiles' = 'local://container/libs/utils.py,local://container/libs/helpers.py'"
+            in query
+        )
+
+    def test_build_with_mixed_local_and_stage_jars(self):
+        """Test mixing local:// jars with stage-uploaded jars."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="app.py", scls_file_stage="@my_stage"
+        )
+        builder.with_jars(["local://container/libs/external.jar", "uploaded.jar"])
+
+        query = builder.build()
+
+        assert (
+            "'spark.jars' = 'local://container/libs/external.jar,/tmp/entrypoint/uploaded.jar'"
+            in query
+        )
+
+    def test_build_with_mixed_local_and_stage_py_files(self):
+        """Test mixing local:// py_files with stage-uploaded py_files."""
+        builder = SubmitQueryBuilder(
+            file_on_stage="app.py", scls_file_stage="@my_stage"
+        )
+        builder.with_py_files(["local://container/libs/external.py", "uploaded.py"])
+
+        query = builder.build()
+
+        assert (
+            "'spark.submit.pyFiles' = 'local://container/libs/external.py,/tmp/entrypoint/uploaded.py'"
+            in query
+        )


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

This change adds support for remote file paths in Spark application submissions. The CLI now accepts files with protocol prefixes (s3://, https://, hdfs://, gs://, local://, file://) and handles them appropriately:

- Remote files (s3://, https://, hdfs://, gs://, local://) are used directly without uploading to a stage
- The `--snow-file-stage` parameter is now only required when uploading local files
- File paths with protocol prefixes are preserved as-is in the generated Spark query
- Local files without protocol prefixes continue to be uploaded to the specified stage

The implementation includes:
- Detection logic to differentiate between local and remote files
- Path handling that preserves remote URLs while prepending stage paths for local files
- Validation to prevent absolute local paths (starting with "/")
- Support for file:// protocol files which are treated as local and uploaded to stages