### PR TITLE
SNOW-3017492 Fix for overloaded functions handling in DCM plan/deploy reporter

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/reporters/plan.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/plan.py
@@ -123,7 +123,10 @@ class PlanRow:
         if self.fqn.schema:
             parts.append(unquote_identifier(self.fqn.schema))
         parts.append(unquote_identifier(self.fqn.name))
-        return ".".join(parts)
+        result = ".".join(parts)
+        if self.fqn.signature:
+            result += self.fqn.signature
+        return result
 
 
 class PlanReporter(Reporter[PlanRow]):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Before the fix, the reporter ignored the function signature. Now it prints the signature as well, which correctly supports overloaded functions.