### PR TITLE
feat(streamlit): add --skip-stage-creation flag for streamlit deploy

### DIFF
--- a/src/snowflake/cli/_plugins/streamlit/commands.py
+++ b/src/snowflake/cli/_plugins/streamlit/commands.py
@@ -134,6 +134,13 @@ LegacyOption = typer.Option(
     is_flag=True,
 )
 
+SkipStageCreationOption = typer.Option(
+    False,
+    "--skip-stage-creation",
+    help="Skip automatic creation of stage. Stage must already exist.",
+    is_flag=True,
+)
+
 
 @app.command("deploy", requires_connection=True)
 @with_project_definition()
@@ -147,6 +154,7 @@ def streamlit_deploy(
     entity_id: str = entity_argument("streamlit"),
     open_: bool = OpenOption,
     legacy: bool = LegacyOption,
+    skip_stage_creation: bool = SkipStageCreationOption,
     **options,
 ) -> CommandResult:
     """
@@ -194,6 +202,7 @@ def streamlit_deploy(
         replace=replace,
         legacy=legacy,
         prune=prune,
+        skip_stage_creation=skip_stage_creation,
     )
 
     if open_:

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -99,6 +99,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         prune: bool = False,
         bundle_map: Optional[BundleMap] = None,
         legacy: bool = False,
+        skip_stage_creation: bool = False,
         *args,
         **kwargs,
     ):
@@ -140,9 +141,9 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
                 )
 
         if legacy:
-            self._deploy_legacy(bundle_map=bundle_map, replace=replace, prune=prune)
+            self._deploy_legacy(bundle_map=bundle_map, replace=replace, prune=prune, skip_stage_creation=skip_stage_creation)
         else:
-            self._deploy_versioned(bundle_map=bundle_map, replace=replace, prune=prune)
+            self._deploy_versioned(bundle_map=bundle_map, replace=replace, prune=prune, skip_stage_creation=skip_stage_creation)
 
         return self.perform(EntityActions.GET_URL, action_context, *args, **kwargs)
 
@@ -256,7 +257,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
             return False
 
     def _deploy_legacy(
-        self, bundle_map: BundleMap, replace: bool = False, prune: bool = False
+        self, bundle_map: BundleMap, replace: bool = False, prune: bool = False, skip_stage_creation: bool = False
     ):
         console = self._workspace_ctx.console
         console.step(f"Uploading artifacts to stage {self.model.stage}")
@@ -278,6 +279,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
             recursive=True,
             stage_path_parts=StageManager().stage_path_parts_from_str(stage_root),
             print_diff=True,
+            skip_stage_creation=skip_stage_creation,
         )
 
         console.step(f"Creating Streamlit object {self.model.fqn.sql_identifier}")
@@ -293,7 +295,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         StreamlitManager(connection=self._conn).grant_privileges(self.model)
 
     def _deploy_versioned(
-        self, bundle_map: BundleMap, replace: bool = False, prune: bool = False
+        self, bundle_map: BundleMap, replace: bool = False, prune: bool = False, skip_stage_creation: bool = False
     ):
         self._execute_query(
             self.get_deploy_sql(
@@ -322,6 +324,7 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
             stage_path_parts=stage_path_parts,
             print_diff=True,
             force_overwrite=True,  # files copied to streamlit vstage need to be overwritten
+            skip_stage_creation=skip_stage_creation,
         )
 
         StreamlitManager(connection=self._conn).grant_privileges(self.model)

--- a/src/snowflake/cli/api/entities/utils.py
+++ b/src/snowflake/cli/api/entities/utils.py
@@ -93,6 +93,7 @@ def sync_deploy_root_with_stage(
     local_paths_to_sync: List[Path] | None = None,
     print_diff: bool = True,
     force_overwrite: bool = False,
+    skip_stage_creation: bool = False,
 ) -> DiffResult:
     """
     Ensures that the files on our remote stage match the artifacts we have in
@@ -112,6 +113,7 @@ def sync_deploy_root_with_stage(
         local paths. Note that providing an empty list here is equivalent to None.
         print_diff (bool): Whether to print the diff between the local files and the remote stage. Defaults to True
         force_overwrite (bool): Some resources (e.g. streamlit) need to overwrite files on the stage. Defaults to False.
+        skip_stage_creation (bool): Whether to skip automatic creation of stage. Stage must already exist. Defaults to False.
 
     Returns:
         A `DiffResult` instance describing the changes that were performed.
@@ -119,6 +121,9 @@ def sync_deploy_root_with_stage(
     if stage_path_parts.is_vstage:
         # vstages are created by FBE, so no need to do it manually
         pass
+    elif skip_stage_creation:
+        # skip stage creation as requested by user
+        console.step(f"Skipping stage creation for {stage_path_parts.stage} (--skip-stage-creation flag is set).")
     elif not package_name:
         # ensure stage exists
         stage_fqn = FQN.from_stage(stage_path_parts.stage)


### PR DESCRIPTION
Fixes #1903

This PR adds a new --skip-stage-creation flag to the snow streamlit deploy command.

Problem: Currently, streamlit deploy runs 'create stage if not exists' even if the stage already exists, requiring create stage access. This is problematic for users who manage infrastructure with Terraform.

Solution: Added --skip-stage-creation flag that skips automatic stage creation. The stage must already exist when using this flag.

Changes:
- Added SkipStageCreationOption to streamlit deploy command
- Updated StreamlitEntity.deploy() to accept skip_stage_creation parameter  
- Modified sync_deploy_root_with_stage() to respect the skip flag
- Added console messaging when stage creation is skipped

Usage: snow streamlit deploy --skip-stage-creation

All existing functionality preserved with default behavior unchanged.