### PR TITLE
Snowflake Apps: Add --upload-only, --build-only, --deploy-only flags to deploy command

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -313,26 +313,55 @@ def deploy(
         "--entity-id",
         help="ID of the snowflake-app entity to deploy. Required if multiple snowflake-app entities exist.",
     ),
+    upload_only: bool = typer.Option(
+        False,
+        "--upload-only",
+        help="Bundle and upload source artifacts to the stage, then stop. "
+        "Skips the build and deploy phases.",
+    ),
+    build_only: bool = typer.Option(
+        False,
+        "--build-only",
+        help="Run only the build phase (assumes artifacts have already been uploaded). "
+        "Skips the upload and deploy phases.",
+    ),
+    deploy_only: bool = typer.Option(
+        False,
+        "--deploy-only",
+        help="Run only the deploy phase (assumes the container image has already been built). "
+        "Skips the upload and build phases.",
+    ),
     skip_build: bool = typer.Option(
         False,
         "--skip-build",
-        help="Skip the build phase and go straight to deploying the service. "
-        "Assumes the container image has already been built.",
+        hidden=True,
+        help="[Deprecated: use --deploy-only] Skip the build phase.",
     ),
     **options,
 ) -> CommandResult:
     """
     Builds and deploys a Snowflake App.
 
-    Uploads source artifacts, builds a container image, creates (or updates)
-    a service, and waits for it to become ready.
+    The deploy pipeline has three phases: upload, build, and deploy.
+    By default all three phases run in sequence. Use --upload-only,
+    --build-only, or --deploy-only to run a single phase.
 
     If --entity-id is not specified and the project contains exactly one snowflake-app
     entity, that entity will be used automatically.
-
-    Use --skip-build to skip the build phase and redeploy using the existing
-    container image (e.g. after a configuration-only change).
     """
+    phase_flags = sum([upload_only, build_only, deploy_only, skip_build])
+    if phase_flags > 1:
+        raise ClickException(
+            "Only one of --upload-only, --build-only, --deploy-only "
+            "(or --skip-build) may be specified."
+        )
+
+    if skip_build:
+        deploy_only = True
+
+    run_upload = not build_only and not deploy_only
+    run_build = not upload_only and not deploy_only
+    run_deploy = not upload_only and not build_only
     resolved_entity_id = _resolve_entity_id(entity_id)
     entity = _get_entity(resolved_entity_id)
 
@@ -388,21 +417,21 @@ def deploy(
         artifact_repo_fqn_str = f"{ar_database}.{ar_schema}.{ar.name}"
 
     # ── Validate required configuration ───────────────────────────────
-    if not skip_build and not build_compute_pool:
+    if run_build and not build_compute_pool:
         raise CliError(
-            "build_compute_pool is required for deploy. "
+            "build_compute_pool is required for the build phase. "
             "Please configure it in snowflake.yml."
         )
 
-    if not service_compute_pool:
+    if run_deploy and not service_compute_pool:
         raise CliError(
-            "service_compute_pool is required for deploy. "
+            "service_compute_pool is required for the deploy phase. "
             "Please configure it in snowflake.yml."
         )
 
-    if not use_artifact_repo and not query_warehouse:
+    if run_deploy and not use_artifact_repo and not query_warehouse:
         raise CliError(
-            "query_warehouse is required for deploy. "
+            "query_warehouse is required for the deploy phase. "
             "Please configure it in snowflake.yml."
         )
 
@@ -414,17 +443,15 @@ def deploy(
 
     stage_manager = StageManager()
 
-    if not use_artifact_repo:
+    if (run_build or run_deploy) and not use_artifact_repo:
         cli_console.step(f"Getting image repository URL for {image_repository}")
         image_repo_url = manager.get_image_repo_url(
             image_repository, database=image_repo_database, schema=image_repo_schema
         )
 
-    # ── Build phase ───────────────────────────────────────────────────
+    # ── Upload phase ──────────────────────────────────────────────────
 
-    if skip_build:
-        cli_console.step("Skipping build phase (--skip-build)")
-    else:
+    if run_upload:
         if manager.stage_exists(stage_fqn):
             cli_console.step(f"Clearing existing stage @{stage_fqn}")
             manager.clear_stage(stage_fqn)
@@ -447,6 +474,12 @@ def deploy(
         finally:
             project_paths.clean_up_output()
 
+    if upload_only:
+        return MessageResult(f"Artifacts uploaded to @{stage_fqn}")
+
+    # ── Build phase ───────────────────────────────────────────────────
+
+    if run_build:
         if use_artifact_repo:
             cli_console.step("Building app using artifact repository...")
             build_result = manager.build_app_artifact_repo(
@@ -508,6 +541,9 @@ def deploy(
                 known_pending_states={"PENDING", "RUNNING"},
                 timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
             )
+
+    if build_only:
+        return MessageResult("Build completed successfully.")
 
     # ── Deploy phase ──────────────────────────────────────────────────
 

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -343,7 +343,7 @@ def deploy(
     If --entity-id is not specified and the project contains exactly one snowflake-app
     entity, that entity will be used automatically.
     """
-    phase_flags = sum([upload_only, build_only, deploy_only])
+    phase_flags = sum((upload_only, build_only, deploy_only))
     if phase_flags > 1:
         raise ClickException(
             "Only one of --upload-only, --build-only, or --deploy-only "
@@ -433,6 +433,7 @@ def deploy(
     service_fqn = FQN(database=database, schema=schema, name=app_name)
 
     stage_manager = StageManager()
+    image_repo_url = None
 
     if (run_build or run_deploy) and not use_artifact_repo:
         cli_console.step(f"Getting image repository URL for {image_repository}")
@@ -554,6 +555,7 @@ def deploy(
         )
         cli_console.step(f"SPCS_TEST_RUN_APP_ARTIFACT_REPO output:\n{run_result}")
     else:
+        assert image_repo_url is not None
         repo_path = "/" + "/".join(image_repo_url.split("/")[1:])
         image_url = f"{repo_path}/{app_name.lower()}:latest"
 

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -331,12 +331,6 @@ def deploy(
         help="Run only the deploy phase (assumes the container image has already been built). "
         "Skips the upload and build phases.",
     ),
-    skip_build: bool = typer.Option(
-        False,
-        "--skip-build",
-        hidden=True,
-        help="[Deprecated: use --deploy-only] Skip the build phase.",
-    ),
     **options,
 ) -> CommandResult:
     """
@@ -349,15 +343,12 @@ def deploy(
     If --entity-id is not specified and the project contains exactly one snowflake-app
     entity, that entity will be used automatically.
     """
-    phase_flags = sum([upload_only, build_only, deploy_only, skip_build])
+    phase_flags = sum([upload_only, build_only, deploy_only])
     if phase_flags > 1:
         raise ClickException(
-            "Only one of --upload-only, --build-only, --deploy-only "
-            "(or --skip-build) may be specified."
+            "Only one of --upload-only, --build-only, or --deploy-only "
+            "may be specified."
         )
-
-    if skip_build:
-        deploy_only = True
 
     run_upload = not build_only and not deploy_only
     run_build = not upload_only and not deploy_only

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -98,23 +98,27 @@
                                                                                   
    Builds and deploys a Snowflake App.                                            
                                                                                   
-   Uploads source artifacts, builds a container image, creates (or updates) a     
-   service, and waits for it to become ready.                                     
+   The deploy pipeline has three phases: upload, build, and deploy. By default    
+   all three phases run in sequence. Use --upload-only, --build-only, or          
+   --deploy-only to run a single phase.                                           
                                                                                   
    If --entity-id is not specified and the project contains exactly one           
    snowflake-app entity, that entity will be used automatically.                  
                                                                                   
-   Use --skip-build to skip the build phase and redeploy using the existing       
-   container image (e.g. after a configuration-only change).                      
-                                                                                  
   +- Options --------------------------------------------------------------------+
-  | --entity-id           TEXT  ID of the snowflake-app entity to deploy.        |
-  |                             Required if multiple snowflake-app entities      |
-  |                             exist.                                           |
-  | --skip-build                Skip the build phase and go straight to          |
-  |                             deploying the service. Assumes the container     |
-  |                             image has already been built.                    |
-  | --help        -h            Show this message and exit.                      |
+  | --entity-id            TEXT  ID of the snowflake-app entity to deploy.       |
+  |                              Required if multiple snowflake-app entities     |
+  |                              exist.                                          |
+  | --upload-only                Bundle and upload source artifacts to the       |
+  |                              stage, then stop. Skips the build and deploy    |
+  |                              phases.                                         |
+  | --build-only                 Run only the build phase (assumes artifacts     |
+  |                              have already been uploaded). Skips the upload   |
+  |                              and deploy phases.                              |
+  | --deploy-only                Run only the deploy phase (assumes the          |
+  |                              container image has already been built). Skips  |
+  |                              the upload and build phases.                    |
+  | --help         -h            Show this message and exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2669,7 +2669,6 @@ class TestDeployCommand:
             with change_directory(tmp_path):
                 result = runner.invoke(["__app", "deploy", "--skip-build"])
                 assert result.exit_code == 0, result.output
-                assert "Skipping build phase" in result.output
                 mock_mgr.get_image_repo_url.assert_called_once_with(
                     "IMAGE_REPO", database="TEST_DB", schema="TEST_SCHEMA"
                 )

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2908,3 +2908,310 @@ class TestDeployCommand:
         mock_mgr.alter_service_spec.assert_not_called()
         mock_mgr.execute_build_job.assert_not_called()
         assert mock_poll.call_count == 2
+
+    # ── Phase flag tests ──────────────────────────────────────────────
+
+    def test_mutually_exclusive_phase_flags(self, runner, tmp_path):
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(
+                    ["__app", "deploy", "--upload-only", "--build-only"]
+                )
+                assert result.exit_code == 1
+                assert "Only one of" in result.output
+
+                result = runner.invoke(
+                    ["__app", "deploy", "--upload-only", "--deploy-only"]
+                )
+                assert result.exit_code == 1
+                assert "Only one of" in result.output
+
+                result = runner.invoke(
+                    ["__app", "deploy", "--build-only", "--deploy-only"]
+                )
+                assert result.exit_code == 1
+                assert "Only one of" in result.output
+
+                result = runner.invoke(
+                    ["__app", "deploy", "--upload-only", "--skip-build"]
+                )
+                assert result.exit_code == 1
+                assert "Only one of" in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_upload_only_runs_upload_and_stops(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        project_paths = ProjectPaths(project_root=tmp_path)
+        mock_perform_bundle.return_value = project_paths
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.stage_exists.return_value = False
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy", "--upload-only"])
+                assert result.exit_code == 0, result.output
+                assert "Artifacts uploaded" in result.output
+
+        mock_mgr.create_stage.assert_called_once()
+        mock_perform_bundle.assert_called_once()
+        mock_mgr.execute_build_job.assert_not_called()
+        mock_mgr.create_service.assert_not_called()
+        mock_mgr.get_image_repo_url.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_build_only_runs_build_and_stops(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
+        entity.build_image = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.get_image_repo_url.return_value = (
+            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
+        )
+        mock_poll.return_value = "DONE"
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy", "--build-only"])
+                assert result.exit_code == 0, result.output
+                assert "Build completed successfully" in result.output
+
+        mock_mgr.execute_build_job.assert_called_once()
+        mock_mgr.create_service.assert_not_called()
+        mock_mgr.alter_service_spec.assert_not_called()
+        mock_mgr.resume_service.assert_not_called()
+        mock_mgr.stage_exists.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_only_runs_deploy_and_stops(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.get_image_repo_url.return_value = (
+            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
+        )
+        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy", "--deploy-only"])
+                assert result.exit_code == 0, result.output
+                assert "App ready at" in result.output
+
+        mock_mgr.create_service.assert_called_once()
+        mock_mgr.alter_service_spec.assert_called_once()
+        mock_mgr.resume_service.assert_called_once()
+        mock_mgr.execute_build_job.assert_not_called()
+        mock_mgr.stage_exists.assert_not_called()
+
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": None,
+            "build_compute_pool": None,
+            "service_compute_pool": None,
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_upload_only_skips_build_and_deploy_validation(
+        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
+    ):
+        """--upload-only should not require build_compute_pool, service_compute_pool, or query_warehouse."""
+        entity = Mock()
+        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        entity.image_repository = None
+        mock_get_entity.return_value = entity
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy", "--upload-only"])
+                assert "build_compute_pool is required" not in result.output
+                assert "service_compute_pool is required" not in result.output
+                assert "query_warehouse is required" not in result.output
+
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": None,
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": None,
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_build_only_skips_deploy_validation(
+        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
+    ):
+        """--build-only should not require service_compute_pool or query_warehouse."""
+        entity = Mock()
+        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        entity.image_repository = None
+        mock_get_entity.return_value = entity
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy", "--build-only"])
+                assert "service_compute_pool is required" not in result.output
+                assert "query_warehouse is required" not in result.output

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2632,7 +2632,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_skip_build_skips_build_phase(
+    def test_deploy_only_skips_upload_and_build_phase(
         self,
         mock_resolve,
         mock_get_entity,
@@ -2667,7 +2667,7 @@ class TestDeployCommand:
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
 
             with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy", "--skip-build"])
+                result = runner.invoke(["__app", "deploy", "--deploy-only"])
                 assert result.exit_code == 0, result.output
                 mock_mgr.get_image_repo_url.assert_called_once_with(
                     "IMAGE_REPO", database="TEST_DB", schema="TEST_SCHEMA"
@@ -2698,10 +2698,10 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_skip_build_allows_missing_build_compute_pool(
+    def test_deploy_only_allows_missing_build_compute_pool(
         self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
     ):
-        """--skip-build should not require build_compute_pool."""
+        """--deploy-only should not require build_compute_pool."""
         entity = Mock()
         entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
         entity.code_stage = None
@@ -2714,7 +2714,7 @@ class TestDeployCommand:
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
 
             with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy", "--skip-build"])
+                result = runner.invoke(["__app", "deploy", "--deploy-only"])
                 assert result.exit_code == 1
                 assert "build_compute_pool is required" not in result.output
                 assert "service_compute_pool is required" in result.output
@@ -2930,12 +2930,6 @@ class TestDeployCommand:
 
                 result = runner.invoke(
                     ["__app", "deploy", "--build-only", "--deploy-only"]
-                )
-                assert result.exit_code == 1
-                assert "Only one of" in result.output
-
-                result = runner.invoke(
-                    ["__app", "deploy", "--upload-only", "--skip-build"]
                 )
                 assert result.exit_code == 1
                 assert "Only one of" in result.output

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2934,6 +2934,86 @@ class TestDeployCommand:
                 assert result.exit_code == 1
                 assert "Only one of" in result.output
 
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_no_phase_flags_runs_all_phases(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """Deploy with no phase flags runs upload, build, and deploy."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
+        entity.build_image = None
+        entity.execute_as_caller = False
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        project_paths = ProjectPaths(project_root=tmp_path)
+        mock_perform_bundle.return_value = project_paths
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.stage_exists.return_value = False
+        mock_mgr.get_image_repo_url.return_value = (
+            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
+        )
+        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy"])
+                assert result.exit_code == 0, result.output
+                assert "App ready at" in result.output
+
+        mock_mgr.create_stage.assert_called_once()
+        mock_perform_bundle.assert_called_once()
+        mock_mgr.execute_build_job.assert_called_once()
+        mock_mgr.create_service.assert_called_once()
+        mock_mgr.alter_service_spec.assert_called_once()
+        mock_mgr.resume_service.assert_called_once()
+
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
     @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3129,6 +3209,9 @@ class TestDeployCommand:
         mock_mgr.execute_build_job.assert_not_called()
         mock_mgr.stage_exists.assert_not_called()
 
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     @patch(
         RESOLVE_DEPLOY_DEFAULTS,
         return_value={
@@ -3149,9 +3232,19 @@ class TestDeployCommand:
         return_value="my_app",
     )
     def test_upload_only_skips_build_and_deploy_validation(
-        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        runner,
+        tmp_path,
     ):
         """--upload-only should not require build_compute_pool, service_compute_pool, or query_warehouse."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
         entity = Mock()
         entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
         entity.code_stage = None
@@ -3161,11 +3254,17 @@ class TestDeployCommand:
         entity.image_repository = None
         mock_get_entity.return_value = entity
 
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+        mock_manager_cls.return_value.stage_exists.return_value = False
+
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
             from tests_common import change_directory
 
             with change_directory(tmp_path):
                 result = runner.invoke(["__app", "deploy", "--upload-only"])
+                assert result.exit_code == 0, result.output
                 assert "build_compute_pool is required" not in result.output
                 assert "service_compute_pool is required" not in result.output
                 assert "query_warehouse is required" not in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Split the `__app deploy` flow into three individually runnable phases — upload, build, and deploy — via new `--upload-only`, `--build-only`, and `--deploy-only` flags.

Validation is now phase-aware: `build_compute_pool` is only required when the build phase runs, and `service_compute_pool`/`query_warehouse` are only required when the deploy phase runs.
