### PR TITLE
chore: add interface-first plugin cookiecutter template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+# The cookiecutter scaffold under plugin-template/ contains Jinja placeholders
+# (e.g. {{ cookiecutter.* }} in file paths, .py, and .toml) that are not valid
+# Python/TOML, so black/ruff/check-ast and the other hooks cannot process them.
+# Exclude the whole directory from every hook.
+exclude: '^plugin-template/'
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,266 @@ Application bundle created.
 Publishing application
 ```
 
+## Writing a Plugin (Interface-First)
+
+Snowflake CLI uses an **interface-first** plugin pattern that separates command
+definition from business logic. This lets outside contributors propose a
+command surface, get it reviewed, and only then write the implementation.
+
+### Two-Phase Contribution Workflow
+
+```
+Phase 1 PR:  interface.py  -->  review command surface  -->  merge
+Phase 2 PR:  handler.py + plugin_spec.py  -->  review implementation  -->  merge
+```
+
+### Quickstart with the Plugin Template
+
+The fastest way to start is with the cookiecutter template:
+
+```bash
+pip install cookiecutter
+cookiecutter plugin-template/
+```
+
+You will be prompted for:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `plugin_name` | Package name (used in `pip install`) | `snow-analytics` |
+| `plugin_module` | Python module name (auto-derived) | `snow_analytics` |
+| `cli_command_name` | CLI command name under `snow` | `analytics` |
+| `command_type` | `group` (multiple subcommands) or `single` | `group` |
+| `requires_connection` | Whether commands need a Snowflake connection | `true` |
+
+This generates a complete plugin project:
+
+```
+snow-analytics/
+├── pyproject.toml                    # Package config with entry point
+├── README.md
+├── src/snowflakecli_plugins/snow_analytics/
+│   ├── interface.py                  # Phase 1: command surface + handler ABC
+│   ├── handler.py                    # Phase 2: implementation
+│   └── plugin_spec.py               # Wires interface + handler
+└── tests/
+    └── test_interface.py             # Contract validation tests
+```
+
+### Phase 1: Define the Interface
+
+The `interface.py` file contains two things:
+
+1. **Command spec** -- frozen dataclasses describing every command, its
+   parameters, help text, and connection requirements.
+2. **Handler ABC** -- an abstract class with one method per command.
+
+Example for a plugin with two commands (`snow analytics run` and
+`snow analytics report`):
+
+```python
+from __future__ import annotations
+from abc import abstractmethod
+from snowflake.cli.api.output.types import CommandResult
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef, CommandGroupSpec, CommandHandler,
+    ParamDef, ParamKind, REQUIRED,
+)
+
+ANALYTICS_SPEC = CommandGroupSpec(
+    name="analytics",
+    help="Run analytics queries.",
+    parent_path=(),                          # root level: snow analytics
+    commands=(
+        CommandDef(
+            name="run",
+            help="Run an analytics query.",
+            handler_method="run",
+            requires_connection=True,
+            params=(
+                ParamDef(
+                    name="query_name",
+                    type=str,
+                    kind=ParamKind.ARGUMENT,
+                    help="Name of the query to run.",
+                ),
+                ParamDef(
+                    name="limit",
+                    type=int,
+                    kind=ParamKind.OPTION,
+                    cli_names=("--limit", "-l"),
+                    help="Maximum rows to return.",
+                    default=100,
+                    required=False,
+                ),
+            ),
+            output_type="QueryResult",
+        ),
+        CommandDef(
+            name="report",
+            help="Generate a summary report.",
+            handler_method="report",
+            requires_connection=True,
+            output_type="MessageResult",
+        ),
+    ),
+)
+
+
+class AnalyticsHandler(CommandHandler):
+    @abstractmethod
+    def run(self, query_name: str, limit: int) -> CommandResult: ...
+
+    @abstractmethod
+    def report(self) -> CommandResult: ...
+```
+
+**Key types used in interfaces:**
+
+| Dataclass | Purpose |
+|-----------|---------|
+| `CommandGroupSpec` | Command group with subcommands (e.g. `snow notebook`) |
+| `SingleCommandSpec` | A single command (e.g. `snow sql`) |
+| `CommandDef` | One command: name, help, params, connection requirements |
+| `ParamDef` | One parameter: name, type, argument vs option, CLI names |
+| `CommandHandler` | ABC base class for handler methods |
+
+**ParamDef fields:**
+
+| Field | Description |
+|-------|-------------|
+| `name` | Python parameter name (kwarg to handler method) |
+| `type` | Python type (`str`, `int`, `bool`, `FQN`, `Path`, ...) |
+| `kind` | `ParamKind.ARGUMENT` or `ParamKind.OPTION` |
+| `help` | Help text for `--help` |
+| `cli_names` | CLI names, e.g. `("--limit", "-l")`. Empty = auto-derived |
+| `default` | Default value. `REQUIRED` = no default |
+| `is_flag` | `True` for boolean flags like `--replace` |
+| `click_type` | Custom Click `ParamType` for non-standard types (e.g. `IdentifierType()` for `FQN`) |
+
+**Submit the interface for review.** Reviewers can evaluate the complete command
+surface without seeing any implementation.
+
+### Setting Up CODEOWNERS for Phase 2
+
+As part of the interface PR, add yourself and a colleague as `CODEOWNERS` for
+your plugin directory. This way the Phase 2 implementation PR only requires
+review from your team -- not the Snowflake CLI core team.
+
+In your interface PR, append a line to the `CODEOWNERS` file:
+
+```
+# my-analytics plugin
+/src/snowflake/cli/_plugins/analytics/   @your-github-handle @colleague-handle
+```
+
+For external plugins in a separate repository this is not needed, since you
+own the repo. This guidance applies to built-in plugins contributed to
+`snowflake-cli` by teams outside the CLI core team.
+
+### Phase 2: Implement the Handler
+
+After the interface is approved, create `handler.py`:
+
+```python
+from snowflake.cli.api.output.types import CommandResult, MessageResult, QueryResult
+from snowflake.cli.api.sql_execution import SqlExecutionMixin
+from .interface import AnalyticsHandler
+
+
+class AnalyticsHandlerImpl(AnalyticsHandler):
+
+    def run(self, query_name: str, limit: int) -> CommandResult:
+        executor = SqlExecutionMixin()
+        cursor = executor.execute_query(
+            f"SELECT * FROM analytics.{query_name} LIMIT {limit}"
+        )
+        return QueryResult(cursor)
+
+    def report(self) -> CommandResult:
+        return MessageResult("Report generated.")
+```
+
+Then wire it up in `plugin_spec.py`:
+
+```python
+from snowflake.cli.api.plugins.command import build_command_spec, plugin_hook_impl
+from .interface import ANALYTICS_SPEC
+from .handler import AnalyticsHandlerImpl
+
+
+@plugin_hook_impl
+def command_spec():
+    return build_command_spec(ANALYTICS_SPEC, AnalyticsHandlerImpl())
+```
+
+### Testing Your Plugin
+
+Use the built-in testing utilities to validate the interface-handler contract:
+
+```python
+from snowflake.cli.api.plugins.command.testing import (
+    assert_interface_well_formed,
+    assert_handler_satisfies,
+    assert_builds_valid_spec,
+)
+from .interface import ANALYTICS_SPEC
+from .handler import AnalyticsHandlerImpl
+
+
+def test_interface():
+    assert_interface_well_formed(ANALYTICS_SPEC)
+
+def test_handler_contract():
+    assert_handler_satisfies(ANALYTICS_SPEC, AnalyticsHandlerImpl())
+
+def test_full_build():
+    assert_builds_valid_spec(ANALYTICS_SPEC, AnalyticsHandlerImpl())
+```
+
+These tests run without a Snowflake connection and catch contract mismatches
+at development time.
+
+### Installing and Enabling Your Plugin
+
+```bash
+# Install in development mode
+pip install -e /path/to/your/plugin
+
+# Enable it
+snow plugin enable your_plugin_module
+
+# Verify
+snow plugin list
+```
+
+### Using Decorators
+
+Some commands need extra decorators like `@with_project_definition`. Add them
+to `CommandDef.decorators`:
+
+```python
+CommandDef(
+    name="deploy",
+    help="Deploy from project definition.",
+    handler_method="deploy",
+    requires_connection=True,
+    decorators=("with_project_definition",),
+    ...
+)
+```
+
+Available built-in decorators: `with_project_definition`.
+
+Register custom decorators with `register_decorator("name", factory_fn)`.
+
+### Reference Example
+
+See the notebook plugin for a complete migration example:
+- `src/snowflake/cli/_plugins/notebook/interface.py` -- 5 commands with various param types
+- `src/snowflake/cli/_plugins/notebook/handler.py` -- concrete implementation
+- `src/snowflake/cli/_plugins/notebook/plugin_spec.py` -- one-liner wiring
+
 ## Known issues
 
 ### `permission denied` during integration tests on Windows

--- a/plugin-template/conftest.py
+++ b/plugin-template/conftest.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This cookiecutter template is not part of the snowflake-cli test suite. Its
+# files contain Jinja placeholders (`{{ cookiecutter.* }}`) and are not valid
+# Python, so the repo-wide pytest runs that collect from the project root
+# (e.g. `pytest -m performance`, `pytest -m e2e`) would fail trying to import
+# them. Ignore everything under this directory during collection; the generated
+# project ships its own valid tests.
+collect_ignore_glob = ["*"]

--- a/plugin-template/cookiecutter.json
+++ b/plugin-template/cookiecutter.json
@@ -1,0 +1,13 @@
+{
+    "plugin_name": "my-snow-plugin",
+    "plugin_module": "{{ cookiecutter.plugin_name | replace('-', '_') }}",
+    "package_namespace": "snowflakecli_plugins",
+    "cli_command_name": "{{ cookiecutter.plugin_name }}",
+    "cli_parent_path": "",
+    "plugin_description": "A Snowflake CLI plugin.",
+    "author_name": "Your Name",
+    "author_email": "you@example.com",
+    "requires_connection": true,
+    "command_type": ["group", "single"],
+    "python_requires": ">=3.10"
+}

--- a/plugin-template/cookiecutter.json
+++ b/plugin-template/cookiecutter.json
@@ -1,6 +1,7 @@
 {
     "plugin_name": "my-snow-plugin",
     "plugin_module": "{{ cookiecutter.plugin_name | replace('-', '_') }}",
+    "plugin_class_name": "{{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}",
     "package_namespace": "snowflakecli_plugins",
     "cli_command_name": "{{ cookiecutter.plugin_name }}",
     "cli_parent_path": "",

--- a/plugin-template/{{cookiecutter.plugin_name}}/README.md
+++ b/plugin-template/{{cookiecutter.plugin_name}}/README.md
@@ -1,0 +1,37 @@
+# {{ cookiecutter.plugin_name }}
+
+{{ cookiecutter.plugin_description }}
+
+## Development
+
+### Install in development mode
+
+```bash
+pip install -e .
+```
+
+### Enable the plugin
+
+```bash
+snow plugin enable {{ cookiecutter.plugin_module }}
+```
+
+### Run tests
+
+```bash
+pytest
+```
+
+## Plugin Structure
+
+| File | Purpose |
+|------|---------|
+| `interface.py` | Command surface definition (spec + handler ABC) -- reviewed in Phase 1 |
+| `handler.py` | Business logic implementation -- reviewed in Phase 2 |
+| `plugin_spec.py` | Wires interface + handler into Snowflake CLI |
+
+## Contributing
+
+1. Modify `interface.py` to define your command surface (Phase 1 PR)
+2. After approval, implement handlers in `handler.py` (Phase 2 PR)
+3. Run `pytest` to validate the interface-handler contract

--- a/plugin-template/{{cookiecutter.plugin_name}}/README.md
+++ b/plugin-template/{{cookiecutter.plugin_name}}/README.md
@@ -1,0 +1,53 @@
+<!--
+ Copyright (c) 2024 Snowflake Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# {{ cookiecutter.plugin_name }}
+
+{{ cookiecutter.plugin_description }}
+
+## Development
+
+### Install in development mode
+
+```bash
+pip install -e .
+```
+
+### Enable the plugin
+
+```bash
+snow plugin enable {{ cookiecutter.plugin_module }}
+```
+
+### Run tests
+
+```bash
+pytest
+```
+
+## Plugin Structure
+
+| File | Purpose |
+|------|---------|
+| `interface.py` | Command surface definition (spec + handler ABC) -- reviewed in Phase 1 |
+| `handler.py` | Business logic implementation -- reviewed in Phase 2 |
+| `plugin_spec.py` | Wires interface + handler into Snowflake CLI |
+
+## Contributing
+
+1. Modify `interface.py` to define your command surface (Phase 1 PR)
+2. After approval, implement handlers in `handler.py` (Phase 2 PR)
+3. Run `pytest` to validate the interface-handler contract

--- a/plugin-template/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/plugin-template/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ cookiecutter.plugin_name }}"
+version = "0.1.0"
+description = "{{ cookiecutter.plugin_description }}"
+requires-python = "{{ cookiecutter.python_requires }}"
+authors = [
+    { name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}" },
+]
+dependencies = [
+    "snowflake-cli",
+]
+
+[project.entry-points."snowflake.cli.plugin.command"]
+{{ cookiecutter.plugin_module }} = "{{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.plugin_spec"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/plugin-template/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/plugin-template/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -1,0 +1,38 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ cookiecutter.plugin_name }}"
+version = "0.1.0"
+description = "{{ cookiecutter.plugin_description }}"
+requires-python = "{{ cookiecutter.python_requires }}"
+authors = [
+    { name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}" },
+]
+dependencies = [
+    "snowflake-cli",
+]
+
+[project.entry-points."snowflake.cli.plugin.command"]
+{{ cookiecutter.plugin_module }} = "{{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.plugin_spec"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{{ cookiecutter.package_namespace }}"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/__init__.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/__init__.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/handler.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/handler.py
@@ -1,0 +1,29 @@
+"""{{ cookiecutter.plugin_description }} -- Implementation.
+
+This file contains the concrete handler implementing the interface
+defined in ``interface.py``.  Submit this for review (Phase 2) after
+the interface has been approved.
+"""
+
+from __future__ import annotations
+
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import (
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+)
+
+
+class {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl(
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+):
+{% if cookiecutter.command_type == "group" %}
+    def hello(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello, {name}!")
+
+    def status(self) -> CommandResult:
+        return MessageResult("Plugin is running.")
+{%- else %}
+    def run(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello, {name}!")
+{%- endif %}

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/handler.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/handler.py
@@ -24,12 +24,12 @@ from __future__ import annotations
 from snowflake.cli.api.output.types import CommandResult, MessageResult
 
 from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import (
-    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+    {{ cookiecutter.plugin_class_name }}Handler,
 )
 
 
-class {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl(
-    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+class {{ cookiecutter.plugin_class_name }}HandlerImpl(
+    {{ cookiecutter.plugin_class_name }}Handler,
 ):
 {% if cookiecutter.command_type == "group" %}
     def hello(self, name: str) -> CommandResult:

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/handler.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/handler.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""{{ cookiecutter.plugin_description }} -- Implementation.
+
+This file contains the concrete handler implementing the interface
+defined in ``interface.py``.  Submit this for review (Phase 2) after
+the interface has been approved.
+"""
+
+from __future__ import annotations
+
+from snowflake.cli.api.output.types import CommandResult, MessageResult
+
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import (
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+)
+
+
+class {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl(
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+):
+{% if cookiecutter.command_type == "group" %}
+    def hello(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello, {name}!")
+
+    def status(self) -> CommandResult:
+        return MessageResult("Plugin is running.")
+{%- else %}
+    def run(self, name: str) -> CommandResult:
+        return MessageResult(f"Hello, {name}!")
+{%- endif %}

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
@@ -1,0 +1,116 @@
+"""{{ cookiecutter.plugin_description }}
+
+This file defines the command surface for ``snow {{ cookiecutter.cli_command_name }}``.
+Submit this file for review (Phase 1) before writing the implementation.
+
+Commands
+--------
+{%- if cookiecutter.command_type == "group" %}
+- ``snow {{ cookiecutter.cli_command_name }} hello <name>``  -- Say hello.
+- ``snow {{ cookiecutter.cli_command_name }} status``        -- Show status.
+{%- else %}
+- ``snow {{ cookiecutter.cli_command_name }} <name>``  -- Run the command.
+{%- endif %}
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from snowflake.cli.api.output.types import CommandResult
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+{%- if cookiecutter.command_type == "group" %}
+    CommandGroupSpec,
+{%- else %}
+    SingleCommandSpec,
+{%- endif %}
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    REQUIRED,
+)
+
+# ---------------------------------------------------------------------------
+# Command surface (reviewable spec)
+# ---------------------------------------------------------------------------
+
+{% if cookiecutter.command_type == "group" -%}
+PLUGIN_SPEC = CommandGroupSpec(
+    name="{{ cookiecutter.cli_command_name }}",
+    help="{{ cookiecutter.plugin_description }}",
+    parent_path=({{ cookiecutter.cli_parent_path | default("", true) }}),
+    commands=(
+        CommandDef(
+            name="hello",
+            help="Say hello to someone.",
+            handler_method="hello",
+            requires_connection={{ cookiecutter.requires_connection }},
+            params=(
+                ParamDef(
+                    name="name",
+                    type=str,
+                    kind=ParamKind.ARGUMENT,
+                    help="Name to greet.",
+                ),
+            ),
+            output_type="MessageResult",
+        ),
+        CommandDef(
+            name="status",
+            help="Show plugin status.",
+            handler_method="status",
+            requires_connection={{ cookiecutter.requires_connection }},
+            output_type="MessageResult",
+        ),
+    ),
+)
+{%- else -%}
+PLUGIN_SPEC = SingleCommandSpec(
+    parent_path=({{ cookiecutter.cli_parent_path | default("", true) }}),
+    command=CommandDef(
+        name="{{ cookiecutter.cli_command_name }}",
+        help="{{ cookiecutter.plugin_description }}",
+        handler_method="run",
+        requires_connection={{ cookiecutter.requires_connection }},
+        params=(
+            ParamDef(
+                name="name",
+                type=str,
+                kind=ParamKind.ARGUMENT,
+                help="Name argument.",
+            ),
+        ),
+        output_type="MessageResult",
+    ),
+)
+{%- endif %}
+
+
+# ---------------------------------------------------------------------------
+# Handler contract (ABC)
+# ---------------------------------------------------------------------------
+
+
+class {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler(CommandHandler):
+    """Handler contract for {{ cookiecutter.cli_command_name }} commands.
+
+    Each abstract method corresponds to a ``CommandDef`` above via
+    ``handler_method``.
+    """
+{% if cookiecutter.command_type == "group" %}
+    @abstractmethod
+    def hello(self, name: str) -> CommandResult:
+        """Say hello."""
+        ...
+
+    @abstractmethod
+    def status(self) -> CommandResult:
+        """Show status."""
+        ...
+{% else %}
+    @abstractmethod
+    def run(self, name: str) -> CommandResult:
+        """Run the command."""
+        ...
+{% endif %}

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""{{ cookiecutter.plugin_description }}
+
+This file defines the command surface for ``snow {{ cookiecutter.cli_command_name }}``.
+Submit this file for review (Phase 1) before writing the implementation.
+
+Commands
+--------
+{%- if cookiecutter.command_type == "group" %}
+- ``snow {{ cookiecutter.cli_command_name }} hello <name>``  -- Say hello.
+- ``snow {{ cookiecutter.cli_command_name }} status``        -- Show status.
+{%- else %}
+- ``snow {{ cookiecutter.cli_command_name }} <name>``  -- Run the command.
+{%- endif %}
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from snowflake.cli.api.output.types import CommandResult
+from snowflake.cli.api.plugins.command.interface import (
+    CommandDef,
+{%- if cookiecutter.command_type == "group" %}
+    CommandGroupSpec,
+{%- else %}
+    SingleCommandSpec,
+{%- endif %}
+    CommandHandler,
+    ParamDef,
+    ParamKind,
+    REQUIRED,
+)
+
+# ---------------------------------------------------------------------------
+# Command surface (reviewable spec)
+# ---------------------------------------------------------------------------
+
+{% if cookiecutter.command_type == "group" -%}
+PLUGIN_SPEC = CommandGroupSpec(
+    name="{{ cookiecutter.cli_command_name }}",
+    help="{{ cookiecutter.plugin_description }}",
+    parent_path=({{ cookiecutter.cli_parent_path | default("", true) }}),
+    commands=(
+        CommandDef(
+            name="hello",
+            help="Say hello to someone.",
+            handler_method="hello",
+            requires_connection={{ cookiecutter.requires_connection }},
+            params=(
+                ParamDef(
+                    name="name",
+                    type=str,
+                    kind=ParamKind.ARGUMENT,
+                    help="Name to greet.",
+                ),
+            ),
+            output_type="MessageResult",
+        ),
+        CommandDef(
+            name="status",
+            help="Show plugin status.",
+            handler_method="status",
+            requires_connection={{ cookiecutter.requires_connection }},
+            output_type="MessageResult",
+        ),
+    ),
+)
+{%- else -%}
+PLUGIN_SPEC = SingleCommandSpec(
+    parent_path=({{ cookiecutter.cli_parent_path | default("", true) }}),
+    command=CommandDef(
+        name="{{ cookiecutter.cli_command_name }}",
+        help="{{ cookiecutter.plugin_description }}",
+        handler_method="run",
+        requires_connection={{ cookiecutter.requires_connection }},
+        params=(
+            ParamDef(
+                name="name",
+                type=str,
+                kind=ParamKind.ARGUMENT,
+                help="Name argument.",
+            ),
+        ),
+        output_type="MessageResult",
+    ),
+)
+{%- endif %}
+
+
+# ---------------------------------------------------------------------------
+# Handler contract (ABC)
+# ---------------------------------------------------------------------------
+
+
+class {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler(CommandHandler):
+    """Handler contract for {{ cookiecutter.cli_command_name }} commands.
+
+    Each abstract method corresponds to a ``CommandDef`` above via
+    ``handler_method``.
+    """
+{% if cookiecutter.command_type == "group" %}
+    @abstractmethod
+    def hello(self, name: str) -> CommandResult:
+        """Say hello."""
+        ...
+
+    @abstractmethod
+    def status(self) -> CommandResult:
+        """Show status."""
+        ...
+{% else %}
+    @abstractmethod
+    def run(self, name: str) -> CommandResult:
+        """Run the command."""
+        ...
+{% endif %}

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
@@ -42,7 +42,6 @@ from snowflake.cli.api.plugins.command.interface import (
     CommandHandler,
     ParamDef,
     ParamKind,
-    REQUIRED,
 )
 
 # ---------------------------------------------------------------------------
@@ -53,7 +52,7 @@ from snowflake.cli.api.plugins.command.interface import (
 PLUGIN_SPEC = CommandGroupSpec(
     name="{{ cookiecutter.cli_command_name }}",
     help="{{ cookiecutter.plugin_description }}",
-    parent_path=({{ cookiecutter.cli_parent_path | default("", true) }}),
+    parent_path=({% for p in cookiecutter.cli_parent_path.split() %}"{{ p }}",{% if not loop.last %} {% endif %}{% endfor %}),
     commands=(
         CommandDef(
             name="hello",
@@ -81,7 +80,7 @@ PLUGIN_SPEC = CommandGroupSpec(
 )
 {%- else -%}
 PLUGIN_SPEC = SingleCommandSpec(
-    parent_path=({{ cookiecutter.cli_parent_path | default("", true) }}),
+    parent_path=({% for p in cookiecutter.cli_parent_path.split() %}"{{ p }}",{% if not loop.last %} {% endif %}{% endfor %}),
     command=CommandDef(
         name="{{ cookiecutter.cli_command_name }}",
         help="{{ cookiecutter.plugin_description }}",

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/interface.py
@@ -106,7 +106,7 @@ PLUGIN_SPEC = SingleCommandSpec(
 # ---------------------------------------------------------------------------
 
 
-class {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler(CommandHandler):
+class {{ cookiecutter.plugin_class_name }}Handler(CommandHandler):
     """Handler contract for {{ cookiecutter.cli_command_name }} commands.
 
     Each abstract method corresponds to a ``CommandDef`` above via

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/plugin_spec.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/plugin_spec.py
@@ -1,0 +1,11 @@
+from snowflake.cli.api.plugins.command import build_command_spec, plugin_hook_impl
+
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.handler import (
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+)
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import PLUGIN_SPEC
+
+
+@plugin_hook_impl
+def command_spec():
+    return build_command_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/plugin_spec.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/plugin_spec.py
@@ -16,11 +16,11 @@ from snowflake.cli.api.plugins.command import plugin_hook_impl
 from snowflake.cli.api.plugins.command.bridge import build_command_spec
 
 from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.handler import (
-    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+    {{ cookiecutter.plugin_class_name }}HandlerImpl,
 )
 from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import PLUGIN_SPEC
 
 
 @plugin_hook_impl
 def command_spec():
-    return build_command_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())
+    return build_command_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_class_name }}HandlerImpl())

--- a/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/plugin_spec.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/src/{{cookiecutter.package_namespace}}/{{cookiecutter.plugin_module}}/plugin_spec.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from snowflake.cli.api.plugins.command import plugin_hook_impl
+from snowflake.cli.api.plugins.command.bridge import build_command_spec
+
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.handler import (
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+)
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import PLUGIN_SPEC
+
+
+@plugin_hook_impl
+def command_spec():
+    return build_command_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())

--- a/plugin-template/{{cookiecutter.plugin_name}}/tests/__init__.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/plugin-template/{{cookiecutter.plugin_name}}/tests/test_interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/tests/test_interface.py
@@ -1,0 +1,36 @@
+"""Tests for {{ cookiecutter.plugin_name }} interface and handler contract."""
+
+from __future__ import annotations
+
+from snowflake.cli.api.plugins.command.testing import (
+    assert_builds_valid_spec,
+    assert_handler_satisfies,
+    assert_interface_well_formed,
+)
+
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.handler import (
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+)
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import (
+    PLUGIN_SPEC,
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+)
+
+
+def test_interface_is_well_formed():
+    assert_interface_well_formed(PLUGIN_SPEC)
+
+
+def test_handler_satisfies_interface():
+    assert_handler_satisfies(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())
+
+
+def test_handler_is_subclass_of_abc():
+    assert issubclass(
+        {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+        {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+    )
+
+
+def test_builds_valid_command_spec():
+    assert_builds_valid_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())

--- a/plugin-template/{{cookiecutter.plugin_name}}/tests/test_interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/tests/test_interface.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for {{ cookiecutter.plugin_name }} interface and handler contract."""
+
+from __future__ import annotations
+
+from snowflake.cli.api.plugins.command.testing import (
+    assert_builds_valid_spec,
+    assert_handler_satisfies,
+    assert_interface_well_formed,
+)
+
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.handler import (
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+)
+from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import (
+    PLUGIN_SPEC,
+    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+)
+
+
+def test_interface_is_well_formed():
+    assert_interface_well_formed(PLUGIN_SPEC)
+
+
+def test_handler_satisfies_interface():
+    assert_handler_satisfies(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())
+
+
+def test_handler_is_subclass_of_abc():
+    assert issubclass(
+        {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+        {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+    )
+
+
+def test_builds_valid_command_spec():
+    assert_builds_valid_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())

--- a/plugin-template/{{cookiecutter.plugin_name}}/tests/test_interface.py
+++ b/plugin-template/{{cookiecutter.plugin_name}}/tests/test_interface.py
@@ -23,11 +23,11 @@ from snowflake.cli.api.plugins.command.testing import (
 )
 
 from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.handler import (
-    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
+    {{ cookiecutter.plugin_class_name }}HandlerImpl,
 )
 from {{ cookiecutter.package_namespace }}.{{ cookiecutter.plugin_module }}.interface import (
     PLUGIN_SPEC,
-    {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+    {{ cookiecutter.plugin_class_name }}Handler,
 )
 
 
@@ -36,15 +36,15 @@ def test_interface_is_well_formed():
 
 
 def test_handler_satisfies_interface():
-    assert_handler_satisfies(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())
+    assert_handler_satisfies(PLUGIN_SPEC, {{ cookiecutter.plugin_class_name }}HandlerImpl())
 
 
 def test_handler_is_subclass_of_abc():
     assert issubclass(
-        {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl,
-        {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}Handler,
+        {{ cookiecutter.plugin_class_name }}HandlerImpl,
+        {{ cookiecutter.plugin_class_name }}Handler,
     )
 
 
 def test_builds_valid_command_spec():
-    assert_builds_valid_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_module | replace('_', ' ') | title | replace(' ', '') }}HandlerImpl())
+    assert_builds_valid_spec(PLUGIN_SPEC, {{ cookiecutter.plugin_class_name }}HandlerImpl())


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

_Template/tooling PR: `plugin-template/` is excluded from repo CI (Jinja placeholders, not valid Python/TOML), so repo unit/integration tests and manual platform testing don't apply. Instead the generated project was validated end-to-end (see below). `skip-release-notes` applied._

### Changes description

Split from the original scope of this PR; the contributor guide is now in #3132.

Adds a cookiecutter template under `plugin-template/` for scaffolding
**interface-first** Snowflake CLI plugins:

- Supports `group` (multiple subcommands) and `single` command plugins.
- Generated project: `interface.py` (Phase 1 reviewable command surface + handler
  ABC), `handler.py` (Phase 2 implementation), `plugin_spec.py` (wiring via
  `build_command_spec`), and a contract test using the
  `snowflake.cli.api.plugins.command.testing` helpers.
- Generated files carry the standard Apache license header (matching
  `scripts/LICENSE.txt`), so a plugin contributed back into snowflake-cli as a
  built-in passes the repo's `insert-license` check unchanged.

Because the template **sources** contain Jinja placeholders that are not valid
Python/TOML, they are kept out of the repo's own tooling:
- pre-commit excludes `plugin-template/` globally (black/ruff/check-ast cannot
  parse the Jinja sources).
- `plugin-template/conftest.py` keeps the repo-wide pytest runs that collect from
  the project root (`pytest -m performance` / `-m e2e`) from importing the Jinja
  template tests.

**Validated against current `main`:** `cookiecutter plugin-template/` renders both
the `group` and `single` variants, the generated project builds and installs
(`pip install`), and its contract tests pass (`4 passed`).

**Updated from the original draft to match current `main`:**
- `build_command_spec` is now imported from `...command.bridge` (the package
  `__init__` no longer re-exports it); the old import would have failed at runtime.
- `pyproject.toml` declares `[tool.hatch.build.targets.wheel] packages` so the
  generated `src/`-layout project actually builds.

Pairs with the guide in #3132.
