### PR TITLE
SNOW-3190420: Add start_nbctl.sh validation check for Notebook custom…

### DIFF
--- a/src/snowflake/cli/_plugins/custom_images/config/image_validation.yaml
+++ b/src/snowflake/cli/_plugins/custom_images/config/image_validation.yaml
@@ -2,13 +2,9 @@
 
 version: "1.0"
 
+# Common checks run for all workloads (ML Jobs + Notebooks).
 checks:
   entrypoint: "/usr/local/bin/entrypoint.sh"
-
-  # Scripts that must exist and be executable in the image working directory.
-  # PEP injects "./start_nbctl.sh /shared/nbctl" as container args for vNext notebooks.
-  required_scripts:
-    - start_nbctl.sh
 
   environment_variables:
     - name: DASHBOARD_PORT
@@ -40,3 +36,9 @@ checks:
     enabled: true
     ignore_patterns:
       - jupyter-lsp  # Intentionally uninstalled from official images
+
+# Notebook-specific checks. Always run; failures here only affect Notebook readiness.
+# PEP injects "./start_nbctl.sh /shared/nbctl" as container args for vNext notebooks.
+notebook_checks:
+  required_scripts:
+    - start_nbctl.sh

--- a/src/snowflake/cli/_plugins/custom_images/manager.py
+++ b/src/snowflake/cli/_plugins/custom_images/manager.py
@@ -123,10 +123,12 @@ class CustomImageManager:
         self.config = self._load_config(self.config_path)
         # Config-driven checks (controlled by image_validation.yaml)
         self._check_handlers: dict[str, Any] = {
-            "required_scripts": self._check_required_scripts,
             "environment_variables": self._check_environment_variables,
             "python_packages": self._check_python_packages,
             "dependency_health": self._check_dependency_health,
+        }
+        self._notebook_check_handlers: dict[str, Any] = {
+            "required_scripts": self._check_required_scripts,
         }
 
     def _load_config(self, config_path: Path) -> dict:
@@ -236,12 +238,39 @@ class CustomImageManager:
             else:
                 report.add_result(results)
 
+        # Notebook-specific checks (failures only affect Notebook readiness)
+        notebook_checks = self.config.get("notebook_checks", {})
+        notebook_all_passed = True
+        for check_name, handler in self._notebook_check_handlers.items():
+            check_config = notebook_checks.get(check_name)
+            if check_config is None or check_config is False:
+                continue
+            results = handler(context, check_config)
+            if isinstance(results, list):
+                for result in results:
+                    report.add_result(result)
+                    if not result.passed:
+                        notebook_all_passed = False
+            else:
+                report.add_result(results)
+                if not results.passed:
+                    notebook_all_passed = False
+
         # User-requested checks (controlled by CLI flags)
         if scan_vulnerabilities:
             result = self._check_vulnerabilities(context)
             report.add_result(result)
 
-        return report, format_report(report)
+        common_passed = all(
+            r.passed for r in report.results if not r.check_name.startswith("script_")
+        )
+        readiness = []
+        if common_passed:
+            readiness.append("ML Jobs")
+        if common_passed and notebook_all_passed:
+            readiness.append("Notebooks")
+
+        return report, format_report(report, readiness)
 
     def _check_entrypoint(
         self, context: ValidationContext, expected: str
@@ -533,7 +562,7 @@ class CustomImageManager:
         )
 
 
-def format_report(report: ValidationReport) -> str:
+def format_report(report: ValidationReport, readiness: list[str] | None = None) -> str:
     """Format the validation report for display."""
     lines = []
     lines.append(f"\n{'=' * 60}")
@@ -546,6 +575,11 @@ def format_report(report: ValidationReport) -> str:
 
     lines.append(f"\n{'-' * 60}")
     lines.append(f"Summary: {report.passed_count} passed, {report.failed_count} failed")
+
+    if readiness:
+        lines.append(f"Ready for: {', '.join(readiness)}")
+    elif readiness is not None:
+        lines.append("Ready for: None")
 
     if report.all_passed:
         lines.append("Status: ALL CHECKS PASSED")

--- a/tests/custom_images/test_helpers.py
+++ b/tests/custom_images/test_helpers.py
@@ -90,7 +90,7 @@ def create_mock_side_effect(
                     )
                 elif "test" in cmd and ("-x" in cmd or "-f" in cmd):
                     target = cmd[-1]
-                    failed = any(s in target for s in missing_scripts)
+                    failed = target in missing_scripts
                     return mock.Mock(
                         returncode=1 if failed else 0, stdout="", stderr=""
                     )

--- a/tests/custom_images/test_manager.py
+++ b/tests/custom_images/test_manager.py
@@ -39,8 +39,6 @@ version: "1.0"
 
 checks:
   entrypoint: "/usr/local/bin/entrypoint.sh"
-  required_scripts:
-    - start_nbctl.sh
   environment_variables:
     - name: DASHBOARD_PORT
       value: "12003"
@@ -51,6 +49,10 @@ checks:
     enabled: true
     ignore_patterns:
       - jupyter-lsp
+
+notebook_checks:
+  required_scripts:
+    - start_nbctl.sh
 """
         config_file = tmp_path / "test_config.yaml"
         config_file.write_text(config_content)
@@ -226,8 +228,8 @@ checks:
         assert "vulnerability_scan" not in check_names
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
-    def test_required_scripts_pass(self, mock_run, config_path):
-        """Test that required_scripts check passes when script exists and is executable."""
+    def test_notebook_ready_when_script_present(self, mock_run, config_path):
+        """Test readiness reports both ML Jobs and Notebooks when all checks pass."""
         inspect_response = make_docker_inspect_response(
             entrypoint=["/usr/local/bin/entrypoint.sh"],
             env_vars=["DASHBOARD_PORT=12003"],
@@ -244,17 +246,17 @@ checks:
         )
         manager = CustomImageManager(config_path=config_path)
 
-        report, _ = manager.validate("test-image:latest")
+        report, output = manager.validate("test-image:latest")
 
         script_result = next(
             r for r in report.results if r.check_name == "script_start_nbctl.sh"
         )
         assert script_result.passed
-        assert "executable" in script_result.message
+        assert "Ready for: ML Jobs, Notebooks" in output
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
-    def test_required_scripts_missing(self, mock_run, config_path):
-        """Test that required_scripts check fails when script is missing or not executable."""
+    def test_ml_job_only_when_script_missing(self, mock_run, config_path):
+        """Test readiness reports ML Jobs only when notebook script is missing."""
         inspect_response = make_docker_inspect_response(
             entrypoint=["/usr/local/bin/entrypoint.sh"],
             env_vars=["DASHBOARD_PORT=12003"],
@@ -272,13 +274,57 @@ checks:
         )
         manager = CustomImageManager(config_path=config_path)
 
-        report, _ = manager.validate("test-image:latest")
+        report, output = manager.validate("test-image:latest")
 
         script_result = next(
             r for r in report.results if r.check_name == "script_start_nbctl.sh"
         )
         assert not script_result.passed
-        assert "missing or not executable" in script_result.message
+        assert "Ready for: ML Jobs" in output
+        assert "Notebooks" not in output
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_required_scripts_empty_list(self, mock_run, tmp_path):
+        """Test that an empty required_scripts list is treated as no notebook checks."""
+        config_content = """
+version: "1.0"
+
+checks:
+  entrypoint: "/usr/local/bin/entrypoint.sh"
+  environment_variables:
+    - name: DASHBOARD_PORT
+      value: "12003"
+  python_packages:
+    - snowflake-ml-python
+    - ray
+
+notebook_checks:
+  required_scripts: []
+"""
+        config_file = tmp_path / "empty_scripts_config.yaml"
+        config_file.write_text(config_content)
+
+        inspect_response = make_docker_inspect_response(
+            entrypoint=["/usr/local/bin/entrypoint.sh"],
+            env_vars=["DASHBOARD_PORT=12003"],
+        )
+        pip_list = make_pip_list_response(
+            [
+                {"name": "snowflake-ml-python", "version": "1.0"},
+                {"name": "ray", "version": "2.0"},
+            ]
+        )
+        mock_run.side_effect = create_mock_side_effect(
+            inspect_response=inspect_response,
+            pip_list_response=pip_list,
+        )
+        manager = CustomImageManager(config_path=config_file)
+
+        report, output = manager.validate("test-image:latest")
+
+        check_names = [r.check_name for r in report.results]
+        assert not any(name.startswith("script_") for name in check_names)
+        assert "Ready for: ML Jobs, Notebooks" in output
 
 
 @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

> **Note:** This PR is stacked on top of https://github.com/snowflakedb/snowflake-cli/pull/2809(custom image validation framework) which is still under review. Please treat this as an early preview — it is ready for feedback but should not be merged until the parent PR lands.

**SNOW-3190420: Add `start_nbctl.sh` validation check for Notebook custom images**

This PR adds a Notebook-specific validation check to the `snow custom-image validate` CLI command.

For Notebook vNext, PEP injects `./start_nbctl.sh /shared/nbctl` as the container entrypoint args. If this script is missing or not executable in the custom image, the container will crash immediately on startup. This check catches that before deployment.

**What changed:**
- **`image_validation.yaml`**: Added `required_scripts: [start_nbctl.sh]` config entry
- **`manager.py`**: Added `_check_required_scripts` handler that runs `docker run ... test -x <script>` to verify each script exists and is executable
- **`test_manager.py`**: Added unit tests for pass (script present) and fail (script missing) scenarios, updated mock helper to support `missing_scripts` parameter

**Validation:**
- All 19 unit tests pass (`python3 -m pytest tests/custom_images/ -v`)
- Manually verified `start_nbctl.sh` exists and is executable in the official `snowflake-notebook:ml-cpu` image
- Run the script locally and verified the start_nbctl part works:
<img width="983" height="323" alt="image" src="https://github.com/user-attachments/assets/8a6953b0-e0de-4606-ab53-cf0b5cada369" />
<img width="1081" height="322" alt="image" src="https://github.com/user-attachments/assets/67664b3f-5f1a-4096-9699-7c5f31d89bf9" />
