### PR TITLE
fix: use execute_async() for async queries to prevent session cancellation

### DIFF
--- a/src/snowflake/cli/_plugins/sql/manager.py
+++ b/src/snowflake/cli/_plugins/sql/manager.py
@@ -120,7 +120,7 @@ class SqlManager(SqlExecutionMixin):
         for stmt in compiled_statements:
             if stmt.execute_async:
                 cursor = self._conn.cursor(cursor_class=cursor_class)
-                cursor.execute(stmt.statement, _no_results=True)
+                cursor.execute_async(stmt.statement)
                 # only log query ID for consistency with SnowSQL
                 logger.info("Async execution id: %s", cursor.sfqid)
                 print_result(CollectionResult([{"scheduled query ID": cursor.sfqid}]))

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -19,6 +19,7 @@ from unittest import mock
 import pytest
 from snowflake.cli._plugins.sql.manager import SqlManager
 from snowflake.cli._plugins.sql.snowsql_templating import transpile_snowsql_templates
+from snowflake.cli._plugins.sql.statement_reader import CompiledStatement
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.exceptions import (
     ShowSpecificObjectMultipleRowsError,
@@ -682,3 +683,30 @@ def test_sql_with_old_template_and_invalid_snowflake_yml(
     result = runner.invoke(["sql", "-q", "select <% foo %>"])
     assert result.exit_code == 1, result.output
     assert result.output == snapshot
+
+
+def test_async_query_uses_execute_async():
+    """Verifies that async statements use cursor.execute_async() instead of
+    cursor.execute(_no_results=True), so the query ID is tracked by the
+    connector and connection.close() won't cancel in-flight async queries."""
+    mock_cursor = mock.MagicMock()
+    mock_cursor.sfqid = "test-query-id-123"
+
+    mock_conn = mock.MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+
+    manager = SqlManager(connection=mock_conn)
+    stmts = [
+        CompiledStatement(statement="INSERT INTO t VALUES ('v')", execute_async=True),
+    ]
+
+    # _execute_compiled_statements is a generator; consume it
+    list(
+        manager._execute_compiled_statements(  # noqa: SLF001
+            stmts, cursor_class=VerboseCursor
+        )
+    )
+
+    mock_conn.cursor.assert_called_once_with(cursor_class=VerboseCursor)
+    mock_cursor.execute_async.assert_called_once_with("INSERT INTO t VALUES ('v')")
+    mock_cursor.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- Replace `cursor.execute(stmt, _no_results=True)` with `cursor.execute_async(stmt)` in the async SQL execution path (`sql/manager.py`)
- The `_no_results=True` parameter (internal SnowSQL compat) does not register the query ID in the connector `_async_sfqids` tracking set, so `connection.close()` destroys the session and cancels in-flight async queries
- This fixes flaky `test_only_async_queries` and `test_mix` failures in `tests-trusted-ng` (Config V2) where the heavier config resolution timing made the race condition between query submission and connection teardown reproducible

## Root Cause
1. `cursor.execute(stmt, _no_results=True)` fires the query but does NOT add it to `_async_sfqids`
2. After each CLI invocation, the test runner calls `connection_cache.clear()` then `connection.close()`
3. The connector checks `_async_sfqids` -- empty -- so it calls `delete_session()`
4. The INSERT, still in-flight on the server, gets cancelled and the table ends up completely empty
5. `cursor.execute_async()` properly registers the query ID, preventing session destruction while async queries are pending

## Test plan
- [x] Added unit test `test_async_query_uses_execute_async` verifying `execute_async()` is called instead of `execute(_no_results=True)`
- [x] All 190 existing `tests/sql/` tests pass
- [ ] Integration tests `test_only_async_queries` and `test_mix` should now pass in both `tests-trusted` and `tests-trusted-ng`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
