### PR TITLE
Hide preview, refresh and test DCM commands

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -495,7 +495,7 @@ def drop_deployment(
     )
 
 
-@app.command(requires_connection=True)
+@app.command(requires_connection=True, hidden=True)
 def preview(
     identifier: Optional[FQN] = optional_dcm_identifier,
     object_identifier: FQN = typer.Option(
@@ -545,7 +545,7 @@ def preview(
     return QueryResult(result)
 
 
-@app.command(requires_connection=True)
+@app.command(requires_connection=True, hidden=True)
 @mock_dcm_response("refresh")
 def refresh(
     identifier: Optional[FQN] = optional_dcm_identifier,
@@ -567,7 +567,7 @@ def refresh(
     return EmptyResult()
 
 
-@app.command(requires_connection=True)
+@app.command(requires_connection=True, hidden=True)
 @mock_dcm_response("test")
 def test(
     identifier: Optional[FQN] = optional_dcm_identifier,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -9160,9 +9160,6 @@
   | list-deployments   Lists deployments of given DCM Project.                   |
   | plan               Plans a DCM Project deployment (validates without         |
   |                    executing).                                               |
-  | preview            Returns rows from any table, view, dynamic table.         |
-  | refresh            Refreshes dynamic tables defined in DCM project.          |
-  | test               Tests all expectations defined in DCM project.            |
   +------------------------------------------------------------------------------+
   
   
@@ -22907,9 +22904,6 @@
   | list-deployments   Lists deployments of given DCM Project.                   |
   | plan               Plans a DCM Project deployment (validates without         |
   |                    executing).                                               |
-  | preview            Returns rows from any table, view, dynamic table.         |
-  | refresh            Refreshes dynamic tables defined in DCM project.          |
-  | test               Tests all expectations defined in DCM project.            |
   +------------------------------------------------------------------------------+
   
   


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
This change hides preview, refresh, and test commands of the DCM plugin. They are not available yet in the backend.