### PR TITLE
feat: add `snow run` command for project scripts

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,12 @@
 ## Deprecations
 
 ## New additions
+* Added `snow run` command to execute project scripts defined in `snowflake.yml` or `manifest.yml`:
+  * Scripts support variable interpolation (`${database}`, `${env.VAR}`, `${entity.<name>.<prop>}`)
+  * Composite scripts can chain multiple named scripts via the `run` field
+  * Supports `--list`, `--dry-run`, `--continue-on-error`, and `--var` overrides
+  * Additional arguments can be passed through to the underlying command after `--`
+* Added `scripts` section to the `snowflake.yml` project definition schema and `manifest.yml` for defining reusable project scripts. Each script supports `cmd` (single command), `run` (composite), `description`, `shell`, `cwd`, and `env` fields. Scripts must be defined in only one file per project.
 
 ## Fixes and improvements
 

--- a/src/snowflake/cli/_app/commands_registration/builtin_plugins.py
+++ b/src/snowflake/cli/_app/commands_registration/builtin_plugins.py
@@ -26,6 +26,7 @@ from snowflake.cli._plugins.nativeapp import plugin_spec as nativeapp_plugin_spe
 from snowflake.cli._plugins.notebook import plugin_spec as notebook_plugin_spec
 from snowflake.cli._plugins.object import plugin_spec as object_plugin_spec
 from snowflake.cli._plugins.plugin import plugin_spec as plugin_plugin_spec
+from snowflake.cli._plugins.run import plugin_spec as run_plugin_spec
 from snowflake.cli._plugins.snowpark import plugin_spec as snowpark_plugin_spec
 from snowflake.cli._plugins.spcs import plugin_spec as spcs_plugin_spec
 from snowflake.cli._plugins.sql import plugin_spec as sql_plugin_spec
@@ -58,6 +59,7 @@ def get_builtin_plugin_name_to_plugin_spec():
         "plugin": plugin_plugin_spec,
         "dbt": dbt_plugin_spec,
         "logs": logs_plugin_spec,
+        "run": run_plugin_spec,
     }
 
     return plugin_specs

--- a/src/snowflake/cli/_plugins/run/__init__.py
+++ b/src/snowflake/cli/_plugins/run/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/snowflake/cli/_plugins/run/commands.py
+++ b/src/snowflake/cli/_plugins/run/commands.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
-from click import ClickException
+
 from snowflake.cli._plugins.run.manager import ScriptManager
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.decorators import with_project_definition
@@ -26,7 +26,13 @@ from snowflake.cli.api.commands.flags import variables_option
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.commands.utils import parse_key_value_variables
 from snowflake.cli.api.console import cli_console as cc
-from snowflake.cli.api.output.types import CommandResult, MessageResult
+from snowflake.cli.api.exceptions import CliError
+from snowflake.cli.api.output.types import (
+    CollectionResult,
+    CommandResult,
+    MessageResult,
+)
+from snowflake.cli.api.sanitizers import sanitize_for_terminal
 
 app = SnowTyperFactory(
     name="run",
@@ -102,37 +108,43 @@ def run_script(
             return MessageResult("No scripts defined in snowflake.yml or manifest.yml")
 
         source = manager.scripts_source or "project"
-        cc.message(f"Available scripts (from {source}):")
-        for name, script in scripts.items():
-            desc = script.description or "(no description)"
-            cc.message(f"  {name:20} {desc}")
-        return MessageResult("")
+        return CollectionResult(
+            [
+                {
+                    "name": name,
+                    "description": script.description or "",
+                    "source": source,
+                }
+                for name, script in scripts.items()
+            ]
+        )
 
     if not script_name:
         scripts = manager.list_scripts()
-        if scripts:
-            source = manager.scripts_source or "project"
-            cc.message(f"Available scripts from {source} (use --list for details):")
-            for name in scripts:
-                cc.message(f"  {name}")
-            return MessageResult("\nSpecify a script name to run, or use --list")
-        return MessageResult(
-            "No scripts defined. Add a 'scripts' section to snowflake.yml or manifest.yml"
-        )
+        if not scripts:
+            return MessageResult(
+                "No scripts defined. Add a 'scripts' section to snowflake.yml or manifest.yml"
+            )
+        source = manager.scripts_source or "project"
+        cc.message(f"Available scripts from {source} (use --list for details):")
+        for name in scripts:
+            cc.message(f"  {sanitize_for_terminal(name)}")
+        return MessageResult("\nSpecify a script name to run, or use --list")
 
-    vars_dict = {}
-    if var_overrides:
-        for v in parse_key_value_variables(var_overrides):
-            vars_dict[v.key] = v.value
+    vars_dict = (
+        {v.key: v.value for v in parse_key_value_variables(var_overrides)}
+        if var_overrides
+        else {}
+    )
 
     script = manager.get_script(script_name)
     if not script:
         available = list(manager.list_scripts().keys())
         if available:
-            raise ClickException(
+            raise CliError(
                 f"Script '{script_name}' not found. Available scripts: {', '.join(available)}"
             )
-        raise ClickException(
+        raise CliError(
             f"Script '{script_name}' not found. No scripts defined in snowflake.yml or manifest.yml"
         )
 
@@ -146,5 +158,7 @@ def run_script(
     )
 
     if not result.success:
-        raise typer.Exit(result.exit_code)
+        raise CliError(
+            f"Script '{script_name}' failed with exit code {result.exit_code}"
+        )
     return MessageResult("")

--- a/src/snowflake/cli/_plugins/run/commands.py
+++ b/src/snowflake/cli/_plugins/run/commands.py
@@ -116,7 +116,9 @@ def run_script(
             for name in scripts:
                 cc.message(f"  {name}")
             return MessageResult("\nSpecify a script name to run, or use --list")
-        return MessageResult("No scripts defined. Add a 'scripts' section to snowflake.yml or manifest.yml")
+        return MessageResult(
+            "No scripts defined. Add a 'scripts' section to snowflake.yml or manifest.yml"
+        )
 
     vars_dict = {}
     if var_overrides:

--- a/src/snowflake/cli/_plugins/run/commands.py
+++ b/src/snowflake/cli/_plugins/run/commands.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from click import ClickException
+from snowflake.cli._plugins.run.manager import ScriptManager
+from snowflake.cli.api.cli_global_context import get_cli_context
+from snowflake.cli.api.commands.decorators import with_project_definition
+from snowflake.cli.api.commands.flags import variables_option
+from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.commands.utils import parse_key_value_variables
+from snowflake.cli.api.console import cli_console as cc
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+
+app = SnowTyperFactory(
+    name="run",
+    help="Execute project scripts defined in snowflake.yml or manifest.yml.",
+)
+
+
+@app.command(name="run", no_args_is_help=False)
+@with_project_definition(is_optional=True)
+def run_script(
+    script_name: Optional[str] = typer.Argument(
+        None,
+        help="Name of the script to run.",
+    ),
+    list_scripts: bool = typer.Option(
+        False,
+        "--list",
+        "-l",
+        help="List available scripts.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be executed without running.",
+    ),
+    continue_on_error: bool = typer.Option(
+        False,
+        "--continue-on-error",
+        help="Continue executing composite scripts even if a step fails.",
+    ),
+    var_overrides: Optional[List[str]] = variables_option(
+        "Override script variables in key=value format.",
+    ),
+    extra_args: Optional[List[str]] = typer.Argument(
+        None,
+        help="Additional arguments to pass to the script (use -- before args).",
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Execute project scripts defined in snowflake.yml or manifest.yml.
+
+    Scripts are defined in the 'scripts' section of your snowflake.yml or manifest.yml file.
+    Use --list to see available scripts. Pass additional arguments after --.
+
+    Example usage:
+
+        snow run deploy
+
+        snow run dev -- --server.port 8502
+
+        snow run dcm-plan --var database=PROD
+
+    Variable interpolation supports:
+
+        ${database}, ${schema}, ${connection} - from defaults section
+
+        ${env.VAR_NAME} - from env section or environment variables
+
+        ${entity.<name>.<prop>} - from entity definitions
+    """
+    ctx = get_cli_context()
+
+    project_root = ctx.project_root
+    if project_root is None:
+        project_root = Path.cwd()
+
+    manager = ScriptManager(project_root)
+
+    if list_scripts:
+        scripts = manager.list_scripts()
+        if not scripts:
+            return MessageResult("No scripts defined in snowflake.yml or manifest.yml")
+
+        source = manager.scripts_source or "project"
+        cc.message(f"Available scripts (from {source}):")
+        for name, script in scripts.items():
+            desc = script.description or "(no description)"
+            cc.message(f"  {name:20} {desc}")
+        return MessageResult("")
+
+    if not script_name:
+        scripts = manager.list_scripts()
+        if scripts:
+            source = manager.scripts_source or "project"
+            cc.message(f"Available scripts from {source} (use --list for details):")
+            for name in scripts:
+                cc.message(f"  {name}")
+            return MessageResult("\nSpecify a script name to run, or use --list")
+        return MessageResult("No scripts defined. Add a 'scripts' section to snowflake.yml or manifest.yml")
+
+    vars_dict = {}
+    if var_overrides:
+        for v in parse_key_value_variables(var_overrides):
+            vars_dict[v.key] = v.value
+
+    script = manager.get_script(script_name)
+    if not script:
+        available = list(manager.list_scripts().keys())
+        if available:
+            raise ClickException(
+                f"Script '{script_name}' not found. Available scripts: {', '.join(available)}"
+            )
+        raise ClickException(
+            f"Script '{script_name}' not found. No scripts defined in snowflake.yml or manifest.yml"
+        )
+
+    result = manager.execute_script(
+        script_name,
+        extra_args=extra_args,
+        var_overrides=vars_dict,
+        dry_run=dry_run,
+        verbose=ctx.verbose,
+        continue_on_error=continue_on_error,
+    )
+
+    if not result.success:
+        raise typer.Exit(result.exit_code)
+    return MessageResult("")

--- a/src/snowflake/cli/_plugins/run/commands.py
+++ b/src/snowflake/cli/_plugins/run/commands.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
-
 from snowflake.cli._plugins.run.manager import ScriptManager
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.decorators import with_project_definition

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -18,10 +18,10 @@ import logging
 import os
 import re
 import shlex
-import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from subprocess import run as _subprocess_run
 from typing import Dict, List, Optional, Tuple
 
 import yaml
@@ -58,7 +58,7 @@ class ScriptManager:
 
     def _load_scripts(self) -> None:
         """Load scripts from snowflake.yml or manifest.yml.
-        
+
         Scripts can be defined in either file but not both.
         Raises ClickException if scripts are found in both files.
         """
@@ -81,15 +81,23 @@ class ScriptManager:
             self._scripts = manifest_scripts
             self._scripts_source = manifest_source
 
-    def _load_snowflake_scripts(self) -> Tuple[Optional[Dict[str, ScriptModel]], Optional[str]]:
+    def _load_snowflake_scripts(
+        self,
+    ) -> Tuple[Optional[Dict[str, ScriptModel]], Optional[str]]:
         """Load scripts from snowflake.yml via project definition."""
         ctx = get_cli_context()
         project_def = ctx.project_definition
-        if project_def and isinstance(project_def, DefinitionV20) and project_def.scripts:
+        if (
+            project_def
+            and isinstance(project_def, DefinitionV20)
+            and project_def.scripts
+        ):
             return project_def.scripts, "snowflake.yml"
         return None, None
 
-    def _load_manifest_scripts(self) -> Tuple[Optional[Dict[str, ScriptModel]], Optional[str]]:
+    def _load_manifest_scripts(
+        self,
+    ) -> Tuple[Optional[Dict[str, ScriptModel]], Optional[str]]:
         """Load scripts from manifest.yml if present."""
         manifest_path = SecurePath(self.project_root / MANIFEST_FILE_NAME)
         if not manifest_path.exists():
@@ -99,7 +107,7 @@ class ScriptManager:
             with manifest_path.open("r", read_file_limit_mb=DEFAULT_SIZE_LIMIT_MB) as f:
                 manifest_data = yaml.safe_load(f.read())
         except Exception as e:
-            log.debug(f"Could not read manifest.yml: {e}")
+            log.debug("Could not read manifest.yml: %s", e)
             return None, None
 
         if not manifest_data or "scripts" not in manifest_data:
@@ -216,7 +224,13 @@ class ScriptManager:
 
         if script.run:
             return self._execute_composite(
-                name, script, extra_args, var_overrides, dry_run, verbose, continue_on_error
+                name,
+                script,
+                extra_args,
+                var_overrides,
+                dry_run,
+                verbose,
+                continue_on_error,
             )
 
         return self._execute_command(
@@ -260,14 +274,14 @@ class ScriptManager:
                 )
 
             if sys.platform == "win32":
-                result = subprocess.run(
+                result = _subprocess_run(
                     cmd,
                     shell=True,
                     cwd=cwd,
                     env=env,
                 )
             else:
-                result = subprocess.run(
+                result = _subprocess_run(
                     cmd,
                     shell=True,
                     cwd=cwd,
@@ -276,7 +290,7 @@ class ScriptManager:
                 )
         else:
             args = shlex.split(cmd)
-            result = subprocess.run(
+            result = _subprocess_run(
                 args,
                 cwd=cwd,
                 env=env,

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -216,8 +216,17 @@ class ScriptManager:
         dry_run: bool = False,
         verbose: bool = False,
         continue_on_error: bool = False,
+        _call_stack: Optional[List[str]] = None,
     ) -> ScriptExecutionResult:
         """Execute a script by name."""
+        if _call_stack is None:
+            _call_stack = []
+
+        if name in _call_stack:
+            raise ClickException(
+                f"Circular dependency detected: {' -> '.join(_call_stack)} -> {name}"
+            )
+
         script = self.get_script(name)
         if not script:
             raise ValueError(f"Script '{name}' not found")
@@ -231,6 +240,7 @@ class ScriptManager:
                 dry_run,
                 verbose,
                 continue_on_error,
+                _call_stack=_call_stack + [name],
             )
 
         return self._execute_command(
@@ -307,8 +317,12 @@ class ScriptManager:
         dry_run: bool,
         verbose: bool,
         continue_on_error: bool,
+        _call_stack: Optional[List[str]] = None,
     ) -> ScriptExecutionResult:
         """Execute a composite script (list of scripts)."""
+        if _call_stack is None:
+            _call_stack = []
+
         cc.message(f"Running script: {name}")
 
         total = len(script.run)
@@ -331,6 +345,7 @@ class ScriptManager:
                 dry_run=dry_run,
                 verbose=verbose,
                 continue_on_error=continue_on_error,
+                _call_stack=_call_stack,
             )
 
             if not result.success:

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -268,7 +268,7 @@ class ScriptManager:
         )
 
         if extra_args:
-            cmd = f"{cmd} {' '.join(extra_args)}"
+            cmd = f"{cmd} {' '.join(shlex.quote(arg) for arg in extra_args)}"
 
         cc.message(f"Running script: {name}")
         cc.message(f"> {cmd}")

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -215,6 +215,10 @@ class ScriptManager:
                 f"Define it in your project env section or pass --var {var_name}=VALUE"
             )
 
+        if not shell_mode:
+            args = shlex.split(cmd)
+            return shlex.join(VARIABLE_PATTERN.sub(replace_var, arg) for arg in args)
+
         return VARIABLE_PATTERN.sub(replace_var, cmd)
 
     def execute_script(
@@ -240,7 +244,7 @@ class ScriptManager:
         if not script:
             raise ValueError(f"Script '{name}' not found")
 
-        if script.run:
+        if script.run is not None:
             return self._execute_composite(
                 name,
                 script,
@@ -266,9 +270,8 @@ class ScriptManager:
         verbose: bool,
     ) -> ScriptExecutionResult:
         """Execute a single command script."""
-        cmd = self.interpolate_variables(
-            script.cmd, var_overrides, shell_mode=bool(script.shell)
-        )
+        is_shell = bool(script.shell)
+        cmd = self.interpolate_variables(script.cmd, var_overrides, shell_mode=is_shell)
 
         if extra_args:
             cmd = f"{cmd} {' '.join(shlex.quote(arg) for arg in extra_args)}"
@@ -287,7 +290,7 @@ class ScriptManager:
         if script.env:
             env.update(script.env)
 
-        if script.shell:
+        if is_shell:
             if sys.platform == "win32":
                 result = _subprocess_run(
                     cmd,

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -194,7 +194,10 @@ class ScriptManager:
                 variables[full_key] = str(value)
 
     def interpolate_variables(
-        self, cmd: str, var_overrides: Optional[Dict[str, str]] = None
+        self,
+        cmd: str,
+        var_overrides: Optional[Dict[str, str]] = None,
+        shell_mode: bool = False,
     ) -> str:
         """Interpolate variables in command string."""
         variables = self._build_variable_context(var_overrides)
@@ -202,7 +205,10 @@ class ScriptManager:
         def replace_var(match: re.Match) -> str:
             var_name = match.group(1)
             if var_name in variables:
-                return variables[var_name]
+                value = variables[var_name]
+                if shell_mode:
+                    return shlex.quote(value)
+                return value
             log.warning("Variable '${%s}' not found, leaving as-is", var_name)
             return match.group(0)
 
@@ -257,7 +263,9 @@ class ScriptManager:
         verbose: bool,
     ) -> ScriptExecutionResult:
         """Execute a single command script."""
-        cmd = self.interpolate_variables(script.cmd, var_overrides)
+        cmd = self.interpolate_variables(
+            script.cmd, var_overrides, shell_mode=bool(script.shell)
+        )
 
         if extra_args:
             cmd = f"{cmd} {' '.join(extra_args)}"
@@ -277,12 +285,6 @@ class ScriptManager:
             env.update(script.env)
 
         if script.shell:
-            if VARIABLE_PATTERN.search(script.cmd):
-                log.warning(
-                    "Using shell=true with variable interpolation. "
-                    "Ensure interpolated values are safe."
-                )
-
             if sys.platform == "win32":
                 result = _subprocess_run(
                     cmd,
@@ -327,6 +329,7 @@ class ScriptManager:
 
         total = len(script.run)
         failed_scripts = []
+        first_failure_exit_code = 1
 
         for idx, sub_name in enumerate(script.run, 1):
             cc.message(f"\n[{idx}/{total}] {sub_name}")
@@ -349,13 +352,15 @@ class ScriptManager:
             )
 
             if not result.success:
+                if not failed_scripts:
+                    first_failure_exit_code = result.exit_code
                 if not continue_on_error:
                     return result
                 failed_scripts.append(sub_name)
 
         if failed_scripts:
             cc.warning(f"\nCompleted with errors in: {', '.join(failed_scripts)}")
-            return ScriptExecutionResult(name, 1, False)
+            return ScriptExecutionResult(name, first_failure_exit_code, False)
 
         cc.message(f"\nDone! ({total} scripts executed)")
         return ScriptExecutionResult(name, 0, True)

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -25,7 +25,6 @@ from subprocess import run as _subprocess_run
 from typing import Dict, List, Optional, Tuple
 
 import yaml
-
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -25,10 +25,11 @@ from subprocess import run as _subprocess_run
 from typing import Dict, List, Optional, Tuple
 
 import yaml
-from click import ClickException
+
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.console import cli_console as cc
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
+from snowflake.cli.api.exceptions import CliError
 from snowflake.cli.api.project.schemas.project_definition import DefinitionV20
 from snowflake.cli.api.project.schemas.scripts import ScriptModel
 from snowflake.cli.api.secure_path import SecurePath
@@ -60,13 +61,13 @@ class ScriptManager:
         """Load scripts from snowflake.yml or manifest.yml.
 
         Scripts can be defined in either file but not both.
-        Raises ClickException if scripts are found in both files.
+        Raises CliError if scripts are found in both files.
         """
         snowflake_scripts, snowflake_source = self._load_snowflake_scripts()
         manifest_scripts, manifest_source = self._load_manifest_scripts()
 
         if snowflake_scripts and manifest_scripts:
-            raise ClickException(
+            raise CliError(
                 "Scripts defined in both manifest.yml and snowflake.yml.\n"
                 "Scripts must be defined in only one file per directory.\n\n"
                 "Recommendation: Move all scripts to one file.\n"
@@ -209,8 +210,10 @@ class ScriptManager:
                 if shell_mode:
                     return shlex.quote(value)
                 return value
-            log.warning("Variable '${%s}' not found, leaving as-is", var_name)
-            return match.group(0)
+            raise CliError(
+                f"Undefined variable '${{{var_name}}}' in script command. "
+                f"Define it in your project env section or pass --var {var_name}=VALUE"
+            )
 
         return VARIABLE_PATTERN.sub(replace_var, cmd)
 
@@ -229,7 +232,7 @@ class ScriptManager:
             _call_stack = []
 
         if name in _call_stack:
-            raise ClickException(
+            raise CliError(
                 f"Circular dependency detected: {' -> '.join(_call_stack)} -> {name}"
             )
 

--- a/src/snowflake/cli/_plugins/run/manager.py
+++ b/src/snowflake/cli/_plugins/run/manager.py
@@ -1,0 +1,332 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+from click import ClickException
+from snowflake.cli.api.cli_global_context import get_cli_context
+from snowflake.cli.api.console import cli_console as cc
+from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
+from snowflake.cli.api.project.schemas.project_definition import DefinitionV20
+from snowflake.cli.api.project.schemas.scripts import ScriptModel
+from snowflake.cli.api.secure_path import SecurePath
+from snowflake.cli.api.utils.models import ProjectEnvironment
+
+log = logging.getLogger(__name__)
+
+VARIABLE_PATTERN = re.compile(r"\$\{([^}]+)\}")
+MANIFEST_FILE_NAME = "manifest.yml"
+
+
+@dataclass
+class ScriptExecutionResult:
+    script_name: str
+    exit_code: int
+    success: bool
+
+
+class ScriptManager:
+    """Manager for loading and executing project scripts."""
+
+    def __init__(self, project_root: Path):
+        self.project_root = project_root
+        self._scripts: Dict[str, ScriptModel] = {}
+        self._scripts_source: Optional[str] = None
+        self._load_scripts()
+
+    def _load_scripts(self) -> None:
+        """Load scripts from snowflake.yml or manifest.yml.
+        
+        Scripts can be defined in either file but not both.
+        Raises ClickException if scripts are found in both files.
+        """
+        snowflake_scripts, snowflake_source = self._load_snowflake_scripts()
+        manifest_scripts, manifest_source = self._load_manifest_scripts()
+
+        if snowflake_scripts and manifest_scripts:
+            raise ClickException(
+                "Scripts defined in both manifest.yml and snowflake.yml.\n"
+                "Scripts must be defined in only one file per directory.\n\n"
+                "Recommendation: Move all scripts to one file.\n"
+                "- Use manifest.yml for DCM-focused projects\n"
+                "- Use snowflake.yml for app-focused projects"
+            )
+
+        if snowflake_scripts:
+            self._scripts = snowflake_scripts
+            self._scripts_source = snowflake_source
+        elif manifest_scripts:
+            self._scripts = manifest_scripts
+            self._scripts_source = manifest_source
+
+    def _load_snowflake_scripts(self) -> Tuple[Optional[Dict[str, ScriptModel]], Optional[str]]:
+        """Load scripts from snowflake.yml via project definition."""
+        ctx = get_cli_context()
+        project_def = ctx.project_definition
+        if project_def and isinstance(project_def, DefinitionV20) and project_def.scripts:
+            return project_def.scripts, "snowflake.yml"
+        return None, None
+
+    def _load_manifest_scripts(self) -> Tuple[Optional[Dict[str, ScriptModel]], Optional[str]]:
+        """Load scripts from manifest.yml if present."""
+        manifest_path = SecurePath(self.project_root / MANIFEST_FILE_NAME)
+        if not manifest_path.exists():
+            return None, None
+
+        try:
+            with manifest_path.open("r", read_file_limit_mb=DEFAULT_SIZE_LIMIT_MB) as f:
+                manifest_data = yaml.safe_load(f.read())
+        except Exception as e:
+            log.debug(f"Could not read manifest.yml: {e}")
+            return None, None
+
+        if not manifest_data or "scripts" not in manifest_data:
+            return None, None
+
+        scripts = self._parse_manifest_scripts(manifest_data["scripts"])
+        return scripts, "manifest.yml"
+
+    def _parse_manifest_scripts(self, scripts_data: dict) -> Dict[str, ScriptModel]:
+        """Parse scripts section from manifest.yml into ScriptModel objects."""
+        result = {}
+        for name, script_def in scripts_data.items():
+            if isinstance(script_def, str):
+                result[name] = ScriptModel(cmd=script_def)
+            else:
+                result[name] = ScriptModel(**script_def)
+        return result
+
+    @property
+    def scripts_source(self) -> Optional[str]:
+        """Return the source file for scripts (snowflake.yml or manifest.yml)."""
+        return self._scripts_source
+
+    def list_scripts(self) -> Dict[str, ScriptModel]:
+        """Return all available scripts."""
+        return self._scripts
+
+    def get_script(self, name: str) -> Optional[ScriptModel]:
+        """Get a script by name."""
+        return self._scripts.get(name)
+
+    def _build_variable_context(
+        self, var_overrides: Optional[Dict[str, str]] = None
+    ) -> Dict[str, str]:
+        """Build the context dict for variable interpolation."""
+        ctx = get_cli_context()
+        template_context = ctx.template_context.get("ctx", {})
+
+        variables: Dict[str, str] = {}
+
+        defaults = template_context.get("defaults", {})
+        if defaults:
+            for key in ["database", "schema", "connection"]:
+                if key in defaults and defaults[key]:
+                    variables[key] = str(defaults[key])
+
+        env_section = template_context.get("env")
+        if env_section is not None:
+            if isinstance(env_section, ProjectEnvironment):
+                if env_section.default_env:
+                    for key, value in env_section.default_env.items():
+                        variables[f"env.{key}"] = str(value)
+            elif isinstance(env_section, dict):
+                for key, value in env_section.items():
+                    variables[f"env.{key}"] = str(value)
+
+        for key, value in os.environ.items():
+            env_key = f"env.{key}"
+            if env_key not in variables:
+                variables[env_key] = value
+
+        entities = template_context.get("entities", {})
+        if entities:
+            for entity_name, entity_data in entities.items():
+                if isinstance(entity_data, dict):
+                    self._flatten_entity(
+                        f"entity.{entity_name}", entity_data, variables
+                    )
+
+        if var_overrides:
+            variables.update(var_overrides)
+
+        return variables
+
+    def _flatten_entity(
+        self, prefix: str, data: dict, variables: Dict[str, str]
+    ) -> None:
+        """Flatten nested entity data into dot-notation keys."""
+        for key, value in data.items():
+            full_key = f"{prefix}.{key}"
+            if isinstance(value, dict):
+                self._flatten_entity(full_key, value, variables)
+            elif value is not None:
+                variables[full_key] = str(value)
+
+    def interpolate_variables(
+        self, cmd: str, var_overrides: Optional[Dict[str, str]] = None
+    ) -> str:
+        """Interpolate variables in command string."""
+        variables = self._build_variable_context(var_overrides)
+
+        def replace_var(match: re.Match) -> str:
+            var_name = match.group(1)
+            if var_name in variables:
+                return variables[var_name]
+            log.warning("Variable '${%s}' not found, leaving as-is", var_name)
+            return match.group(0)
+
+        return VARIABLE_PATTERN.sub(replace_var, cmd)
+
+    def execute_script(
+        self,
+        name: str,
+        extra_args: Optional[List[str]] = None,
+        var_overrides: Optional[Dict[str, str]] = None,
+        dry_run: bool = False,
+        verbose: bool = False,
+        continue_on_error: bool = False,
+    ) -> ScriptExecutionResult:
+        """Execute a script by name."""
+        script = self.get_script(name)
+        if not script:
+            raise ValueError(f"Script '{name}' not found")
+
+        if script.run:
+            return self._execute_composite(
+                name, script, extra_args, var_overrides, dry_run, verbose, continue_on_error
+            )
+
+        return self._execute_command(
+            name, script, extra_args, var_overrides, dry_run, verbose
+        )
+
+    def _execute_command(
+        self,
+        name: str,
+        script: ScriptModel,
+        extra_args: Optional[List[str]],
+        var_overrides: Optional[Dict[str, str]],
+        dry_run: bool,
+        verbose: bool,
+    ) -> ScriptExecutionResult:
+        """Execute a single command script."""
+        cmd = self.interpolate_variables(script.cmd, var_overrides)
+
+        if extra_args:
+            cmd = f"{cmd} {' '.join(extra_args)}"
+
+        cc.message(f"Running script: {name}")
+        cc.message(f"> {cmd}")
+
+        if dry_run:
+            return ScriptExecutionResult(name, 0, True)
+
+        cwd = self.project_root
+        if script.cwd:
+            cwd = self.project_root / script.cwd
+
+        env = os.environ.copy()
+        if script.env:
+            env.update(script.env)
+
+        if script.shell:
+            if VARIABLE_PATTERN.search(script.cmd):
+                log.warning(
+                    "Using shell=true with variable interpolation. "
+                    "Ensure interpolated values are safe."
+                )
+
+            if sys.platform == "win32":
+                result = subprocess.run(
+                    cmd,
+                    shell=True,
+                    cwd=cwd,
+                    env=env,
+                )
+            else:
+                result = subprocess.run(
+                    cmd,
+                    shell=True,
+                    cwd=cwd,
+                    env=env,
+                    executable="/bin/sh",
+                )
+        else:
+            args = shlex.split(cmd)
+            result = subprocess.run(
+                args,
+                cwd=cwd,
+                env=env,
+            )
+
+        return ScriptExecutionResult(name, result.returncode, result.returncode == 0)
+
+    def _execute_composite(
+        self,
+        name: str,
+        script: ScriptModel,
+        extra_args: Optional[List[str]],
+        var_overrides: Optional[Dict[str, str]],
+        dry_run: bool,
+        verbose: bool,
+        continue_on_error: bool,
+    ) -> ScriptExecutionResult:
+        """Execute a composite script (list of scripts)."""
+        cc.message(f"Running script: {name}")
+
+        total = len(script.run)
+        failed_scripts = []
+
+        for idx, sub_name in enumerate(script.run, 1):
+            cc.message(f"\n[{idx}/{total}] {sub_name}")
+
+            if sub_name not in self._scripts:
+                cc.warning(f"Script '{sub_name}' not found, skipping")
+                if not continue_on_error:
+                    return ScriptExecutionResult(name, 1, False)
+                failed_scripts.append(sub_name)
+                continue
+
+            result = self.execute_script(
+                sub_name,
+                extra_args=None,
+                var_overrides=var_overrides,
+                dry_run=dry_run,
+                verbose=verbose,
+                continue_on_error=continue_on_error,
+            )
+
+            if not result.success:
+                if not continue_on_error:
+                    return result
+                failed_scripts.append(sub_name)
+
+        if failed_scripts:
+            cc.warning(f"\nCompleted with errors in: {', '.join(failed_scripts)}")
+            return ScriptExecutionResult(name, 1, False)
+
+        cc.message(f"\nDone! ({total} scripts executed)")
+        return ScriptExecutionResult(name, 0, True)

--- a/src/snowflake/cli/_plugins/run/plugin_spec.py
+++ b/src/snowflake/cli/_plugins/run/plugin_spec.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from snowflake.cli._plugins.run import commands
+from snowflake.cli.api.plugins.command import (
+    SNOWCLI_ROOT_COMMAND_PATH,
+    CommandSpec,
+    CommandType,
+    plugin_hook_impl,
+)
+
+
+@plugin_hook_impl
+def command_spec():
+    return CommandSpec(
+        parent_command_path=SNOWCLI_ROOT_COMMAND_PATH,
+        command_type=CommandType.SINGLE_COMMAND,
+        typer_instance=commands.app.create_instance(),
+    )

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -35,12 +35,12 @@ from snowflake.cli.api.project.schemas.entities.entities import (
     EntityModel,
     v2_entity_model_types_map,
 )
+from snowflake.cli.api.project.schemas.scripts import ScriptModel
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
 from snowflake.cli.api.project.schemas.v1.native_app.native_app import (
     NativeApp,
     NativeAppV11,
 )
-from snowflake.cli.api.project.schemas.scripts import ScriptModel
 from snowflake.cli.api.project.schemas.v1.snowpark.snowpark import Snowpark
 from snowflake.cli.api.project.schemas.v1.streamlit.streamlit import Streamlit
 from snowflake.cli.api.utils.types import Context

--- a/src/snowflake/cli/api/project/schemas/project_definition.py
+++ b/src/snowflake/cli/api/project/schemas/project_definition.py
@@ -40,6 +40,7 @@ from snowflake.cli.api.project.schemas.v1.native_app.native_app import (
     NativeApp,
     NativeAppV11,
 )
+from snowflake.cli.api.project.schemas.scripts import ScriptModel
 from snowflake.cli.api.project.schemas.v1.snowpark.snowpark import Snowpark
 from snowflake.cli.api.project.schemas.v1.streamlit.streamlit import Streamlit
 from snowflake.cli.api.utils.types import Context
@@ -131,6 +132,10 @@ class DefinitionV20(_ProjectDefinitionBase):
     )
     mixins: Optional[Dict[str, Dict]] = Field(
         title="Mixins to apply to entities",
+        default=None,
+    )
+    scripts: Optional[Dict[str, ScriptModel]] = Field(
+        title="Project scripts for common tasks",
         default=None,
     )
 

--- a/src/snowflake/cli/api/project/schemas/scripts.py
+++ b/src/snowflake/cli/api/project/schemas/scripts.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import Field, model_validator
+from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
+
+
+class ScriptModel(UpdatableModel):
+    """Model for a single script definition in snowflake.yml."""
+
+    cmd: Optional[str] = Field(
+        default=None,
+        title="Command to execute",
+    )
+    run: Optional[List[str]] = Field(
+        default=None,
+        title="List of script names to run in sequence (composite script)",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        title="Human-readable description of the script",
+    )
+    shell: bool = Field(
+        default=False,
+        title="Whether to run through shell (required for pipes, redirects, globs)",
+    )
+    cwd: Optional[str] = Field(
+        default=None,
+        title="Working directory for the script (relative to project root)",
+    )
+    env: Optional[Dict[str, str]] = Field(
+        default=None,
+        title="Environment variables to set for the script",
+    )
+
+    @model_validator(mode="after")
+    def validate_cmd_or_run(self):
+        if self.cmd is None and self.run is None:
+            raise ValueError("Script must have either 'cmd' or 'run' defined")
+        if self.cmd is not None and self.run is not None:
+            raise ValueError("Script cannot have both 'cmd' and 'run' defined")
+        return self

--- a/src/snowflake/cli/api/project/schemas/scripts.py
+++ b/src/snowflake/cli/api/project/schemas/scripts.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 
 from pydantic import Field, model_validator
+
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
 
 
@@ -54,4 +55,6 @@ class ScriptModel(UpdatableModel):
             raise ValueError("Script must have either 'cmd' or 'run' defined")
         if self.cmd is not None and self.run is not None:
             raise ValueError("Script cannot have both 'cmd' and 'run' defined")
+        if self.run is not None and len(self.run) == 0:
+            raise ValueError("'run' field cannot be an empty list")
         return self

--- a/src/snowflake/cli/api/project/schemas/scripts.py
+++ b/src/snowflake/cli/api/project/schemas/scripts.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 
 from pydantic import Field, model_validator
-
 from snowflake.cli.api.project.schemas.updatable_model import UpdatableModel
 
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -31,6 +31,8 @@
   | logs         Retrieves logs for a given object.                              |
   | notebook     Manages notebooks in Snowflake.                                 |
   | object       Manages Snowflake objects like warehouses and stages            |
+  | run          Execute project scripts defined in snowflake.yml or             |
+  |              manifest.yml.                                                   |
   | snowpark     Manages procedures and functions.                               |
   | spcs         Manages Snowpark Container Services compute pools, services,    |
   |              image registries, and image repositories.                       |
@@ -13167,6 +13169,89 @@
   
   '''
 # ---
+# name: test_help_messages[run]
+  '''
+                                                                                  
+   Usage: root run [OPTIONS] [SCRIPT_NAME] [EXTRA_ARGS]...                        
+                                                                                  
+   Execute project scripts defined in snowflake.yml or manifest.yml.              
+                                                                                  
+   Scripts are defined in the 'scripts' section of your snowflake.yml or          
+   manifest.yml file. Use --list to see available scripts. Pass additional        
+   arguments after --.                                                            
+                                                                                  
+   Example usage:                                                                 
+                                                                                  
+                                                                                  
+    snow run deploy                                                               
+                                                                                  
+    snow run dev -- --server.port 8502                                            
+                                                                                  
+    snow run dcm-plan --var database=PROD                                         
+                                                                                  
+                                                                                  
+   Variable interpolation supports:                                               
+                                                                                  
+                                                                                  
+    ${database}, ${schema}, ${connection} - from defaults section                 
+                                                                                  
+    ${env.VAR_NAME} - from env section or environment variables                   
+                                                                                  
+    ${entity.<name>.<prop>} - from entity definitions                             
+                                                                                  
+                                                                                  
+  +- Arguments ------------------------------------------------------------------+
+  |   script_name      [SCRIPT_NAME]    Name of the script to run.               |
+  |   extra_args       [EXTRA_ARGS]...  Additional arguments to pass to the      |
+  |                                     script (use -- before args).             |
+  +------------------------------------------------------------------------------+
+  +- Options --------------------------------------------------------------------+
+  | --list               -l            List available scripts.                   |
+  | --dry-run                          Show what would be executed without       |
+  |                                    running.                                  |
+  | --continue-on-error                Continue executing composite scripts even |
+  |                                    if a step fails.                          |
+  | --variable           -D      TEXT  Override script variables in key=value    |
+  |                                    format.                                   |
+  | --project            -p      TEXT  Path where the Snowflake project is       |
+  |                                    stored. Defaults to the current working   |
+  |                                    directory.                                |
+  | --env                        TEXT  String in the format key=value. Overrides |
+  |                                    variables from the env section used for   |
+  |                                    templates.                                |
+  | --help               -h            Show this message and exit.               |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
+  |                                CSV]                   format.                |
+  |                                                       [default: TABLE]       |
+  | --verbose              -v                             Displays log entries   |
+  |                                                       for log levels info    |
+  |                                                       and higher.            |
+  | --debug                                               Displays log entries   |
+  |                                                       for log levels debug   |
+  |                                                       and higher; debug logs |
+  |                                                       contain additional     |
+  |                                                       information.           |
+  | --silent                                              Turns off intermediate |
+  |                                                       output to console.     |
+  | --enhanced-exit-codes                                 Differentiate exit     |
+  |                                                       error codes based on   |
+  |                                                       failure type.          |
+  |                                                       [env var:              |
+  |                                                       SNOWFLAKE_ENHANCED_EX… |
+  | --decimal-precision            INTEGER                Number of decimal      |
+  |                                                       places to display for  |
+  |                                                       decimal values. Uses   |
+  |                                                       Python's default       |
+  |                                                       precision if not       |
+  |                                                       specified. [env var:   |
+  |                                                       SNOWFLAKE_DECIMAL_PRE… |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[snowpark.build]
   '''
                                                                                   
@@ -23284,6 +23369,8 @@
   | logs         Retrieves logs for a given object.                              |
   | notebook     Manages notebooks in Snowflake.                                 |
   | object       Manages Snowflake objects like warehouses and stages            |
+  | run          Execute project scripts defined in snowflake.yml or             |
+  |              manifest.yml.                                                   |
   | snowpark     Manages procedures and functions.                               |
   | spcs         Manages Snowpark Container Services compute pools, services,    |
   |              image registries, and image repositories.                       |

--- a/tests/run/__init__.py
+++ b/tests/run/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/run/test_commands.py
+++ b/tests/run/test_commands.py
@@ -14,9 +14,7 @@
 
 from unittest import mock
 
-import pytest
-
-SUBPROCESS_RUN = "snowflake.cli._plugins.run.manager.subprocess.run"
+SUBPROCESS_RUN = "snowflake.cli._plugins.run.manager._subprocess_run"
 
 
 class TestRunList:
@@ -96,7 +94,9 @@ class TestRunExecute:
             assert "2 scripts executed" in result.output
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_run_composite_script_stops_on_error(self, mock_run, runner, project_directory):
+    def test_run_composite_script_stops_on_error(
+        self, mock_run, runner, project_directory
+    ):
         mock_run.return_value = mock.Mock(returncode=1)
         with project_directory("run_scripts"):
             result = runner.invoke(["run", "deploy-all"])
@@ -104,7 +104,9 @@ class TestRunExecute:
             assert mock_run.call_count == 1
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_run_composite_script_continue_on_error(self, mock_run, runner, project_directory):
+    def test_run_composite_script_continue_on_error(
+        self, mock_run, runner, project_directory
+    ):
         mock_run.return_value = mock.Mock(returncode=1)
         with project_directory("run_scripts"):
             result = runner.invoke(["run", "deploy-all", "--continue-on-error"])
@@ -168,7 +170,9 @@ class TestRunManifestScripts:
             assert "echo" in mock_run.call_args[0][0][0]
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_run_composite_script_from_manifest(self, mock_run, runner, project_directory):
+    def test_run_composite_script_from_manifest(
+        self, mock_run, runner, project_directory
+    ):
         mock_run.return_value = mock.Mock(returncode=0)
         with project_directory("run_manifest_scripts"):
             result = runner.invoke(["run", "all"])

--- a/tests/run/test_commands.py
+++ b/tests/run/test_commands.py
@@ -22,10 +22,10 @@ class TestRunList:
         with project_directory("run_scripts"):
             result = runner.invoke(["run", "--list"])
             assert result.exit_code == 0
-            assert "Available scripts" in result.output
             assert "dev" in result.output
             assert "deploy" in result.output
             assert "build" in result.output
+            assert "snowflake.yml" in result.output
 
     def test_list_scripts_shows_descriptions(self, runner, project_directory):
         with project_directory("run_scripts"):
@@ -177,7 +177,8 @@ class TestRunExecute:
         mock_run.return_value = mock.Mock(returncode=42)
         with project_directory("run_scripts"):
             result = runner.invoke(["run", "deploy-all", "--continue-on-error"])
-            assert result.exit_code == 42
+            assert result.exit_code == 1
+            assert "failed with exit code" in result.output
 
 
 class TestRunHelp:
@@ -194,8 +195,7 @@ class TestRunManifestScripts:
         with project_directory("run_manifest_scripts"):
             result = runner.invoke(["run", "--list"])
             assert result.exit_code == 0
-            assert "Available scripts" in result.output
-            assert "from manifest.yml" in result.output
+            assert "manifest.yml" in result.output
             assert "validate" in result.output
             assert "deploy" in result.output
 
@@ -230,7 +230,7 @@ class TestRunManifestScripts:
         with project_directory("run_scripts"):
             result = runner.invoke(["run", "--list"])
             assert result.exit_code == 0
-            assert "from snowflake.yml" in result.output
+            assert "snowflake.yml" in result.output
 
     @mock.patch(SUBPROCESS_RUN)
     def test_run_manifest_only_project(self, mock_run, runner, project_directory):

--- a/tests/run/test_commands.py
+++ b/tests/run/test_commands.py
@@ -75,6 +75,12 @@ class TestRunExecute:
             assert result.exit_code != 0
             assert "not found" in result.output
 
+    def test_run_circular_dependency_detected(self, runner, project_directory):
+        with project_directory("run_scripts_cycle"):
+            result = runner.invoke(["run", "alpha"])
+            assert result.exit_code != 0
+            assert "Circular dependency detected" in result.output
+
     @mock.patch(SUBPROCESS_RUN)
     def test_run_with_dry_run(self, mock_run, runner, project_directory):
         with project_directory("run_scripts"):

--- a/tests/run/test_commands.py
+++ b/tests/run/test_commands.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+SUBPROCESS_RUN = "snowflake.cli._plugins.run.manager.subprocess.run"
+
+
+class TestRunList:
+    def test_list_scripts_shows_available_scripts(self, runner, project_directory):
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code == 0
+            assert "Available scripts" in result.output
+            assert "dev" in result.output
+            assert "deploy" in result.output
+            assert "build" in result.output
+
+    def test_list_scripts_shows_descriptions(self, runner, project_directory):
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code == 0
+            assert "Start local development server" in result.output
+            assert "Build the project" in result.output
+
+    def test_list_no_scripts_shows_message(self, runner, project_directory):
+        with project_directory("streamlit_full_definition"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code == 0
+            assert "No scripts defined" in result.output
+
+    def test_no_args_shows_available_scripts(self, runner, project_directory):
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run"])
+            assert result.exit_code == 0
+            assert "Available scripts" in result.output
+
+
+class TestRunExecute:
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_simple_script(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "dev"])
+            assert result.exit_code == 0
+            mock_run.assert_called_once()
+            assert "echo" in mock_run.call_args[0][0][0]
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_script_with_variable_interpolation(
+        self, mock_run, runner, project_directory
+    ):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "build"])
+            assert result.exit_code == 0
+            call_args = mock_run.call_args[0][0]
+            assert "TEMP" in " ".join(call_args)
+            assert "DEV_PLATFORM" in " ".join(call_args)
+
+    def test_run_nonexistent_script_fails(self, runner, project_directory):
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "nonexistent"])
+            assert result.exit_code != 0
+            assert "not found" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_with_dry_run(self, mock_run, runner, project_directory):
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "dev", "--dry-run"])
+            assert result.exit_code == 0
+            mock_run.assert_not_called()
+            assert "echo" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_composite_script(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "deploy-all"])
+            assert result.exit_code == 0
+            assert mock_run.call_count == 2
+            assert "Done!" in result.output
+            assert "2 scripts executed" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_composite_script_stops_on_error(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=1)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "deploy-all"])
+            assert result.exit_code == 1
+            assert mock_run.call_count == 1
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_composite_script_continue_on_error(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=1)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "deploy-all", "--continue-on-error"])
+            assert mock_run.call_count == 2
+            assert "Completed with errors" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_with_extra_args(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "dev", "--", "--server.port", "8502"])
+            assert result.exit_code == 0
+            cmd_str = " ".join(mock_run.call_args[0][0])
+            assert "--server.port" in cmd_str
+            assert "8502" in cmd_str
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_with_var_override(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "build", "-D", "env.database=PROD"])
+            assert result.exit_code == 0
+            cmd_str = " ".join(mock_run.call_args[0][0])
+            assert "PROD" in cmd_str
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_shell_script(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "shell-test"])
+            assert result.exit_code == 0
+            assert mock_run.call_args[1]["shell"] is True
+
+
+class TestRunHelp:
+    def test_run_help_shows_usage(self, runner):
+        result = runner.invoke(["run", "--help"])
+        assert result.exit_code == 0
+        assert "Execute project scripts" in result.output
+        assert "--list" in result.output
+        assert "--dry-run" in result.output
+
+
+class TestRunManifestScripts:
+    def test_list_scripts_from_manifest(self, runner, project_directory):
+        with project_directory("run_manifest_scripts"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code == 0
+            assert "Available scripts" in result.output
+            assert "from manifest.yml" in result.output
+            assert "validate" in result.output
+            assert "deploy" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_script_from_manifest(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_manifest_scripts"):
+            result = runner.invoke(["run", "validate"])
+            assert result.exit_code == 0
+            mock_run.assert_called_once()
+            assert "echo" in mock_run.call_args[0][0][0]
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_composite_script_from_manifest(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_manifest_scripts"):
+            result = runner.invoke(["run", "all"])
+            assert result.exit_code == 0
+            assert mock_run.call_count == 2
+
+    def test_scripts_conflict_raises_error(self, runner, project_directory):
+        with project_directory("run_scripts_conflict"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code != 0
+            assert "Scripts defined in both" in result.output
+            assert "manifest.yml" in result.output
+            assert "snowflake.yml" in result.output
+
+    def test_list_shows_source_file_snowflake(self, runner, project_directory):
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code == 0
+            assert "from snowflake.yml" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_manifest_only_project(self, mock_run, runner, project_directory):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_manifest_only"):
+            result = runner.invoke(["run", "test"])
+            assert result.exit_code == 0
+            mock_run.assert_called_once()

--- a/tests/run/test_commands.py
+++ b/tests/run/test_commands.py
@@ -146,6 +146,39 @@ class TestRunExecute:
             assert result.exit_code == 0
             assert mock_run.call_args[1]["shell"] is True
 
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_shell_mode_escapes_interpolated_variables(
+        self, mock_run, runner, project_directory
+    ):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(
+                ["run", "shell-with-vars", "-D", "env.database=TEST; rm -rf /"]
+            )
+            assert result.exit_code == 0
+            cmd_str = mock_run.call_args[0][0]
+            assert "rm -rf" not in cmd_str or "'" in cmd_str
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_extra_args_with_spaces_are_quoted(
+        self, mock_run, runner, project_directory
+    ):
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "dev", "--", "--flag=value with spaces"])
+            assert result.exit_code == 0
+            cmd_str = " ".join(mock_run.call_args[0][0])
+            assert "value with spaces" in cmd_str
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_composite_preserves_first_failure_exit_code(
+        self, mock_run, runner, project_directory
+    ):
+        mock_run.return_value = mock.Mock(returncode=42)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "deploy-all", "--continue-on-error"])
+            assert result.exit_code == 42
+
 
 class TestRunHelp:
     def test_run_help_shows_usage(self, runner):

--- a/tests/run/test_integration.py
+++ b/tests/run/test_integration.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SUBPROCESS_RUN = "snowflake.cli._plugins.run.manager.subprocess.run"
+
+
+class TestRunIntegration:
+    """Integration tests for snow run command."""
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_run_echo_script_in_real_project(
+        self, mock_run, runner, project_directory
+    ):
+        """Test running a simple echo script."""
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "dev"])
+            assert result.exit_code == 0
+            assert "Running script: dev" in result.output
+            assert "echo" in result.output
+            mock_run.assert_called_once()
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_composite_script_runs_all_steps(
+        self, mock_run, runner, project_directory
+    ):
+        """Test composite script executes all child scripts."""
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "deploy-all"])
+            assert result.exit_code == 0
+            assert "[1/2] build" in result.output
+            assert "[2/2] deploy" in result.output
+            assert "Done! (2 scripts executed)" in result.output
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_variable_interpolation_from_env_section(
+        self, mock_run, runner, project_directory
+    ):
+        """Test that env variables are properly interpolated."""
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "build"])
+            assert result.exit_code == 0
+            cmd = " ".join(mock_run.call_args[0][0])
+            assert "TEMP.DEV_PLATFORM" in cmd
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_override_variable_from_cli(
+        self, mock_run, runner, project_directory
+    ):
+        """Test that -D flag properly overrides variables."""
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "build", "-D", "env.database=PRODUCTION"])
+            assert result.exit_code == 0
+            cmd = " ".join(mock_run.call_args[0][0])
+            assert "PRODUCTION" in cmd
+
+    @mock.patch(SUBPROCESS_RUN)
+    def test_shell_mode_for_pipes(
+        self, mock_run, runner, project_directory
+    ):
+        """Test that shell=true scripts use shell execution."""
+        mock_run.return_value = mock.Mock(returncode=0)
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "shell-test"])
+            assert result.exit_code == 0
+            call_kwargs = mock_run.call_args[1]
+            assert call_kwargs["shell"] is True
+
+    def test_missing_script_shows_available_scripts(self, runner, project_directory):
+        """Test that missing script name shows list of available scripts."""
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "missing-script"])
+            assert result.exit_code != 0
+            assert "not found" in result.output
+            assert "dev" in result.output or "Available scripts" in result.output
+
+    def test_list_option_shows_all_scripts(self, runner, project_directory):
+        """Test --list option shows all available scripts with descriptions."""
+        with project_directory("run_scripts"):
+            result = runner.invoke(["run", "--list"])
+            assert result.exit_code == 0
+            assert "dev" in result.output
+            assert "build" in result.output
+            assert "deploy" in result.output
+            assert "Start local development server" in result.output

--- a/tests/run/test_integration.py
+++ b/tests/run/test_integration.py
@@ -12,22 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from pathlib import Path
 from unittest import mock
 
-import pytest
-
-SUBPROCESS_RUN = "snowflake.cli._plugins.run.manager.subprocess.run"
+SUBPROCESS_RUN = "snowflake.cli._plugins.run.manager._subprocess_run"
 
 
 class TestRunIntegration:
     """Integration tests for snow run command."""
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_run_echo_script_in_real_project(
-        self, mock_run, runner, project_directory
-    ):
+    def test_run_echo_script_in_real_project(self, mock_run, runner, project_directory):
         """Test running a simple echo script."""
         mock_run.return_value = mock.Mock(returncode=0)
         with project_directory("run_scripts"):
@@ -38,9 +32,7 @@ class TestRunIntegration:
             mock_run.assert_called_once()
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_composite_script_runs_all_steps(
-        self, mock_run, runner, project_directory
-    ):
+    def test_composite_script_runs_all_steps(self, mock_run, runner, project_directory):
         """Test composite script executes all child scripts."""
         mock_run.return_value = mock.Mock(returncode=0)
         with project_directory("run_scripts"):
@@ -63,9 +55,7 @@ class TestRunIntegration:
             assert "TEMP.DEV_PLATFORM" in cmd
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_override_variable_from_cli(
-        self, mock_run, runner, project_directory
-    ):
+    def test_override_variable_from_cli(self, mock_run, runner, project_directory):
         """Test that -D flag properly overrides variables."""
         mock_run.return_value = mock.Mock(returncode=0)
         with project_directory("run_scripts"):
@@ -75,9 +65,7 @@ class TestRunIntegration:
             assert "PRODUCTION" in cmd
 
     @mock.patch(SUBPROCESS_RUN)
-    def test_shell_mode_for_pipes(
-        self, mock_run, runner, project_directory
-    ):
+    def test_shell_mode_for_pipes(self, mock_run, runner, project_directory):
         """Test that shell=true scripts use shell execution."""
         mock_run.return_value = mock.Mock(returncode=0)
         with project_directory("run_scripts"):

--- a/tests/run/test_schema.py
+++ b/tests/run/test_schema.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from snowflake.cli.api.project.schemas.scripts import ScriptModel
+
+
+class TestScriptModel:
+    def test_script_with_cmd_only(self):
+        script = ScriptModel(cmd="echo hello")
+        assert script.cmd == "echo hello"
+        assert script.run is None
+        assert script.shell is False
+
+    def test_script_with_run_only(self):
+        script = ScriptModel(run=["build", "deploy"])
+        assert script.cmd is None
+        assert script.run == ["build", "deploy"]
+
+    def test_script_with_description(self):
+        script = ScriptModel(cmd="echo hello", description="Say hello")
+        assert script.description == "Say hello"
+
+    def test_script_with_shell_true(self):
+        script = ScriptModel(cmd="echo hello | cat", shell=True)
+        assert script.shell is True
+
+    def test_script_with_cwd(self):
+        script = ScriptModel(cmd="npm install", cwd="frontend")
+        assert script.cwd == "frontend"
+
+    def test_script_with_env(self):
+        script = ScriptModel(cmd="node app.js", env={"NODE_ENV": "production"})
+        assert script.env == {"NODE_ENV": "production"}
+
+    def test_script_must_have_cmd_or_run(self):
+        with pytest.raises(ValueError) as exc_info:
+            ScriptModel(description="Missing cmd or run")
+        assert "must have either 'cmd' or 'run'" in str(exc_info.value)
+
+    def test_script_cannot_have_both_cmd_and_run(self):
+        with pytest.raises(ValueError) as exc_info:
+            ScriptModel(cmd="echo hello", run=["build"])
+        assert "cannot have both 'cmd' and 'run'" in str(exc_info.value)
+
+    def test_script_all_fields(self):
+        script = ScriptModel(
+            cmd="npm run build",
+            description="Build the frontend",
+            shell=True,
+            cwd="frontend",
+            env={"NODE_ENV": "production", "CI": "true"},
+        )
+        assert script.cmd == "npm run build"
+        assert script.description == "Build the frontend"
+        assert script.shell is True
+        assert script.cwd == "frontend"
+        assert script.env == {"NODE_ENV": "production", "CI": "true"}

--- a/tests/test_data/projects/run_manifest_only/manifest.yml
+++ b/tests/test_data/projects/run_manifest_only/manifest.yml
@@ -1,0 +1,6 @@
+type: dcm_project
+
+scripts:
+  test:
+    cmd: echo "Testing manifest-only project"
+    description: Test script in manifest-only project

--- a/tests/test_data/projects/run_manifest_scripts/manifest.yml
+++ b/tests/test_data/projects/run_manifest_scripts/manifest.yml
@@ -1,0 +1,16 @@
+type: dcm_project
+
+scripts:
+  validate:
+    cmd: echo "Validating DCM project"
+    description: Validate DCM configuration
+
+  deploy:
+    cmd: echo "Deploying DCM resources"
+    description: Deploy DCM resources
+
+  all:
+    run:
+      - validate
+      - deploy
+    description: Run all DCM tasks

--- a/tests/test_data/projects/run_manifest_scripts/snowflake.yml
+++ b/tests/test_data/projects/run_manifest_scripts/snowflake.yml
@@ -1,0 +1,1 @@
+definition_version: 2

--- a/tests/test_data/projects/run_scripts/snowflake.yml
+++ b/tests/test_data/projects/run_scripts/snowflake.yml
@@ -1,0 +1,34 @@
+definition_version: 2
+
+env:
+  database: TEMP
+  schema: DEV_PLATFORM
+  connection: snowhouse
+
+scripts:
+  dev:
+    cmd: echo "Starting dev server"
+    description: Start local development server
+
+  build:
+    cmd: echo "Building for ${env.database}.${env.schema}"
+    description: Build the project
+
+  deploy:
+    cmd: echo "Deploying to ${env.connection}"
+    description: Deploy to Snowflake
+
+  deploy-all:
+    run:
+      - build
+      - deploy
+    description: Build and deploy
+
+  shell-test:
+    cmd: echo "test" | cat
+    shell: true
+    description: Test shell execution
+
+  with-env:
+    cmd: echo "User is ${env.USER}"
+    description: Test env variable interpolation

--- a/tests/test_data/projects/run_scripts/snowflake.yml
+++ b/tests/test_data/projects/run_scripts/snowflake.yml
@@ -32,3 +32,8 @@ scripts:
   with-env:
     cmd: echo "User is ${env.USER}"
     description: Test env variable interpolation
+
+  shell-with-vars:
+    cmd: echo "${env.database}" | cat
+    shell: true
+    description: Shell script with variable interpolation

--- a/tests/test_data/projects/run_scripts_conflict/manifest.yml
+++ b/tests/test_data/projects/run_scripts_conflict/manifest.yml
@@ -1,0 +1,6 @@
+type: dcm_project
+
+scripts:
+  deploy:
+    cmd: echo "Deploying from manifest.yml"
+    description: Deploy script from manifest.yml

--- a/tests/test_data/projects/run_scripts_conflict/snowflake.yml
+++ b/tests/test_data/projects/run_scripts_conflict/snowflake.yml
@@ -1,0 +1,6 @@
+definition_version: 2
+
+scripts:
+  build:
+    cmd: echo "Building from snowflake.yml"
+    description: Build script from snowflake.yml

--- a/tests/test_data/projects/run_scripts_cycle/snowflake.yml
+++ b/tests/test_data/projects/run_scripts_cycle/snowflake.yml
@@ -1,0 +1,12 @@
+definition_version: 2
+
+scripts:
+  alpha:
+    run:
+      - beta
+    description: Calls beta
+
+  beta:
+    run:
+      - alpha
+    description: Calls alpha

--- a/tests_e2e/__snapshots__/test_installation.ambr
+++ b/tests_e2e/__snapshots__/test_installation.ambr
@@ -40,6 +40,8 @@
   | logs                 Retrieves logs for a given object.                      |
   | notebook             Manages notebooks in Snowflake.                         |
   | object               Manages Snowflake objects like warehouses and stages    |
+  | run                  Execute project scripts defined in snowflake.yml or     |
+  |                      manifest.yml.                                           |
   | snowpark             Manages procedures and functions.                       |
   | spcs                 Manages Snowpark Container Services compute pools,      |
   |                      services, image registries, and image repositories.     |
@@ -104,6 +106,8 @@
   | logs         Retrieves logs for a given object.                              |
   | notebook     Manages notebooks in Snowflake.                                 |
   | object       Manages Snowflake objects like warehouses and stages            |
+  | run          Execute project scripts defined in snowflake.yml or             |
+  |              manifest.yml.                                                   |
   | snowpark     Manages procedures and functions.                               |
   | spcs         Manages Snowpark Container Services compute pools, services,    |
   |              image registries, and image repositories.                       |
@@ -149,6 +153,8 @@
   | logs                 Retrieves logs for a given object.                      |
   | notebook             Manages notebooks in Snowflake.                         |
   | object               Manages Snowflake objects like warehouses and stages    |
+  | run                  Execute project scripts defined in snowflake.yml or     |
+  |                      manifest.yml.                                           |
   | snowpark             Manages procedures and functions.                       |
   | spcs                 Manages Snowpark Container Services compute pools,      |
   |                      services, image registries, and image repositories.     |
@@ -233,6 +239,8 @@
   | logs         Retrieves logs for a given object.                              |
   | notebook     Manages notebooks in Snowflake.                                 |
   | object       Manages Snowflake objects like warehouses and stages            |
+  | run          Execute project scripts defined in snowflake.yml or             |
+  |              manifest.yml.                                                   |
   | snowpark     Manages procedures and functions.                               |
   | spcs         Manages Snowpark Container Services compute pools, services,    |
   |              image registries, and image repositories.                       |


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Add a new `snow run` command that allows users to define and execute project-specific scripts in snowflake.yml or manifest.yml. Features include:

- Load script from either snowflake.yml or manifest.yml with conflict detection
- Track script source file and show in --list output
- Script definitions with cmd, description, shell, cwd, and env options
- Composite scripts using `run:` to sequence multiple scripts
- Variable interpolation with ${env.VAR} syntax
- CLI overrides with -D flag
- Dry-run mode and continue-on-error for composite scripts
- Extensive unit and integration tests covering various scenarios and edge cases