### PR TITLE
SNOW-2326969 Use lighter blue text color in DCM

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 from rich.style import Style
 
+_COLOR_BLUE = "#a0a8fe"
+
 DOMAIN_STYLE = Style(color="cyan")
 BOLD_STYLE = Style(bold=True)
 
 # Refresh
-STATUS_STYLE = Style(color="blue")
+STATUS_STYLE = Style(color=_COLOR_BLUE)
 REMOVED_STYLE = Style(color="red", italic=True)
 INSERTED_STYLE = Style(color="green", italic=True)
 
@@ -29,4 +31,4 @@ FAIL_STYLE = Style(color="red")
 CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
-UNKNOWN_STYLE = Style(color="blue")
+UNKNOWN_STYLE = Style(color=_COLOR_BLUE)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Improved text styles to use a lighter blue instead of standard blue in DCM to increase the contrast when the black terminal background is used
