### PR TITLE
feat: [SNOW-3680799] add interface-first plugin framework

### DIFF
--- a/src/snowflake/cli/api/plugins/command/__init__.py
+++ b/src/snowflake/cli/api/plugins/command/__init__.py
@@ -70,3 +70,21 @@ class CommandSpec:
     @cached_property
     def full_command_path(self) -> CommandPath:
         return CommandPath(self.parent_command_path.path_segments + [self.command.name])
+
+
+# -- Interface-first plugin API (spec + handler pattern) --------------------
+
+from snowflake.cli.api.plugins.command.interface import (  # noqa: E402
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    REQUIRED,
+    SingleCommandSpec,
+)
+from snowflake.cli.api.plugins.command.bridge import (  # noqa: E402
+    InterfaceValidationError,
+    build_command_spec,
+    register_decorator,
+)

--- a/src/snowflake/cli/api/plugins/command/bridge.py
+++ b/src/snowflake/cli/api/plugins/command/bridge.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge: converts a command spec + handler into a standard CommandSpec.
+
+The bridge is the only piece that knows about both the declarative interface
+layer and the Typer/Click runtime.  Downstream code (plugin loader, command
+registration) sees a plain ``CommandSpec`` and is completely unaware of the
+interface/handler split.
+"""
+
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import Callable
+
+import typer
+
+from snowflake.cli.api.commands.decorators import with_project_definition
+from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.plugins.command import (
+    CommandPath,
+    CommandSpec,
+    CommandType,
+)
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    REQUIRED,
+    SingleCommandSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Decorator registry — maps string names to factory callables
+# ---------------------------------------------------------------------------
+
+_DECORATOR_REGISTRY: dict[str, Callable] = {
+    "with_project_definition": lambda: with_project_definition(),
+}
+
+
+def register_decorator(name: str, factory: Callable) -> None:
+    """Register an additional decorator for use in ``CommandDef.decorators``.
+
+    *factory* is called with no arguments and must return a decorator function.
+    """
+    _DECORATOR_REGISTRY[name] = factory
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def build_command_spec(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+    *,
+    validate: bool = True,
+) -> CommandSpec:
+    """Convert a declarative spec + handler into a standard ``CommandSpec``.
+
+    The returned object is identical to what a traditional ``plugin_spec.py``
+    would produce — the rest of the CLI infrastructure is unchanged.
+
+    Args:
+        spec: Declarative command surface.
+        handler: Concrete handler implementing the business logic.
+        validate: If ``True`` (default), verify the handler satisfies the spec
+            before building.  Disable in production for faster startup if the
+            interface tests already cover this.
+    """
+    if validate:
+        validate_interface_handler(spec, handler)
+
+    if isinstance(spec, SingleCommandSpec):
+        factory = _build_single_command(spec, handler)
+        command_type = CommandType.SINGLE_COMMAND
+    else:
+        factory = _build_command_group(spec, handler)
+        command_type = CommandType.COMMAND_GROUP
+
+    return CommandSpec(
+        parent_command_path=CommandPath(list(spec.parent_path)),
+        command_type=command_type,
+        typer_instance=factory.create_instance(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class InterfaceValidationError(Exception):
+    """Raised when a handler does not satisfy its interface spec."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        msg = "Interface validation failed:\n" + "\n".join(
+            f"  - {e}" for e in errors
+        )
+        super().__init__(msg)
+
+
+def validate_interface_handler(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+) -> None:
+    """Check that *handler* has a callable method for every command in *spec*.
+
+    Raises ``InterfaceValidationError`` with all violations listed.
+    """
+    errors: list[str] = []
+    for cmd in _collect_commands(spec):
+        method = getattr(handler, cmd.handler_method, None)
+        if method is None:
+            errors.append(
+                f"Handler missing method '{cmd.handler_method}' "
+                f"for command '{cmd.name}'"
+            )
+        elif not callable(method):
+            errors.append(f"Handler.{cmd.handler_method} is not callable")
+    if errors:
+        raise InterfaceValidationError(errors)
+
+
+def _collect_commands(
+    spec: CommandGroupSpec | SingleCommandSpec,
+) -> list[CommandDef]:
+    """Recursively collect all ``CommandDef`` objects from a spec tree."""
+    if isinstance(spec, SingleCommandSpec):
+        return [spec.command]
+    commands = list(spec.commands)
+    for sub in spec.subgroups:
+        commands.extend(_collect_commands(sub))
+    return commands
+
+
+# ---------------------------------------------------------------------------
+# Typer construction
+# ---------------------------------------------------------------------------
+
+
+def _build_command_group(
+    spec: CommandGroupSpec,
+    handler: CommandHandler,
+) -> SnowTyperFactory:
+    factory = SnowTyperFactory(name=spec.name, help=spec.help)
+
+    for cmd_def in spec.commands:
+        _register_command(factory, cmd_def, handler)
+
+    for subgroup in spec.subgroups:
+        sub_factory = _build_command_group(subgroup, handler)
+        factory.add_typer(sub_factory)
+
+    return factory
+
+
+def _build_single_command(
+    spec: SingleCommandSpec,
+    handler: CommandHandler,
+) -> SnowTyperFactory:
+    factory = SnowTyperFactory(name=spec.command.name)
+
+    _register_command(factory, spec.command, handler)
+
+    return factory
+
+
+def _register_command(
+    factory: SnowTyperFactory,
+    cmd_def: CommandDef,
+    handler: CommandHandler,
+) -> None:
+    """Build a Typer command function from a ``CommandDef`` + handler method."""
+    handler_method = getattr(handler, cmd_def.handler_method)
+    spec_param_names = {p.name for p in cmd_def.params}
+
+    # Build signature parameters for Typer introspection
+    sig_params: list[inspect.Parameter] = []
+    annotations: dict[str, type] = {}
+
+    for p in cmd_def.params:
+        annotations[p.name] = p.type
+        default = _make_typer_default(p)
+        sig_params.append(
+            inspect.Parameter(
+                p.name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=p.type,
+            )
+        )
+
+    # **options is required by SnowTyper's global_options decorator injection
+    sig_params.append(
+        inspect.Parameter("options", inspect.Parameter.VAR_KEYWORD)
+    )
+
+    # Create the wrapper that Typer will call at runtime
+    @wraps(handler_method)
+    def command_fn(**kwargs):
+        handler_kwargs = {k: v for k, v in kwargs.items() if k in spec_param_names}
+        return handler_method(**handler_kwargs)
+
+    # Attach the constructed signature so Typer/Click build the right CLI
+    command_fn.__signature__ = inspect.Signature(sig_params)
+    command_fn.__annotations__ = annotations
+    command_fn.__doc__ = cmd_def.help
+    command_fn.__name__ = cmd_def.handler_method
+    command_fn.__qualname__ = cmd_def.handler_method
+
+    # Apply registered decorators in reverse order (outermost first)
+    for dec_name in reversed(cmd_def.decorators):
+        dec_factory = _DECORATOR_REGISTRY.get(dec_name)
+        if dec_factory is None:
+            raise ValueError(
+                f"Unknown decorator '{dec_name}' in command '{cmd_def.name}'. "
+                f"Register it with register_decorator() first."
+            )
+        command_fn = dec_factory()(command_fn)
+
+    factory.command(
+        name=cmd_def.name,
+        requires_connection=cmd_def.requires_connection,
+        require_warehouse=cmd_def.require_warehouse,
+        preview=cmd_def.is_preview,
+        hidden=cmd_def.is_hidden,
+    )(command_fn)
+
+
+def _make_typer_default(p: ParamDef):
+    """Create the appropriate ``typer.Argument`` or ``typer.Option`` default."""
+    is_required = p.default is REQUIRED
+
+    # Extra kwargs for custom Click type parsing (e.g. IdentifierType for FQN)
+    extra: dict = {}
+    if p.click_type is not None:
+        extra["click_type"] = p.click_type
+
+    if p.kind == ParamKind.ARGUMENT:
+        return typer.Argument(
+            ... if is_required else p.default,
+            help=p.help,
+            show_default=p.show_default,
+            hidden=p.hidden,
+            **extra,
+        )
+
+    # OPTION
+    cli_names = p.cli_names or (f"--{p.name.replace('_', '-')}",)
+
+    if p.is_flag:
+        return typer.Option(
+            p.default if not is_required else False,
+            *cli_names,
+            help=p.help,
+            is_flag=True,
+            show_default=p.show_default,
+            hidden=p.hidden,
+            **extra,
+        )
+
+    return typer.Option(
+        ... if is_required else p.default,
+        *cli_names,
+        help=p.help,
+        show_default=p.show_default,
+        hidden=p.hidden,
+        **extra,
+    )

--- a/src/snowflake/cli/api/plugins/command/bridge.py
+++ b/src/snowflake/cli/api/plugins/command/bridge.py
@@ -222,7 +222,7 @@ def _register_command(
         return handler_method(**handler_kwargs)
 
     # Attach the constructed signature so Typer/Click build the right CLI
-    command_fn.__signature__ = inspect.Signature(sig_params)
+    command_fn.__signature__ = inspect.Signature(sig_params)  # type: ignore[attr-defined]
     command_fn.__annotations__ = annotations
     command_fn.__doc__ = cmd_def.help
     command_fn.__name__ = cmd_def.handler_method

--- a/src/snowflake/cli/api/plugins/command/bridge.py
+++ b/src/snowflake/cli/api/plugins/command/bridge.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge: converts a command spec + handler into a standard CommandSpec.
+
+The bridge is the only piece that knows about both the declarative interface
+layer and the Typer/Click runtime.  Downstream code (plugin loader, command
+registration) sees a plain ``CommandSpec`` and is completely unaware of the
+interface/handler split.
+"""
+
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import Callable
+
+import typer
+from snowflake.cli.api.commands.decorators import with_project_definition
+from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.plugins.command import (
+    CommandPath,
+    CommandSpec,
+    CommandType,
+)
+from snowflake.cli.api.plugins.command.interface import (
+    REQUIRED,
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    SingleCommandSpec,
+)
+
+# ---------------------------------------------------------------------------
+# Decorator registry — maps string names to factory callables
+# ---------------------------------------------------------------------------
+
+_DECORATOR_REGISTRY: dict[str, Callable] = {
+    "with_project_definition": lambda: with_project_definition(),
+}
+
+
+def register_decorator(name: str, factory: Callable) -> None:
+    """Register an additional decorator for use in ``CommandDef.decorators``.
+
+    *factory* is called with no arguments and must return a decorator function.
+    """
+    _DECORATOR_REGISTRY[name] = factory
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def build_command_spec(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+    *,
+    validate: bool = True,
+) -> CommandSpec:
+    """Convert a declarative spec + handler into a standard ``CommandSpec``.
+
+    The returned object is identical to what a traditional ``plugin_spec.py``
+    would produce — the rest of the CLI infrastructure is unchanged.
+
+    Args:
+        spec: Declarative command surface.
+        handler: Concrete handler implementing the business logic.
+        validate: If ``True`` (default), verify the handler satisfies the spec
+            before building.  Disable in production for faster startup if the
+            interface tests already cover this.
+    """
+    if validate:
+        validate_interface_handler(spec, handler)
+
+    if isinstance(spec, SingleCommandSpec):
+        factory = _build_single_command(spec, handler)
+        command_type = CommandType.SINGLE_COMMAND
+    else:
+        factory = _build_command_group(spec, handler)
+        command_type = CommandType.COMMAND_GROUP
+
+    return CommandSpec(
+        parent_command_path=CommandPath(list(spec.parent_path)),
+        command_type=command_type,
+        typer_instance=factory.create_instance(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class InterfaceValidationError(Exception):
+    """Raised when a handler does not satisfy its interface spec."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        msg = "Interface validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+        super().__init__(msg)
+
+
+def validate_interface_handler(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+) -> None:
+    """Check that *handler* has a callable method for every command in *spec*.
+
+    Raises ``InterfaceValidationError`` with all violations listed.
+    """
+    errors: list[str] = []
+    for cmd in _collect_commands(spec):
+        method = getattr(handler, cmd.handler_method, None)
+        if method is None:
+            errors.append(
+                f"Handler missing method '{cmd.handler_method}' "
+                f"for command '{cmd.name}'"
+            )
+        elif not callable(method):
+            errors.append(f"Handler.{cmd.handler_method} is not callable")
+    if errors:
+        raise InterfaceValidationError(errors)
+
+
+def _collect_commands(
+    spec: CommandGroupSpec | SingleCommandSpec,
+) -> list[CommandDef]:
+    """Recursively collect all ``CommandDef`` objects from a spec tree."""
+    if isinstance(spec, SingleCommandSpec):
+        return [spec.command]
+    commands = list(spec.commands)
+    for sub in spec.subgroups:
+        commands.extend(_collect_commands(sub))
+    return commands
+
+
+# ---------------------------------------------------------------------------
+# Typer construction
+# ---------------------------------------------------------------------------
+
+
+def _build_command_group(
+    spec: CommandGroupSpec,
+    handler: CommandHandler,
+) -> SnowTyperFactory:
+    factory = SnowTyperFactory(name=spec.name, help=spec.help)
+
+    for cmd_def in spec.commands:
+        _register_command(factory, cmd_def, handler)
+
+    for subgroup in spec.subgroups:
+        sub_factory = _build_command_group(subgroup, handler)
+        factory.add_typer(sub_factory)
+
+    return factory
+
+
+def _build_single_command(
+    spec: SingleCommandSpec,
+    handler: CommandHandler,
+) -> SnowTyperFactory:
+    factory = SnowTyperFactory(name=spec.command.name)
+
+    _register_command(factory, spec.command, handler)
+
+    return factory
+
+
+def _register_command(
+    factory: SnowTyperFactory,
+    cmd_def: CommandDef,
+    handler: CommandHandler,
+) -> None:
+    """Build a Typer command function from a ``CommandDef`` + handler method."""
+    handler_method = getattr(handler, cmd_def.handler_method)
+    spec_param_names = {p.name for p in cmd_def.params}
+
+    # Build signature parameters for Typer introspection
+    sig_params: list[inspect.Parameter] = []
+    annotations: dict[str, type] = {}
+
+    for p in cmd_def.params:
+        annotations[p.name] = p.type
+        default = _make_typer_default(p)
+        sig_params.append(
+            inspect.Parameter(
+                p.name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=p.type,
+            )
+        )
+
+    # **options is required by SnowTyper's global_options decorator injection
+    sig_params.append(inspect.Parameter("options", inspect.Parameter.VAR_KEYWORD))
+
+    # Create the wrapper that Typer will call at runtime
+    @wraps(handler_method)
+    def command_fn(**kwargs):
+        handler_kwargs = {k: v for k, v in kwargs.items() if k in spec_param_names}
+        return handler_method(**handler_kwargs)
+
+    # Attach the constructed signature so Typer/Click build the right CLI
+    command_fn.__signature__ = inspect.Signature(sig_params)  # type: ignore[attr-defined]
+    command_fn.__annotations__ = annotations
+    command_fn.__doc__ = cmd_def.help
+    command_fn.__name__ = cmd_def.handler_method
+    command_fn.__qualname__ = cmd_def.handler_method
+
+    # Apply registered decorators in reverse order (outermost first)
+    for dec_name in reversed(cmd_def.decorators):
+        dec_factory = _DECORATOR_REGISTRY.get(dec_name)
+        if dec_factory is None:
+            raise ValueError(
+                f"Unknown decorator '{dec_name}' in command '{cmd_def.name}'. "
+                f"Register it with register_decorator() first."
+            )
+        command_fn = dec_factory()(command_fn)
+
+    factory.command(
+        name=cmd_def.name,
+        requires_connection=cmd_def.requires_connection,
+        require_warehouse=cmd_def.require_warehouse,
+        preview=cmd_def.is_preview,
+        hidden=cmd_def.is_hidden,
+    )(command_fn)
+
+
+def _make_typer_default(p: ParamDef):
+    """Create the appropriate ``typer.Argument`` or ``typer.Option`` default."""
+    is_required = p.default is REQUIRED
+
+    # Extra kwargs for custom Click type parsing (e.g. IdentifierType for FQN)
+    extra: dict = {}
+    if p.click_type is not None:
+        extra["click_type"] = p.click_type
+
+    if p.kind == ParamKind.ARGUMENT:
+        return typer.Argument(
+            ... if is_required else p.default,
+            help=p.help,
+            show_default=p.show_default,
+            hidden=p.hidden,
+            **extra,
+        )
+
+    # OPTION
+    cli_names = p.cli_names or (f"--{p.name.replace('_', '-')}",)
+
+    if p.is_flag:
+        # Typer derives flag behaviour from the ``bool`` annotation; passing
+        # Click's ``is_flag`` directly is deprecated. A single declaration
+        # (e.g. ``--dry-run``) yields a flag with no ``--no-*`` counterpart.
+        return typer.Option(
+            p.default if not is_required else False,
+            *cli_names,
+            help=p.help,
+            show_default=p.show_default,
+            hidden=p.hidden,
+            **extra,
+        )
+
+    return typer.Option(
+        ... if is_required else p.default,
+        *cli_names,
+        help=p.help,
+        show_default=p.show_default,
+        hidden=p.hidden,
+        **extra,
+    )

--- a/src/snowflake/cli/api/plugins/command/bridge.py
+++ b/src/snowflake/cli/api/plugins/command/bridge.py
@@ -80,9 +80,13 @@ def build_command_spec(
     Args:
         spec: Declarative command surface.
         handler: Concrete handler implementing the business logic.
-        validate: If ``True`` (default), verify the handler satisfies the spec
-            before building.  Disable in production for faster startup if the
-            interface tests already cover this.
+        validate: If ``True`` (default), check that the handler implements
+            every declared ``handler_method`` before building — see
+            ``validate_interface_handler``. Set ``False`` to skip *only* that
+            handler-method presence check for faster startup when the interface
+            tests already cover it. This flag does **not** disable all error
+            checking: unknown-decorator resolution (and any other spec-shape
+            error) still raises at build time regardless of its value.
     """
     if validate:
         validate_interface_handler(spec, handler)
@@ -222,7 +226,9 @@ def _register_command(
     command_fn.__name__ = cmd_def.handler_method
     command_fn.__qualname__ = cmd_def.handler_method
 
-    # Apply registered decorators in reverse order (outermost first)
+    # Apply registered decorators. The spec lists them outermost-first, so we
+    # iterate in reverse to wrap the innermost one first:
+    #   decorators=("A", "B")  ->  A(B(command_fn))
     for dec_name in reversed(cmd_def.decorators):
         dec_factory = _DECORATOR_REGISTRY.get(dec_name)
         if dec_factory is None:
@@ -245,6 +251,16 @@ def _make_typer_default(p: ParamDef):
     """Create the appropriate ``typer.Argument`` or ``typer.Option`` default."""
     is_required = p.default is REQUIRED
 
+    if p.is_flag and is_required:
+        # A required boolean flag is semantically nonsensical (a flag is either
+        # present or absent), so this is almost certainly a spec authoring
+        # error. Surface it loudly rather than silently coercing to ``False``.
+        raise ValueError(
+            f"Parameter '{p.name}' is a boolean flag (is_flag=True) with no "
+            f"default. A required flag is meaningless; give it an explicit "
+            f"default (e.g. default=False)."
+        )
+
     # Extra kwargs for custom Click type parsing (e.g. IdentifierType for FQN)
     extra: dict = {}
     if p.click_type is not None:
@@ -266,8 +282,9 @@ def _make_typer_default(p: ParamDef):
         # Typer derives flag behaviour from the ``bool`` annotation; passing
         # Click's ``is_flag`` directly is deprecated. A single declaration
         # (e.g. ``--dry-run``) yields a flag with no ``--no-*`` counterpart.
+        # ``is_required`` is guaranteed ``False`` here (guarded above).
         return typer.Option(
-            p.default if not is_required else False,
+            p.default,
             *cli_names,
             help=p.help,
             show_default=p.show_default,

--- a/src/snowflake/cli/api/plugins/command/interface.py
+++ b/src/snowflake/cli/api/plugins/command/interface.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plugin interface definitions.
+
+This module provides frozen dataclasses for declaring a plugin's command
+surface (what commands exist, their parameters, help text) separately from
+the implementation. The command spec is reviewed in Phase 1; the handler
+implementation follows in Phase 2.
+
+Typical usage in a plugin's ``interface.py``::
+
+    from snowflake.cli.api.plugins.command.interface import (
+        CommandDef, CommandGroupSpec, CommandHandler, ParamDef, ParamKind, REQUIRED,
+    )
+
+    MY_SPEC = CommandGroupSpec(
+        name="my-plugin",
+        help="Does something useful.",
+        commands=(
+            CommandDef(
+                name="run",
+                help="Run the thing.",
+                handler_method="run",
+                requires_connection=True,
+                params=(
+                    ParamDef(name="name", type=str, kind=ParamKind.ARGUMENT, help="Name"),
+                ),
+            ),
+        ),
+    )
+
+    class MyHandler(CommandHandler):
+        @abstractmethod
+        def run(self, name: str) -> CommandResult: ...
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Type
+
+import click
+
+
+class _RequiredSentinel:
+    """Sentinel indicating a parameter has no default and is required."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "REQUIRED"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+REQUIRED = _RequiredSentinel()
+
+
+class ParamKind(Enum):
+    """Whether a CLI parameter is a positional argument or a named option."""
+
+    ARGUMENT = "argument"
+    OPTION = "option"
+
+
+@dataclass(frozen=True)
+class ParamDef:
+    """Declares a single CLI parameter (argument or option).
+
+    Attributes:
+        name: Python parameter name (used as the handler method kwarg).
+        type: The Python type (``str``, ``FQN``, ``Path``, ...).
+        kind: ``ParamKind.ARGUMENT`` or ``ParamKind.OPTION``.
+        help: Help text shown in ``--help``.
+        cli_names: Explicit CLI names, e.g. ``("--notebook-file", "-f")``.
+            Empty means auto-derived from *name*.
+        default: Default value. Use ``REQUIRED`` (the default) for required params.
+        required: Whether the parameter is required.
+        is_flag: ``True`` for boolean flags like ``--replace``.
+        show_default: Whether ``--help`` shows the default value.
+        hidden: Hide from ``--help`` output.
+        click_type: Optional Click ``ParamType`` for custom type parsing.
+            Use for types that Typer doesn't handle natively (e.g. ``FQN``
+            with ``IdentifierType()``).
+    """
+
+    name: str
+    type: Type
+    kind: ParamKind
+    help: str = ""
+    cli_names: tuple[str, ...] = ()
+    default: Any = REQUIRED
+    required: bool = True
+    is_flag: bool = False
+    show_default: bool = True
+    hidden: bool = False
+    click_type: Optional[click.ParamType] = None
+
+
+@dataclass(frozen=True)
+class CommandDef:
+    """Declares a single CLI command.
+
+    Attributes:
+        name: The CLI command name (e.g. ``"execute"``, ``"get-url"``).
+        help: Help text shown in ``--help``.
+        handler_method: Method name on the ``CommandHandler`` subclass.
+        params: Tuple of ``ParamDef`` instances.
+        requires_connection: Whether a Snowflake connection is needed.
+        require_warehouse: Whether a warehouse must be set.
+        is_preview: Mark as a preview feature.
+        is_hidden: Hide from ``--help`` output.
+        decorators: Names of extra decorators to apply (e.g.
+            ``("with_project_definition",)``).
+        output_type: Documentation hint for reviewers (not enforced at runtime).
+    """
+
+    name: str
+    help: str
+    handler_method: str
+    params: tuple[ParamDef, ...] = ()
+    requires_connection: bool = False
+    require_warehouse: bool = False
+    is_preview: bool = False
+    is_hidden: bool = False
+    decorators: tuple[str, ...] = ()
+    output_type: str = "CommandResult"
+
+
+@dataclass(frozen=True)
+class CommandGroupSpec:
+    """Declares a command group — the top-level reviewable spec.
+
+    Attributes:
+        name: Group name (e.g. ``"notebook"`` for ``snow notebook``).
+        help: Group-level help text.
+        parent_path: Where to attach in the CLI tree.
+            ``()`` = root level, ``("snowpark",)`` = nested under snowpark.
+        commands: Direct child commands.
+        subgroups: Nested command groups.
+    """
+
+    name: str
+    help: str
+    parent_path: tuple[str, ...] = ()
+    commands: tuple[CommandDef, ...] = ()
+    subgroups: tuple["CommandGroupSpec", ...] = ()
+
+
+@dataclass(frozen=True)
+class SingleCommandSpec:
+    """Declares a single command (not a group).
+
+    Use this instead of ``CommandGroupSpec`` when the plugin contributes
+    exactly one command with no subcommands.
+
+    Attributes:
+        parent_path: Where to attach in the CLI tree.
+        command: The command definition.
+    """
+
+    parent_path: tuple[str, ...] = ()
+    command: CommandDef = None  # type: ignore[assignment]
+
+
+class CommandHandler(ABC):
+    """Base class for plugin command handlers.
+
+    Subclass this and declare abstract methods whose names match the
+    ``handler_method`` values in your ``CommandGroupSpec`` / ``SingleCommandSpec``.
+
+    The bridge validates at load time that every command in the spec has
+    a corresponding callable method on the handler.
+    """
+
+    pass

--- a/src/snowflake/cli/api/plugins/command/interface.py
+++ b/src/snowflake/cli/api/plugins/command/interface.py
@@ -42,8 +42,8 @@ Typical usage in a plugin's ``interface.py``::
     )
 
     class MyHandler(CommandHandler):
-        @abstractmethod
-        def run(self, name: str) -> CommandResult: ...
+        def run(self, name: str) -> CommandResult:
+            return MessageResult(f"Hello, {name}!")
 """
 
 from __future__ import annotations
@@ -185,13 +185,22 @@ class SingleCommandSpec:
 
 
 class CommandHandler(ABC):
-    """Base class for plugin command handlers.
+    """Marker base class for plugin command handlers.
 
-    Subclass this and declare abstract methods whose names match the
-    ``handler_method`` values in your ``CommandGroupSpec`` / ``SingleCommandSpec``.
+    Subclass this and implement one method per ``handler_method`` named in your
+    ``CommandGroupSpec`` / ``SingleCommandSpec``.
 
-    The bridge validates at load time that every command in the spec has
-    a corresponding callable method on the handler.
+    .. note::
+        This is intentionally a *marker* base: it declares **no**
+        ``@abstractmethod`` members, so Python's ABC machinery enforces
+        nothing and any subclass can be instantiated freely. The real
+        contract — that every declared ``handler_method`` exists and is
+        callable — is enforced by :func:`validate_interface_handler` at
+        bridge build time (and surfaced early via ``assert_handler_satisfies``).
+        Enforcement is deferred to the bridge so the spec (plain data) stays
+        the single source of truth for which methods are required, rather than
+        duplicating that list as abstract declarations here.
     """
 
+    # No abstract methods by design — see the note in the docstring above.
     pass

--- a/src/snowflake/cli/api/plugins/command/interface.py
+++ b/src/snowflake/cli/api/plugins/command/interface.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plugin interface definitions.
+
+This module provides frozen dataclasses for declaring a plugin's command
+surface (what commands exist, their parameters, help text) separately from
+the implementation. The command spec is reviewed in Phase 1; the handler
+implementation follows in Phase 2.
+
+Typical usage in a plugin's ``interface.py``::
+
+    from snowflake.cli.api.plugins.command.interface import (
+        CommandDef, CommandGroupSpec, CommandHandler, ParamDef, ParamKind, REQUIRED,
+    )
+
+    MY_SPEC = CommandGroupSpec(
+        name="my-plugin",
+        help="Does something useful.",
+        commands=(
+            CommandDef(
+                name="run",
+                help="Run the thing.",
+                handler_method="run",
+                requires_connection=True,
+                params=(
+                    ParamDef(name="name", type=str, kind=ParamKind.ARGUMENT, help="Name"),
+                ),
+            ),
+        ),
+    )
+
+    class MyHandler(CommandHandler):
+        @abstractmethod
+        def run(self, name: str) -> CommandResult: ...
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Type
+
+import click
+
+
+class _RequiredSentinel:
+    """Sentinel indicating a parameter has no default and is required."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "REQUIRED"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+REQUIRED = _RequiredSentinel()
+
+
+class ParamKind(Enum):
+    """Whether a CLI parameter is a positional argument or a named option."""
+
+    ARGUMENT = "argument"
+    OPTION = "option"
+
+
+@dataclass(frozen=True)
+class ParamDef:
+    """Declares a single CLI parameter (argument or option).
+
+    Attributes:
+        name: Python parameter name (used as the handler method kwarg).
+        type: The Python type (``str``, ``FQN``, ``Path``, ...).
+        kind: ``ParamKind.ARGUMENT`` or ``ParamKind.OPTION``.
+        help: Help text shown in ``--help``.
+        cli_names: Explicit CLI names, e.g. ``("--notebook-file", "-f")``.
+            Empty means auto-derived from *name*.
+        default: Default value, or ``REQUIRED`` (the default) to mark the
+            parameter as required. Any other value (e.g. ``None``) makes it
+            optional with that default — this single field is the source of
+            truth for whether the parameter is required.
+        is_flag: ``True`` for boolean flags like ``--replace``.
+        show_default: Whether ``--help`` shows the default value.
+        hidden: Hide from ``--help`` output.
+        click_type: Optional Click ``ParamType`` for custom type parsing.
+            Use for types that Typer doesn't handle natively (e.g. ``FQN``
+            with ``IdentifierType()``).
+    """
+
+    name: str
+    type: Type  # noqa: A003
+    kind: ParamKind
+    help: str = ""  # noqa: A003
+    cli_names: tuple[str, ...] = ()
+    default: Any = REQUIRED
+    is_flag: bool = False
+    show_default: bool = True
+    hidden: bool = False
+    click_type: Optional[click.ParamType] = None
+
+
+@dataclass(frozen=True)
+class CommandDef:
+    """Declares a single CLI command.
+
+    Attributes:
+        name: The CLI command name (e.g. ``"execute"``, ``"get-url"``).
+        help: Help text shown in ``--help``.
+        handler_method: Method name on the ``CommandHandler`` subclass.
+        params: Tuple of ``ParamDef`` instances.
+        requires_connection: Whether a Snowflake connection is needed.
+        require_warehouse: Whether a warehouse must be set.
+        is_preview: Mark as a preview feature.
+        is_hidden: Hide from ``--help`` output.
+        decorators: Names of extra decorators to apply (e.g.
+            ``("with_project_definition",)``).
+        output_type: Documentation hint for reviewers (not enforced at runtime).
+    """
+
+    name: str
+    help: str  # noqa: A003
+    handler_method: str
+    params: tuple[ParamDef, ...] = ()
+    requires_connection: bool = False
+    require_warehouse: bool = False
+    is_preview: bool = False
+    is_hidden: bool = False
+    decorators: tuple[str, ...] = ()
+    output_type: str = "CommandResult"
+
+
+@dataclass(frozen=True)
+class CommandGroupSpec:
+    """Declares a command group — the top-level reviewable spec.
+
+    Attributes:
+        name: Group name (e.g. ``"notebook"`` for ``snow notebook``).
+        help: Group-level help text.
+        parent_path: Where to attach in the CLI tree.
+            ``()`` = root level, ``("snowpark",)`` = nested under snowpark.
+        commands: Direct child commands.
+        subgroups: Nested command groups.
+    """
+
+    name: str
+    help: str  # noqa: A003
+    parent_path: tuple[str, ...] = ()
+    commands: tuple[CommandDef, ...] = ()
+    subgroups: tuple["CommandGroupSpec", ...] = ()
+
+
+@dataclass(frozen=True)
+class SingleCommandSpec:
+    """Declares a single command (not a group).
+
+    Use this instead of ``CommandGroupSpec`` when the plugin contributes
+    exactly one command with no subcommands.
+
+    Attributes:
+        command: The command definition.
+        parent_path: Where to attach in the CLI tree.
+    """
+
+    command: CommandDef
+    parent_path: tuple[str, ...] = ()
+
+
+class CommandHandler(ABC):
+    """Base class for plugin command handlers.
+
+    Subclass this and declare abstract methods whose names match the
+    ``handler_method`` values in your ``CommandGroupSpec`` / ``SingleCommandSpec``.
+
+    The bridge validates at load time that every command in the spec has
+    a corresponding callable method on the handler.
+    """
+
+    pass

--- a/src/snowflake/cli/api/plugins/command/testing.py
+++ b/src/snowflake/cli/api/plugins/command/testing.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test utilities for plugin authors.
+
+These helpers validate interface specs and handler implementations without
+requiring a Snowflake connection.  Use them in unit tests to catch contract
+mismatches early::
+
+    from snowflake.cli.api.plugins.command.testing import (
+        assert_interface_well_formed,
+        assert_handler_satisfies,
+        assert_builds_valid_spec,
+    )
+
+    def test_my_interface():
+        assert_interface_well_formed(MY_SPEC)
+
+    def test_my_handler():
+        assert_handler_satisfies(MY_SPEC, MyHandlerImpl())
+
+    def test_full_build():
+        assert_builds_valid_spec(MY_SPEC, MyHandlerImpl())
+"""
+
+from __future__ import annotations
+
+from snowflake.cli.api.plugins.command.bridge import (
+    _collect_commands,
+    build_command_spec,
+    validate_interface_handler,
+)
+from snowflake.cli.api.plugins.command.interface import (
+    CommandGroupSpec,
+    CommandHandler,
+    SingleCommandSpec,
+)
+
+
+def assert_interface_well_formed(
+    spec: CommandGroupSpec | SingleCommandSpec,
+) -> None:
+    """Validate the spec dataclass tree is complete and consistent.
+
+    Checks:
+    - Every command has a non-empty name, help text, and handler_method.
+    - No duplicate handler_method values across the entire tree.
+    - handler_method values are valid Python identifiers.
+
+    Raises ``AssertionError`` on the first violation found.
+    """
+    commands = _collect_commands(spec)
+    seen_methods: set[str] = set()
+
+    for cmd in commands:
+        assert cmd.name, "Command has empty name"
+        assert cmd.help, f"Command '{cmd.name}' has empty help text"
+        assert cmd.handler_method, f"Command '{cmd.name}' has empty handler_method"
+        assert cmd.handler_method.isidentifier(), (
+            f"Command '{cmd.name}': handler_method '{cmd.handler_method}' "
+            f"is not a valid Python identifier"
+        )
+        assert cmd.handler_method not in seen_methods, (
+            f"Duplicate handler_method '{cmd.handler_method}' "
+            f"(used by command '{cmd.name}')"
+        )
+        seen_methods.add(cmd.handler_method)
+
+        for param in cmd.params:
+            assert param.name, f"Command '{cmd.name}' has a param with empty name"
+            assert param.name.isidentifier(), (
+                f"Command '{cmd.name}': param name '{param.name}' "
+                f"is not a valid Python identifier"
+            )
+
+
+def assert_handler_satisfies(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+) -> None:
+    """Validate that *handler* implements all methods required by *spec*.
+
+    Delegates to ``validate_interface_handler`` which raises
+    ``InterfaceValidationError`` with all violations listed.
+    """
+    validate_interface_handler(spec, handler)
+
+
+def assert_builds_valid_spec(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+) -> None:
+    """Full integration check: spec + handler produce a valid ``CommandSpec``.
+
+    Builds the ``CommandSpec`` (with validation) and verifies that the
+    resulting Click command tree was created successfully.
+    """
+    result = build_command_spec(spec, handler, validate=True)
+    assert result.command is not None, "build_command_spec produced a None Click command"

--- a/src/snowflake/cli/api/plugins/command/testing.py
+++ b/src/snowflake/cli/api/plugins/command/testing.py
@@ -37,11 +37,13 @@ mismatches early::
 from __future__ import annotations
 
 from snowflake.cli.api.plugins.command.bridge import (
-    _collect_commands,
+    InterfaceValidationError,
     build_command_spec,
     validate_interface_handler,
 )
 from snowflake.cli.api.plugins.command.interface import (
+    REQUIRED,
+    CommandDef,
     CommandGroupSpec,
     CommandHandler,
     SingleCommandSpec,
@@ -55,15 +57,21 @@ def assert_interface_well_formed(
 
     Checks:
     - Every command has a non-empty name, help text, and handler_method.
-    - No duplicate handler_method values across the entire tree.
-    - handler_method values are valid Python identifiers.
+    - handler_method values are valid Python identifiers and unique across the
+      entire tree (each maps to one method on a single handler instance).
+    - Command (CLI) names are unique *within their group* — sibling commands
+      may not collide, but two different subgroups may reuse a name.
+    - Param names are valid Python identifiers.
+    - No boolean flag (``is_flag=True``) is left required (``default=REQUIRED``);
+      a required flag is meaningless. Mirrors the build-time guard in the bridge.
 
     Raises ``AssertionError`` on the first violation found.
     """
-    commands = _collect_commands(spec)
+    # handler_method must be unique across the whole tree: every method resolves
+    # against one handler instance, so any collision is a genuine conflict.
     seen_methods: set[str] = set()
 
-    for cmd in commands:
+    def check_command(cmd: CommandDef) -> None:
         assert cmd.name, "Command has empty name"
         assert cmd.help, f"Command '{cmd.name}' has empty help text"
         assert cmd.handler_method, f"Command '{cmd.name}' has empty handler_method"
@@ -83,6 +91,29 @@ def assert_interface_well_formed(
                 f"Command '{cmd.name}': param name '{param.name}' "
                 f"is not a valid Python identifier"
             )
+            assert not (param.is_flag and param.default is REQUIRED), (
+                f"Command '{cmd.name}': param '{param.name}' is a boolean flag "
+                f"(is_flag=True) with no default; give it an explicit default "
+                f"(e.g. default=False)"
+            )
+
+    def check_group(group: CommandGroupSpec) -> None:
+        # Command names need only be unique among siblings — two different
+        # subgroups may legitimately expose the same command name.
+        seen_names: set[str] = set()
+        for cmd in group.commands:
+            check_command(cmd)
+            assert (
+                cmd.name not in seen_names
+            ), f"Duplicate command name '{cmd.name}' in group '{group.name}'"
+            seen_names.add(cmd.name)
+        for sub in group.subgroups:
+            check_group(sub)
+
+    if isinstance(spec, SingleCommandSpec):
+        check_command(spec.command)
+    else:
+        check_group(spec)
 
 
 def assert_handler_satisfies(
@@ -91,10 +122,15 @@ def assert_handler_satisfies(
 ) -> None:
     """Validate that *handler* implements all methods required by *spec*.
 
-    Delegates to ``validate_interface_handler`` which raises
-    ``InterfaceValidationError`` with all violations listed.
+    Delegates to ``validate_interface_handler`` and re-raises its
+    ``InterfaceValidationError`` as an ``AssertionError`` so all three
+    ``assert_*`` helpers fail with the same exception type — plugin authors
+    can write ``pytest.raises(AssertionError)`` uniformly across them.
     """
-    validate_interface_handler(spec, handler)
+    try:
+        validate_interface_handler(spec, handler)
+    except InterfaceValidationError as e:
+        raise AssertionError(str(e)) from e
 
 
 def assert_builds_valid_spec(
@@ -104,9 +140,16 @@ def assert_builds_valid_spec(
     """Full integration check: spec + handler produce a valid ``CommandSpec``.
 
     Builds the ``CommandSpec`` (with validation) and verifies that the
-    resulting Click command tree was created successfully.
+    resulting Click command tree was created successfully. Any build or
+    validation failure (``InterfaceValidationError`` for a missing handler
+    method, ``ValueError`` for a malformed spec) is re-raised as an
+    ``AssertionError`` so this helper fails with the same exception type as
+    its siblings.
     """
-    result = build_command_spec(spec, handler, validate=True)
+    try:
+        result = build_command_spec(spec, handler, validate=True)
+    except (InterfaceValidationError, ValueError) as e:
+        raise AssertionError(str(e)) from e
     assert (
         result.command is not None
     ), "build_command_spec produced a None Click command"

--- a/src/snowflake/cli/api/plugins/command/testing.py
+++ b/src/snowflake/cli/api/plugins/command/testing.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test utilities for plugin authors.
+
+These helpers validate interface specs and handler implementations without
+requiring a Snowflake connection.  Use them in unit tests to catch contract
+mismatches early::
+
+    from snowflake.cli.api.plugins.command.testing import (
+        assert_interface_well_formed,
+        assert_handler_satisfies,
+        assert_builds_valid_spec,
+    )
+
+    def test_my_interface():
+        assert_interface_well_formed(MY_SPEC)
+
+    def test_my_handler():
+        assert_handler_satisfies(MY_SPEC, MyHandlerImpl())
+
+    def test_full_build():
+        assert_builds_valid_spec(MY_SPEC, MyHandlerImpl())
+"""
+
+from __future__ import annotations
+
+from snowflake.cli.api.plugins.command.bridge import (
+    _collect_commands,
+    build_command_spec,
+    validate_interface_handler,
+)
+from snowflake.cli.api.plugins.command.interface import (
+    CommandGroupSpec,
+    CommandHandler,
+    SingleCommandSpec,
+)
+
+
+def assert_interface_well_formed(
+    spec: CommandGroupSpec | SingleCommandSpec,
+) -> None:
+    """Validate the spec dataclass tree is complete and consistent.
+
+    Checks:
+    - Every command has a non-empty name, help text, and handler_method.
+    - No duplicate handler_method values across the entire tree.
+    - handler_method values are valid Python identifiers.
+
+    Raises ``AssertionError`` on the first violation found.
+    """
+    commands = _collect_commands(spec)
+    seen_methods: set[str] = set()
+
+    for cmd in commands:
+        assert cmd.name, "Command has empty name"
+        assert cmd.help, f"Command '{cmd.name}' has empty help text"
+        assert cmd.handler_method, f"Command '{cmd.name}' has empty handler_method"
+        assert cmd.handler_method.isidentifier(), (
+            f"Command '{cmd.name}': handler_method '{cmd.handler_method}' "
+            f"is not a valid Python identifier"
+        )
+        assert cmd.handler_method not in seen_methods, (
+            f"Duplicate handler_method '{cmd.handler_method}' "
+            f"(used by command '{cmd.name}')"
+        )
+        seen_methods.add(cmd.handler_method)
+
+        for param in cmd.params:
+            assert param.name, f"Command '{cmd.name}' has a param with empty name"
+            assert param.name.isidentifier(), (
+                f"Command '{cmd.name}': param name '{param.name}' "
+                f"is not a valid Python identifier"
+            )
+
+
+def assert_handler_satisfies(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+) -> None:
+    """Validate that *handler* implements all methods required by *spec*.
+
+    Delegates to ``validate_interface_handler`` which raises
+    ``InterfaceValidationError`` with all violations listed.
+    """
+    validate_interface_handler(spec, handler)
+
+
+def assert_builds_valid_spec(
+    spec: CommandGroupSpec | SingleCommandSpec,
+    handler: CommandHandler,
+) -> None:
+    """Full integration check: spec + handler produce a valid ``CommandSpec``.
+
+    Builds the ``CommandSpec`` (with validation) and verifies that the
+    resulting Click command tree was created successfully.
+    """
+    result = build_command_spec(spec, handler, validate=True)
+    assert (
+        result.command is not None
+    ), "build_command_spec produced a None Click command"

--- a/src/snowflake/cli/api/plugins/command/testing.py
+++ b/src/snowflake/cli/api/plugins/command/testing.py
@@ -59,8 +59,10 @@ def assert_interface_well_formed(
     - Every command has a non-empty name, help text, and handler_method.
     - handler_method values are valid Python identifiers and unique across the
       entire tree (each maps to one method on a single handler instance).
-    - Command (CLI) names are unique *within their group* — sibling commands
-      may not collide, but two different subgroups may reuse a name.
+    - CLI names are unique *within their group*: a leaf command and a subgroup
+      share one Click namespace, so no two siblings — command/command,
+      subgroup/subgroup, or command/subgroup — may reuse a name. Different
+      groups may still reuse the same name.
     - Param names are valid Python identifiers.
     - No boolean flag (``is_flag=True``) is left required (``default=REQUIRED``);
       a required flag is meaningless. Mirrors the build-time guard in the bridge.
@@ -98,8 +100,12 @@ def assert_interface_well_formed(
             )
 
     def check_group(group: CommandGroupSpec) -> None:
-        # Command names need only be unique among siblings — two different
-        # subgroups may legitimately expose the same command name.
+        # A leaf command and a subgroup occupy one shared CLI namespace: Typer
+        # registers both onto the same Click group, whose ``commands`` dict is
+        # keyed by name, so any reused name — command/command, subgroup/subgroup,
+        # or command/subgroup — silently shadows the earlier entry. Enforce
+        # uniqueness across the union. Names are scoped to this group only, so a
+        # different group may legitimately reuse them.
         seen_names: set[str] = set()
         for cmd in group.commands:
             check_command(cmd)
@@ -108,6 +114,10 @@ def assert_interface_well_formed(
             ), f"Duplicate command name '{cmd.name}' in group '{group.name}'"
             seen_names.add(cmd.name)
         for sub in group.subgroups:
+            assert (
+                sub.name not in seen_names
+            ), f"Duplicate name '{sub.name}' in group '{group.name}'"
+            seen_names.add(sub.name)
             check_group(sub)
 
     if isinstance(spec, SingleCommandSpec):

--- a/tests/api/plugins/command/test_bridge.py
+++ b/tests/api/plugins/command/test_bridge.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the interface-to-CommandSpec bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+from snowflake.cli.api.plugins.command import (
+    CommandPath,
+    CommandType,
+)
+from snowflake.cli.api.plugins.command.bridge import (
+    InterfaceValidationError,
+    _collect_commands,
+    build_command_spec,
+    validate_interface_handler,
+)
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    REQUIRED,
+    SingleCommandSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal spec + handler for testing
+# ---------------------------------------------------------------------------
+
+
+def _simple_spec():
+    return CommandGroupSpec(
+        name="test-plugin",
+        help="A test plugin.",
+        parent_path=(),
+        commands=(
+            CommandDef(
+                name="greet",
+                help="Say hello.",
+                handler_method="greet",
+                params=(
+                    ParamDef(
+                        name="name",
+                        type=str,
+                        kind=ParamKind.ARGUMENT,
+                        help="Name to greet",
+                    ),
+                ),
+            ),
+            CommandDef(
+                name="count",
+                help="Count things.",
+                handler_method="count",
+                params=(
+                    ParamDef(
+                        name="n",
+                        type=int,
+                        kind=ParamKind.OPTION,
+                        cli_names=("--number", "-n"),
+                        help="How many",
+                        default=5,
+                        required=False,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class _SimpleHandler(CommandHandler):
+    def greet(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello, {name}!")
+
+    def count(self, n: int = 5) -> CommandResult:
+        return MessageResult(f"Counted {n}.")
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_handler_passes(self):
+        validate_interface_handler(_simple_spec(), _SimpleHandler())
+
+    def test_missing_method_raises(self):
+        class Incomplete(CommandHandler):
+            def greet(self, name: str) -> CommandResult:
+                return MessageResult(name)
+
+        with pytest.raises(InterfaceValidationError) as exc_info:
+            validate_interface_handler(_simple_spec(), Incomplete())
+        assert "count" in str(exc_info.value)
+
+    def test_non_callable_raises(self):
+        class BadHandler(CommandHandler):
+            greet = "not a method"
+
+            def count(self, n: int = 5) -> CommandResult:
+                return MessageResult(str(n))
+
+        with pytest.raises(InterfaceValidationError) as exc_info:
+            validate_interface_handler(_simple_spec(), BadHandler())
+        assert "not callable" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _collect_commands tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCommands:
+    def test_flat_group(self):
+        spec = _simple_spec()
+        cmds = _collect_commands(spec)
+        assert [c.name for c in cmds] == ["greet", "count"]
+
+    def test_nested_subgroups(self):
+        inner = CommandGroupSpec(
+            name="sub",
+            help="Sub.",
+            commands=(
+                CommandDef(name="inner-cmd", help="Inner.", handler_method="inner_cmd"),
+            ),
+        )
+        outer = CommandGroupSpec(
+            name="outer",
+            help="Outer.",
+            commands=(
+                CommandDef(name="outer-cmd", help="Outer.", handler_method="outer_cmd"),
+            ),
+            subgroups=(inner,),
+        )
+        cmds = _collect_commands(outer)
+        assert {c.name for c in cmds} == {"outer-cmd", "inner-cmd"}
+
+    def test_single_command_spec(self):
+        cmd = CommandDef(name="solo", help="Solo.", handler_method="solo")
+        spec = SingleCommandSpec(parent_path=("parent",), command=cmd)
+        cmds = _collect_commands(spec)
+        assert len(cmds) == 1
+        assert cmds[0].name == "solo"
+
+
+# ---------------------------------------------------------------------------
+# build_command_spec tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommandSpec:
+    def test_command_group_type(self):
+        result = build_command_spec(_simple_spec(), _SimpleHandler())
+        assert result.command_type == CommandType.COMMAND_GROUP
+
+    def test_parent_path(self):
+        spec = CommandGroupSpec(
+            name="nested",
+            help="Nested.",
+            parent_path=("snowpark",),
+            commands=(
+                CommandDef(name="hello", help="Hello.", handler_method="hello"),
+            ),
+        )
+
+        class Handler(CommandHandler):
+            def hello(self) -> CommandResult:
+                return MessageResult("hi")
+
+        result = build_command_spec(spec, Handler())
+        assert result.parent_command_path == CommandPath(["snowpark"])
+
+    def test_single_command_type(self):
+        cmd = CommandDef(name="solo", help="Solo.", handler_method="solo")
+        spec = SingleCommandSpec(parent_path=(), command=cmd)
+
+        class Handler(CommandHandler):
+            def solo(self) -> CommandResult:
+                return MessageResult("done")
+
+        result = build_command_spec(spec, Handler())
+        assert result.command_type == CommandType.SINGLE_COMMAND
+
+    def test_produces_click_command(self):
+        result = build_command_spec(_simple_spec(), _SimpleHandler())
+        click_cmd = result.command
+        assert click_cmd is not None
+        assert click_cmd.name == "test-plugin"
+
+    def test_skip_validation(self):
+        class Incomplete(CommandHandler):
+            def greet(self, name: str) -> CommandResult:
+                return MessageResult(name)
+
+            def count(self, n: int = 5) -> CommandResult:
+                return MessageResult(str(n))
+
+        # With validate=False, validation is skipped (useful for production perf).
+        # We still need handler methods for building, but no validation error is raised.
+        result = build_command_spec(
+            _simple_spec(), Incomplete(), validate=False
+        )
+        assert result.command is not None
+
+    def test_flag_param(self):
+        spec = CommandGroupSpec(
+            name="flags",
+            help="Flags test.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    params=(
+                        ParamDef(
+                            name="dry_run",
+                            type=bool,
+                            kind=ParamKind.OPTION,
+                            cli_names=("--dry-run",),
+                            is_flag=True,
+                            default=False,
+                            required=False,
+                            help="Dry run mode",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        class Handler(CommandHandler):
+            def run(self, dry_run: bool = False) -> CommandResult:
+                return MessageResult(f"dry_run={dry_run}")
+
+        result = build_command_spec(spec, Handler())
+        assert result.command is not None
+
+    def test_unknown_decorator_raises(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    decorators=("nonexistent_decorator",),
+                ),
+            ),
+        )
+
+        class Handler(CommandHandler):
+            def run(self) -> CommandResult:
+                return MessageResult("ok")
+
+        with pytest.raises(ValueError, match="Unknown decorator"):
+            build_command_spec(spec, Handler())

--- a/tests/api/plugins/command/test_bridge.py
+++ b/tests/api/plugins/command/test_bridge.py
@@ -26,6 +26,7 @@ from snowflake.cli.api.plugins.command.bridge import (
     InterfaceValidationError,
     _collect_commands,
     build_command_spec,
+    register_decorator,
     validate_interface_handler,
 )
 from snowflake.cli.api.plugins.command.interface import (
@@ -242,6 +243,39 @@ class TestBuildCommandSpec:
         result = build_command_spec(spec, Handler())
         assert result.command is not None
 
+    def test_required_flag_raises(self):
+        # A boolean flag with no default (default=REQUIRED) is nonsensical and
+        # must raise rather than being silently coerced to False.
+        spec = CommandGroupSpec(
+            name="flags",
+            help="Flags test.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    params=(
+                        ParamDef(
+                            name="force",
+                            type=bool,
+                            kind=ParamKind.OPTION,
+                            cli_names=("--force",),
+                            is_flag=True,
+                            # default omitted => REQUIRED
+                            help="Force it",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        class Handler(CommandHandler):
+            def run(self, force: bool = False) -> CommandResult:
+                return MessageResult(f"force={force}")
+
+        with pytest.raises(ValueError, match="required flag is meaningless"):
+            build_command_spec(spec, Handler())
+
     def test_unknown_decorator_raises(self):
         spec = CommandGroupSpec(
             name="bad",
@@ -262,3 +296,57 @@ class TestBuildCommandSpec:
 
         with pytest.raises(ValueError, match="Unknown decorator"):
             build_command_spec(spec, Handler())
+
+
+# ---------------------------------------------------------------------------
+# Decorator application order
+# ---------------------------------------------------------------------------
+
+
+class TestDecoratorOrder:
+    def test_decorators_applied_outermost_first(self):
+        """``decorators=("outer", "inner")`` must produce ``outer(inner(fn))``."""
+        from snowflake.cli.api.plugins.command.bridge import _DECORATOR_REGISTRY
+
+        applied: list[str] = []
+
+        def make_recorder(tag: str):
+            def factory():
+                def decorator(fn):
+                    # Records when this decorator is *applied* to the function.
+                    applied.append(tag)
+                    return fn
+
+                return decorator
+
+            return factory
+
+        register_decorator("rec_outer", make_recorder("outer"))
+        register_decorator("rec_inner", make_recorder("inner"))
+        try:
+            spec = CommandGroupSpec(
+                name="deco",
+                help="Deco.",
+                commands=(
+                    CommandDef(
+                        name="run",
+                        help="Run.",
+                        handler_method="run",
+                        decorators=("rec_outer", "rec_inner"),
+                    ),
+                ),
+            )
+
+            class Handler(CommandHandler):
+                def run(self) -> CommandResult:
+                    return MessageResult("ok")
+
+            build_command_spec(spec, Handler())
+        finally:
+            _DECORATOR_REGISTRY.pop("rec_outer", None)
+            _DECORATOR_REGISTRY.pop("rec_inner", None)
+
+        # _register_command iterates reversed(decorators), so the innermost one
+        # ("rec_inner") wraps the raw function first and "rec_outer" wraps that:
+        # the resulting structure is outer(inner(fn)).
+        assert applied == ["inner", "outer"]

--- a/tests/api/plugins/command/test_bridge.py
+++ b/tests/api/plugins/command/test_bridge.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the interface-to-CommandSpec bridge."""
+
+from __future__ import annotations
+
+import pytest
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+from snowflake.cli.api.plugins.command import (
+    CommandPath,
+    CommandType,
+)
+from snowflake.cli.api.plugins.command.bridge import (
+    InterfaceValidationError,
+    _collect_commands,
+    build_command_spec,
+    validate_interface_handler,
+)
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    SingleCommandSpec,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal spec + handler for testing
+# ---------------------------------------------------------------------------
+
+
+def _simple_spec():
+    return CommandGroupSpec(
+        name="test-plugin",
+        help="A test plugin.",
+        parent_path=(),
+        commands=(
+            CommandDef(
+                name="greet",
+                help="Say hello.",
+                handler_method="greet",
+                params=(
+                    ParamDef(
+                        name="name",
+                        type=str,
+                        kind=ParamKind.ARGUMENT,
+                        help="Name to greet",
+                    ),
+                ),
+            ),
+            CommandDef(
+                name="count",
+                help="Count things.",
+                handler_method="count",
+                params=(
+                    ParamDef(
+                        name="n",
+                        type=int,
+                        kind=ParamKind.OPTION,
+                        cli_names=("--number", "-n"),
+                        help="How many",
+                        default=5,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class _SimpleHandler(CommandHandler):
+    def greet(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello, {name}!")
+
+    def count(self, n: int = 5) -> CommandResult:
+        return MessageResult(f"Counted {n}.")
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_handler_passes(self):
+        validate_interface_handler(_simple_spec(), _SimpleHandler())
+
+    def test_missing_method_raises(self):
+        class Incomplete(CommandHandler):
+            def greet(self, name: str) -> CommandResult:
+                return MessageResult(name)
+
+        with pytest.raises(InterfaceValidationError) as exc_info:
+            validate_interface_handler(_simple_spec(), Incomplete())
+        assert "count" in str(exc_info.value)
+
+    def test_non_callable_raises(self):
+        class BadHandler(CommandHandler):
+            greet = "not a method"
+
+            def count(self, n: int = 5) -> CommandResult:
+                return MessageResult(str(n))
+
+        with pytest.raises(InterfaceValidationError) as exc_info:
+            validate_interface_handler(_simple_spec(), BadHandler())
+        assert "not callable" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _collect_commands tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCommands:
+    def test_flat_group(self):
+        spec = _simple_spec()
+        cmds = _collect_commands(spec)
+        assert [c.name for c in cmds] == ["greet", "count"]
+
+    def test_nested_subgroups(self):
+        inner = CommandGroupSpec(
+            name="sub",
+            help="Sub.",
+            commands=(
+                CommandDef(name="inner-cmd", help="Inner.", handler_method="inner_cmd"),
+            ),
+        )
+        outer = CommandGroupSpec(
+            name="outer",
+            help="Outer.",
+            commands=(
+                CommandDef(name="outer-cmd", help="Outer.", handler_method="outer_cmd"),
+            ),
+            subgroups=(inner,),
+        )
+        cmds = _collect_commands(outer)
+        assert {c.name for c in cmds} == {"outer-cmd", "inner-cmd"}
+
+    def test_single_command_spec(self):
+        cmd = CommandDef(name="solo", help="Solo.", handler_method="solo")
+        spec = SingleCommandSpec(parent_path=("parent",), command=cmd)
+        cmds = _collect_commands(spec)
+        assert len(cmds) == 1
+        assert cmds[0].name == "solo"
+
+
+# ---------------------------------------------------------------------------
+# build_command_spec tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommandSpec:
+    def test_command_group_type(self):
+        result = build_command_spec(_simple_spec(), _SimpleHandler())
+        assert result.command_type == CommandType.COMMAND_GROUP
+
+    def test_parent_path(self):
+        spec = CommandGroupSpec(
+            name="nested",
+            help="Nested.",
+            parent_path=("snowpark",),
+            commands=(CommandDef(name="hello", help="Hello.", handler_method="hello"),),
+        )
+
+        class Handler(CommandHandler):
+            def hello(self) -> CommandResult:
+                return MessageResult("hi")
+
+        result = build_command_spec(spec, Handler())
+        assert result.parent_command_path == CommandPath(["snowpark"])
+
+    def test_single_command_type(self):
+        cmd = CommandDef(name="solo", help="Solo.", handler_method="solo")
+        spec = SingleCommandSpec(parent_path=(), command=cmd)
+
+        class Handler(CommandHandler):
+            def solo(self) -> CommandResult:
+                return MessageResult("done")
+
+        result = build_command_spec(spec, Handler())
+        assert result.command_type == CommandType.SINGLE_COMMAND
+
+    def test_produces_click_command(self):
+        result = build_command_spec(_simple_spec(), _SimpleHandler())
+        click_cmd = result.command
+        assert click_cmd is not None
+        assert click_cmd.name == "test-plugin"
+
+    def test_skip_validation(self):
+        class Incomplete(CommandHandler):
+            def greet(self, name: str) -> CommandResult:
+                return MessageResult(name)
+
+            def count(self, n: int = 5) -> CommandResult:
+                return MessageResult(str(n))
+
+        # With validate=False, validation is skipped (useful for production perf).
+        # We still need handler methods for building, but no validation error is raised.
+        result = build_command_spec(_simple_spec(), Incomplete(), validate=False)
+        assert result.command is not None
+
+    def test_flag_param(self):
+        spec = CommandGroupSpec(
+            name="flags",
+            help="Flags test.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    params=(
+                        ParamDef(
+                            name="dry_run",
+                            type=bool,
+                            kind=ParamKind.OPTION,
+                            cli_names=("--dry-run",),
+                            is_flag=True,
+                            default=False,
+                            help="Dry run mode",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        class Handler(CommandHandler):
+            def run(self, dry_run: bool = False) -> CommandResult:
+                return MessageResult(f"dry_run={dry_run}")
+
+        result = build_command_spec(spec, Handler())
+        assert result.command is not None
+
+    def test_unknown_decorator_raises(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    decorators=("nonexistent_decorator",),
+                ),
+            ),
+        )
+
+        class Handler(CommandHandler):
+            def run(self) -> CommandResult:
+                return MessageResult("ok")
+
+        with pytest.raises(ValueError, match="Unknown decorator"):
+            build_command_spec(spec, Handler())

--- a/tests/api/plugins/command/test_interface.py
+++ b/tests/api/plugins/command/test_interface.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for plugin interface dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    REQUIRED,
+    SingleCommandSpec,
+)
+
+
+class TestParamDef:
+    def test_required_argument(self):
+        p = ParamDef(name="name", type=str, kind=ParamKind.ARGUMENT, help="A name")
+        assert p.name == "name"
+        assert p.type is str
+        assert p.kind == ParamKind.ARGUMENT
+        assert p.required is True
+        assert p.default is REQUIRED
+
+    def test_optional_option_with_default(self):
+        p = ParamDef(
+            name="count",
+            type=int,
+            kind=ParamKind.OPTION,
+            help="Count",
+            default=10,
+            required=False,
+        )
+        assert p.default == 10
+        assert p.required is False
+
+    def test_flag_option(self):
+        p = ParamDef(
+            name="replace",
+            type=bool,
+            kind=ParamKind.OPTION,
+            is_flag=True,
+            default=False,
+            required=False,
+        )
+        assert p.is_flag is True
+        assert p.default is False
+
+    def test_frozen(self):
+        p = ParamDef(name="x", type=str, kind=ParamKind.ARGUMENT)
+        with pytest.raises(AttributeError):
+            p.name = "y"
+
+
+class TestCommandDef:
+    def test_minimal(self):
+        cmd = CommandDef(name="run", help="Run it.", handler_method="run")
+        assert cmd.name == "run"
+        assert cmd.params == ()
+        assert cmd.requires_connection is False
+        assert cmd.decorators == ()
+
+    def test_with_params_and_decorators(self):
+        cmd = CommandDef(
+            name="deploy",
+            help="Deploy.",
+            handler_method="deploy",
+            requires_connection=True,
+            decorators=("with_project_definition",),
+            params=(
+                ParamDef(name="target", type=str, kind=ParamKind.ARGUMENT, help="T"),
+            ),
+        )
+        assert len(cmd.params) == 1
+        assert cmd.decorators == ("with_project_definition",)
+
+    def test_frozen(self):
+        cmd = CommandDef(name="x", help="h", handler_method="x")
+        with pytest.raises(AttributeError):
+            cmd.name = "y"
+
+
+class TestCommandGroupSpec:
+    def test_basic_group(self):
+        spec = CommandGroupSpec(
+            name="notebook",
+            help="Notebooks.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="run"),
+                CommandDef(name="stop", help="Stop.", handler_method="stop"),
+            ),
+        )
+        assert spec.name == "notebook"
+        assert len(spec.commands) == 2
+        assert spec.parent_path == ()
+        assert spec.subgroups == ()
+
+    def test_nested_subgroups(self):
+        inner = CommandGroupSpec(
+            name="pool",
+            help="Pool cmds.",
+            commands=(
+                CommandDef(name="create", help="Create.", handler_method="pool_create"),
+            ),
+        )
+        outer = CommandGroupSpec(
+            name="spcs",
+            help="SPCS.",
+            subgroups=(inner,),
+        )
+        assert len(outer.subgroups) == 1
+        assert outer.subgroups[0].name == "pool"
+
+    def test_frozen(self):
+        spec = CommandGroupSpec(name="x", help="h")
+        with pytest.raises(AttributeError):
+            spec.name = "y"
+
+
+class TestSingleCommandSpec:
+    def test_basic(self):
+        cmd = CommandDef(name="sql", help="Execute SQL.", handler_method="execute_sql")
+        spec = SingleCommandSpec(parent_path=(), command=cmd)
+        assert spec.command.name == "sql"
+
+
+class TestCommandHandler:
+    def test_is_abstract(self):
+        # Cannot instantiate directly if subclass has abstract methods
+        assert issubclass(CommandHandler, CommandHandler)
+
+
+class TestRequiredSentinel:
+    def test_is_singleton(self):
+        from snowflake.cli.api.plugins.command.interface import _RequiredSentinel
+
+        assert _RequiredSentinel() is _RequiredSentinel()
+
+    def test_repr(self):
+        assert repr(REQUIRED) == "REQUIRED"
+
+    def test_falsy(self):
+        assert not REQUIRED

--- a/tests/api/plugins/command/test_interface.py
+++ b/tests/api/plugins/command/test_interface.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for plugin interface dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+from snowflake.cli.api.plugins.command.interface import (
+    REQUIRED,
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    SingleCommandSpec,
+)
+
+
+class TestParamDef:
+    def test_required_argument(self):
+        p = ParamDef(name="name", type=str, kind=ParamKind.ARGUMENT, help="A name")
+        assert p.name == "name"
+        assert p.type is str
+        assert p.kind == ParamKind.ARGUMENT
+        assert p.default is REQUIRED
+
+    def test_optional_option_with_default(self):
+        p = ParamDef(
+            name="count",
+            type=int,
+            kind=ParamKind.OPTION,
+            help="Count",
+            default=10,
+        )
+        assert p.default == 10
+        assert p.default is not REQUIRED
+
+    def test_flag_option(self):
+        p = ParamDef(
+            name="replace",
+            type=bool,
+            kind=ParamKind.OPTION,
+            is_flag=True,
+            default=False,
+        )
+        assert p.is_flag is True
+        assert p.default is False
+
+    def test_frozen(self):
+        p = ParamDef(name="x", type=str, kind=ParamKind.ARGUMENT)
+        with pytest.raises(AttributeError):
+            p.name = "y"
+
+
+class TestCommandDef:
+    def test_minimal(self):
+        cmd = CommandDef(name="run", help="Run it.", handler_method="run")
+        assert cmd.name == "run"
+        assert cmd.params == ()
+        assert cmd.requires_connection is False
+        assert cmd.decorators == ()
+
+    def test_with_params_and_decorators(self):
+        cmd = CommandDef(
+            name="deploy",
+            help="Deploy.",
+            handler_method="deploy",
+            requires_connection=True,
+            decorators=("with_project_definition",),
+            params=(
+                ParamDef(name="target", type=str, kind=ParamKind.ARGUMENT, help="T"),
+            ),
+        )
+        assert len(cmd.params) == 1
+        assert cmd.decorators == ("with_project_definition",)
+
+    def test_frozen(self):
+        cmd = CommandDef(name="x", help="h", handler_method="x")
+        with pytest.raises(AttributeError):
+            cmd.name = "y"
+
+
+class TestCommandGroupSpec:
+    def test_basic_group(self):
+        spec = CommandGroupSpec(
+            name="notebook",
+            help="Notebooks.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="run"),
+                CommandDef(name="stop", help="Stop.", handler_method="stop"),
+            ),
+        )
+        assert spec.name == "notebook"
+        assert len(spec.commands) == 2
+        assert spec.parent_path == ()
+        assert spec.subgroups == ()
+
+    def test_nested_subgroups(self):
+        inner = CommandGroupSpec(
+            name="pool",
+            help="Pool cmds.",
+            commands=(
+                CommandDef(name="create", help="Create.", handler_method="pool_create"),
+            ),
+        )
+        outer = CommandGroupSpec(
+            name="spcs",
+            help="SPCS.",
+            subgroups=(inner,),
+        )
+        assert len(outer.subgroups) == 1
+        assert outer.subgroups[0].name == "pool"
+
+    def test_frozen(self):
+        spec = CommandGroupSpec(name="x", help="h")
+        with pytest.raises(AttributeError):
+            spec.name = "y"
+
+
+class TestSingleCommandSpec:
+    def test_basic(self):
+        cmd = CommandDef(name="sql", help="Execute SQL.", handler_method="execute_sql")
+        spec = SingleCommandSpec(parent_path=(), command=cmd)
+        assert spec.command.name == "sql"
+
+
+class TestCommandHandler:
+    def test_is_abstract(self):
+        # Cannot instantiate directly if subclass has abstract methods
+        assert issubclass(CommandHandler, CommandHandler)
+
+
+class TestRequiredSentinel:
+    def test_is_singleton(self):
+        from snowflake.cli.api.plugins.command.interface import _RequiredSentinel
+
+        assert _RequiredSentinel() is _RequiredSentinel()
+
+    def test_repr(self):
+        assert repr(REQUIRED) == "REQUIRED"
+
+    def test_falsy(self):
+        assert not REQUIRED

--- a/tests/api/plugins/command/test_interface.py
+++ b/tests/api/plugins/command/test_interface.py
@@ -137,9 +137,21 @@ class TestSingleCommandSpec:
 
 
 class TestCommandHandler:
-    def test_is_abstract(self):
-        # Cannot instantiate directly if subclass has abstract methods
-        assert issubclass(CommandHandler, CommandHandler)
+    def test_is_marker_base_with_no_abstract_methods(self):
+        # CommandHandler is a *marker* base: it declares no @abstractmethod
+        # members, so Python's ABC machinery enforces nothing. The real
+        # contract (every declared handler_method exists and is callable) is
+        # enforced by the bridge's validate_interface_handler, not by ABC.
+        assert CommandHandler.__abstractmethods__ == frozenset()
+
+    def test_subclass_is_instantiable(self):
+        # Because there are no abstract methods, even an empty subclass can be
+        # instantiated freely — ABC does not block it. This documents that
+        # enforcement is deferred to the bridge rather than the type system.
+        class Empty(CommandHandler):
+            pass
+
+        assert isinstance(Empty(), CommandHandler)
 
 
 class TestRequiredSentinel:

--- a/tests/api/plugins/command/test_testing.py
+++ b/tests/api/plugins/command/test_testing.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for plugin testing utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+from snowflake.cli.api.plugins.command.bridge import InterfaceValidationError
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+)
+from snowflake.cli.api.plugins.command.testing import (
+    assert_builds_valid_spec,
+    assert_handler_satisfies,
+    assert_interface_well_formed,
+)
+
+
+def _valid_spec():
+    return CommandGroupSpec(
+        name="example",
+        help="Example plugin.",
+        commands=(
+            CommandDef(
+                name="hello",
+                help="Say hello.",
+                handler_method="hello",
+                params=(
+                    ParamDef(name="name", type=str, kind=ParamKind.ARGUMENT, help="Name"),
+                ),
+            ),
+        ),
+    )
+
+
+class _ValidHandler(CommandHandler):
+    def hello(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello {name}")
+
+
+class TestAssertInterfaceWellFormed:
+    def test_valid_spec_passes(self):
+        assert_interface_well_formed(_valid_spec())
+
+    def test_empty_command_name_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="", help="No name.", handler_method="run"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="empty name"):
+            assert_interface_well_formed(spec)
+
+    def test_empty_help_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="", handler_method="run"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="empty help"):
+            assert_interface_well_formed(spec)
+
+    def test_empty_handler_method_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method=""),
+            ),
+        )
+        with pytest.raises(AssertionError, match="empty handler_method"):
+            assert_interface_well_formed(spec)
+
+    def test_invalid_identifier_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="not-valid-python"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="not a valid Python identifier"):
+            assert_interface_well_formed(spec)
+
+    def test_duplicate_handler_method_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="run"),
+                CommandDef(name="also-run", help="Also run.", handler_method="run"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="Duplicate"):
+            assert_interface_well_formed(spec)
+
+    def test_invalid_param_name_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    params=(
+                        ParamDef(
+                            name="not-valid",
+                            type=str,
+                            kind=ParamKind.ARGUMENT,
+                            help="Bad param name",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(AssertionError, match="not a valid Python identifier"):
+            assert_interface_well_formed(spec)
+
+
+class TestAssertHandlerSatisfies:
+    def test_valid_handler_passes(self):
+        assert_handler_satisfies(_valid_spec(), _ValidHandler())
+
+    def test_incomplete_handler_fails(self):
+        class Empty(CommandHandler):
+            pass
+
+        with pytest.raises(InterfaceValidationError):
+            assert_handler_satisfies(_valid_spec(), Empty())
+
+
+class TestAssertBuildsValidSpec:
+    def test_valid_pair_passes(self):
+        assert_builds_valid_spec(_valid_spec(), _ValidHandler())

--- a/tests/api/plugins/command/test_testing.py
+++ b/tests/api/plugins/command/test_testing.py
@@ -147,6 +147,52 @@ class TestAssertInterfaceWellFormed:
         )
         assert_interface_well_formed(spec)  # must not raise
 
+    def test_duplicate_subgroup_name_in_group_fails(self):
+        # Sibling subgroups share the parent's CLI namespace, so two subgroups
+        # with the same name would silently shadow one another in Typer/Click —
+        # the same class of bug as duplicate command names.
+        spec = CommandGroupSpec(
+            name="root",
+            help="Root.",
+            subgroups=(
+                CommandGroupSpec(
+                    name="dup",
+                    help="First.",
+                    commands=(CommandDef(name="a", help="A.", handler_method="a"),),
+                ),
+                CommandGroupSpec(
+                    name="dup",
+                    help="Second.",
+                    commands=(CommandDef(name="b", help="B.", handler_method="b"),),
+                ),
+            ),
+        )
+        with pytest.raises(AssertionError, match="Duplicate name 'dup'"):
+            assert_interface_well_formed(spec)
+
+    def test_command_and_subgroup_name_collision_fails(self):
+        # A leaf command and a subgroup occupy one namespace within their parent
+        # group, so reusing a name across the two collides just like two
+        # same-named commands would.
+        spec = CommandGroupSpec(
+            name="root",
+            help="Root.",
+            commands=(
+                CommandDef(name="overlap", help="Cmd.", handler_method="overlap"),
+            ),
+            subgroups=(
+                CommandGroupSpec(
+                    name="overlap",
+                    help="Group.",
+                    commands=(
+                        CommandDef(name="inner", help="Inner.", handler_method="inner"),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(AssertionError, match="Duplicate name 'overlap'"):
+            assert_interface_well_formed(spec)
+
     def test_required_boolean_flag_fails(self):
         spec = CommandGroupSpec(
             name="bad",

--- a/tests/api/plugins/command/test_testing.py
+++ b/tests/api/plugins/command/test_testing.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import pytest
 from snowflake.cli.api.output.types import CommandResult, MessageResult
-from snowflake.cli.api.plugins.command.bridge import InterfaceValidationError
 from snowflake.cli.api.plugins.command.interface import (
     CommandDef,
     CommandGroupSpec,
@@ -111,6 +110,68 @@ class TestAssertInterfaceWellFormed:
         with pytest.raises(AssertionError, match="Duplicate"):
             assert_interface_well_formed(spec)
 
+    def test_duplicate_command_name_in_group_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="run_one"),
+                CommandDef(name="run", help="Run again.", handler_method="run_two"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="Duplicate command name 'run'"):
+            assert_interface_well_formed(spec)
+
+    def test_same_command_name_across_subgroups_ok(self):
+        # The same CLI command name may be reused in different subgroups; the
+        # uniqueness check is per-group, not global.
+        spec = CommandGroupSpec(
+            name="root",
+            help="Root.",
+            subgroups=(
+                CommandGroupSpec(
+                    name="a",
+                    help="Group A.",
+                    commands=(
+                        CommandDef(name="list", help="List.", handler_method="a_list"),
+                    ),
+                ),
+                CommandGroupSpec(
+                    name="b",
+                    help="Group B.",
+                    commands=(
+                        CommandDef(name="list", help="List.", handler_method="b_list"),
+                    ),
+                ),
+            ),
+        )
+        assert_interface_well_formed(spec)  # must not raise
+
+    def test_required_boolean_flag_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    params=(
+                        ParamDef(
+                            name="force",
+                            type=bool,
+                            kind=ParamKind.OPTION,
+                            is_flag=True,
+                            # default omitted => REQUIRED
+                            help="Force it",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(AssertionError, match="boolean flag"):
+            assert_interface_well_formed(spec)
+
     def test_invalid_param_name_fails(self):
         spec = CommandGroupSpec(
             name="bad",
@@ -143,10 +204,21 @@ class TestAssertHandlerSatisfies:
         class Empty(CommandHandler):
             pass
 
-        with pytest.raises(InterfaceValidationError):
+        # assert_handler_satisfies wraps the underlying InterfaceValidationError
+        # as AssertionError so all three assert_* helpers share one failure type.
+        with pytest.raises(AssertionError, match="hello"):
             assert_handler_satisfies(_valid_spec(), Empty())
 
 
 class TestAssertBuildsValidSpec:
     def test_valid_pair_passes(self):
         assert_builds_valid_spec(_valid_spec(), _ValidHandler())
+
+    def test_invalid_pair_fails(self):
+        # A handler missing a declared method must fail the full build path,
+        # exercising the validate=True branch inside assert_builds_valid_spec.
+        class Empty(CommandHandler):
+            pass
+
+        with pytest.raises(AssertionError, match="hello"):
+            assert_builds_valid_spec(_valid_spec(), Empty())

--- a/tests/api/plugins/command/test_testing.py
+++ b/tests/api/plugins/command/test_testing.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for plugin testing utilities."""
+
+from __future__ import annotations
+
+import pytest
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+from snowflake.cli.api.plugins.command.bridge import InterfaceValidationError
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+    CommandGroupSpec,
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+)
+from snowflake.cli.api.plugins.command.testing import (
+    assert_builds_valid_spec,
+    assert_handler_satisfies,
+    assert_interface_well_formed,
+)
+
+
+def _valid_spec():
+    return CommandGroupSpec(
+        name="example",
+        help="Example plugin.",
+        commands=(
+            CommandDef(
+                name="hello",
+                help="Say hello.",
+                handler_method="hello",
+                params=(
+                    ParamDef(
+                        name="name", type=str, kind=ParamKind.ARGUMENT, help="Name"
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class _ValidHandler(CommandHandler):
+    def hello(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello {name}")
+
+
+class TestAssertInterfaceWellFormed:
+    def test_valid_spec_passes(self):
+        assert_interface_well_formed(_valid_spec())
+
+    def test_empty_command_name_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(CommandDef(name="", help="No name.", handler_method="run"),),
+        )
+        with pytest.raises(AssertionError, match="empty name"):
+            assert_interface_well_formed(spec)
+
+    def test_empty_help_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(CommandDef(name="run", help="", handler_method="run"),),
+        )
+        with pytest.raises(AssertionError, match="empty help"):
+            assert_interface_well_formed(spec)
+
+    def test_empty_handler_method_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(CommandDef(name="run", help="Run.", handler_method=""),),
+        )
+        with pytest.raises(AssertionError, match="empty handler_method"):
+            assert_interface_well_formed(spec)
+
+    def test_invalid_identifier_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="not-valid-python"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="not a valid Python identifier"):
+            assert_interface_well_formed(spec)
+
+    def test_duplicate_handler_method_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(name="run", help="Run.", handler_method="run"),
+                CommandDef(name="also-run", help="Also run.", handler_method="run"),
+            ),
+        )
+        with pytest.raises(AssertionError, match="Duplicate"):
+            assert_interface_well_formed(spec)
+
+    def test_invalid_param_name_fails(self):
+        spec = CommandGroupSpec(
+            name="bad",
+            help="Bad.",
+            commands=(
+                CommandDef(
+                    name="run",
+                    help="Run.",
+                    handler_method="run",
+                    params=(
+                        ParamDef(
+                            name="not-valid",
+                            type=str,
+                            kind=ParamKind.ARGUMENT,
+                            help="Bad param name",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(AssertionError, match="not a valid Python identifier"):
+            assert_interface_well_formed(spec)
+
+
+class TestAssertHandlerSatisfies:
+    def test_valid_handler_passes(self):
+        assert_handler_satisfies(_valid_spec(), _ValidHandler())
+
+    def test_incomplete_handler_fails(self):
+        class Empty(CommandHandler):
+            pass
+
+        with pytest.raises(InterfaceValidationError):
+            assert_handler_satisfies(_valid_spec(), Empty())
+
+
+class TestAssertBuildsValidSpec:
+    def test_valid_pair_passes(self):
+        assert_builds_valid_spec(_valid_spec(), _ValidHandler())


### PR DESCRIPTION
**Jira:** [SNOW-3680799](https://snowflakecomputing.atlassian.net/browse/SNOW-3680799) — under epic [SNOW-3445770](https://snowflakecomputing.atlassian.net/browse/SNOW-3445770) (Command scaffolding).

### Pre-review checklist
   * [ ] _N/A — no user-facing interface._ This PR adds no commands, flags, or output formats. It is internal plumbing for plugin authors, so the design sign-off for user-facing surfaces does not apply.
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] _N/A — integration tests._ The framework has no runtime CLI surface and never touches a Snowflake connection; correctness is fully covered by unit tests, and `testing.py` exists specifically so plugin authors can validate contracts without a connection.
   * [ ] _N/A — manual macOS test._ Pure library code with no platform-specific behaviour; covered by unit tests.
   * [ ] _N/A — manual Windows test._ Same as above.
   * [x] I've confirmed my changes are up-to-date with the target branch (rebased onto `main`).
   * [ ] _Using the `skip-release-notes` label._ Per [lifecycle.md](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md), release notes describe user-facing impact; this change has none.
   * [x] I've updated documentation if behavior changed — module docstrings document the new API; no behaviour changed.

### Changes description

**Interface-first plugin framework** — a declarative API that separates *what* a plugin's command surface looks like (the **spec**) from *how* it behaves (the **handler**).

#### Motivation

Today a plugin defines its commands and its business logic in one place, so the CLI surface (command names, flags, help text, preview/hidden status) can only be reviewed by reading through the implementation. This framework lets a plugin declare its surface as plain data that can be reviewed and locked in first, with the implementation supplied — and validated against that surface — separately. That makes the public CLI contract easy to review, easy to unit-test, and consistent across plugins.

The bridge emits a standard `CommandSpec`, so **the plugin loader and command registration are completely unchanged** — nothing downstream knows the spec/handler split exists.

#### What's added (all new, additive-only)

| Module | Purpose |
| --- | --- |
| `api/plugins/command/interface.py` | Frozen dataclasses `ParamDef`, `CommandDef`, `CommandGroupSpec`, `SingleCommandSpec`; the `ParamKind` enum; the `REQUIRED` sentinel; and the `CommandHandler` ABC. |
| `api/plugins/command/bridge.py` | `build_command_spec(spec, handler)` → standard `CommandSpec`. Load-time handler validation (`validate_interface_handler`) and a small, extensible decorator registry (`register_decorator`). |
| `api/plugins/command/testing.py` | `assert_interface_well_formed`, `assert_handler_satisfies`, `assert_builds_valid_spec` — let plugin authors unit-test their contracts with no Snowflake connection. |

#### Usage

```python
from snowflake.cli.api.plugins.command.interface import (
    CommandDef, CommandGroupSpec, CommandHandler, ParamDef, ParamKind,
)
from snowflake.cli.api.plugins.command.bridge import build_command_spec

SPEC = CommandGroupSpec(
    name="greeter",
    help="Greeting commands.",
    commands=(
        CommandDef(
            name="hello",
            help="Greet someone.",
            handler_method="hello",
            params=(ParamDef(name="name", type=str, kind=ParamKind.ARGUMENT, help="Who to greet"),),
        ),
    ),
)

class GreeterHandler(CommandHandler):
    def hello(self, name: str) -> CommandResult:
        return MessageResult(f"Hello, {name}!")

# Produces a standard CommandSpec the existing loader consumes unchanged.
command_spec = build_command_spec(SPEC, GreeterHandler())
```

#### Design notes

- **Zero startup cost / no coupling.** The new modules are imported only on demand by plugins that opt in; `api/plugins/command/__init__.py` is untouched, so the CLI startup import graph is unchanged.
- **Validation up front.** `build_command_spec` checks (by default) that the handler implements every declared command before building, raising `InterfaceValidationError` listing *all* violations.
- **Native Typer.** Boolean flags rely on the `bool` annotation rather than the deprecated `is_flag=`, so no Typer deprecation warnings are emitted.

#### Testing

- 38 unit tests across `test_interface.py`, `test_bridge.py`, `test_testing.py` (dataclass validation, the spec→`CommandSpec` bridge, nested groups, single commands, flags, decorator errors, and the assertion helpers).
- `ruff`, `black`, and `mypy` all clean.


[SNOW-3680799]: https://snowflakecomputing.atlassian.net/browse/SNOW-3680799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-3445770]: https://snowflakecomputing.atlassian.net/browse/SNOW-3445770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ