### PR TITLE
Add SnowApps parameters tier to defaults resolution

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -25,6 +25,7 @@ from snowflake.cli._plugins.apps.generate import (
 )
 from snowflake.cli._plugins.apps.manager import (
     _APP_COMMAND_NAME,
+    DEFAULT_IMAGE_REPOSITORY,
     DEFINITION_FILENAME,
     EXPOSE_UNSUPPORTED_SYNTAX,
     SnowflakeAppManager,
@@ -52,6 +53,14 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.api.project.util import get_env_username, identifier_for_url
 from snowflake.connector.errors import ProgrammingError
+
+# ── Source provenance labels ──────────────────────────────────────────
+SOURCE_USER_INPUT = "user input"
+SOURCE_ACCOUNT_PARAM = "account parameter"
+SOURCE_CONFIG_TABLE = "config table"
+SOURCE_CURRENT_SESSION = "current session"
+SOURCE_DEFAULT = "default"
+SOURCE_MISSING = "missing"
 
 app = SnowTyperFactory(
     name=_APP_COMMAND_NAME,
@@ -107,62 +116,121 @@ def setup(
     conn_config = get_connection_dict(connection_name)
 
     manager = SnowflakeAppManager()
+    params = manager.fetch_snow_apps_parameters()
     config_table = {}
     role = manager.current_role()
     if role:
         config_table = manager.fetch_config_table_defaults(role)
 
-    def _resolve(flag_val, config_key, conn_key=None, builtin=None):
-        """Return (value, source) using: flag > account default > connection config > builtin."""
-        if flag_val is not None:
-            return flag_val, "flag"
-        table_val = config_table.get(config_key)
-        if table_val:
-            return table_val, "account default"
-        if conn_key is not None:
-            # ctx.connection_context is only populated (without update_from_config) when
-            # the user explicitly passed the flag on the CLI, so this signals "flag" provenance.
-            ctx_val = getattr(ctx.connection_context, conn_key, None)
-            if ctx_val:
-                return ctx_val, "flag"
-            conn_val = conn_config.get(conn_key)
-            if conn_val:
-                return conn_val, "connection config"
-        if builtin is not None:
-            return builtin, "default"
-        return None, "missing"
+    def _resolve(
+        user_input=None,
+        account_param=None,
+        config_table_val=None,
+        default_value=None,
+        current_session=None,
+    ):
+        """Return (value, source) using a fixed resolution order.
 
-    if IS_PERSONAL_DB_SUPPORTED:
-        database_resolved = (f"USER${get_env_username().upper()}", "personal db")
-    else:
-        database_resolved = _resolve(None, "database", conn_key="database")
+        Resolution: user_input > account_param > config_table > default_value > current_session.
+        """
+        if user_input is not None:
+            return user_input, SOURCE_USER_INPUT
+        if account_param is not None:
+            return account_param, SOURCE_ACCOUNT_PARAM
+        if config_table_val is not None:
+            return config_table_val, SOURCE_CONFIG_TABLE
+        if default_value is not None:
+            return default_value, SOURCE_DEFAULT
+        if current_session is not None:
+            return current_session, SOURCE_CURRENT_SESSION
+        return None, SOURCE_MISSING
 
+    # ── Pre-compute current session values ─────────────────────────────
+    conn = ctx.connection_context
+    session_wh = (
+        getattr(conn, "warehouse", None) or conn_config.get("warehouse") or None
+    )
+    session_db = getattr(conn, "database", None) or conn_config.get("database") or None
+    session_schema = getattr(conn, "schema", None) or conn_config.get("schema") or None
+
+    personal_db = (
+        f"USER${get_env_username().upper()}" if IS_PERSONAL_DB_SUPPORTED else None
+    )
+
+    # ── Resolve each field ────────────────────────────────────────────
     resolved = {
-        "database": database_resolved,
-        "schema": _resolve(None, "schema", conn_key="schema"),
-        "warehouse": _resolve(None, "warehouse", conn_key="warehouse"),
-        "compute_pool": _resolve(compute_pool, "compute_pool"),
-        "build_eai": _resolve(build_eai, "eai"),
+        "database": _resolve(
+            account_param=params.get("database"),
+            config_table_val=config_table.get("database"),
+            default_value=personal_db,
+            current_session=session_db,
+        ),
+        # TODO: Support per-app schema (e.g. APPS.APP_<app_id>) instead of
+        # a single shared schema for all apps.
+        "schema": _resolve(
+            account_param=params.get("schema"),
+            config_table_val=config_table.get("schema"),
+            current_session=session_schema,
+        ),
+        "warehouse": _resolve(
+            account_param=params.get("query_warehouse"),
+            config_table_val=config_table.get("warehouse"),
+            current_session=session_wh,
+        ),
+        # TODO: Consider removing --compute-pool argument once services can run
+        # in the system default compute pool (SYSTEM_COMPUTE_POOL_CPU).
+        "build_compute_pool": _resolve(
+            user_input=compute_pool,
+            account_param=params.get("build_compute_pool"),
+            config_table_val=config_table.get("compute_pool"),
+        ),
+        "service_compute_pool": _resolve(
+            user_input=compute_pool,
+            account_param=params.get("service_compute_pool"),
+            config_table_val=config_table.get("compute_pool"),
+        ),
+        # TODO: Remove --build-eai argument once the builder service no longer
+        # requires an external access integration.
+        "build_eai": _resolve(
+            user_input=build_eai,
+            account_param=params.get("build_eai"),
+            config_table_val=config_table.get("eai"),
+        ),
+        # TODO: Remove image_repository default once the artifact repo path
+        # replaces the image repo path.
+        "image_repository": _resolve(
+            config_table_val=config_table.get("image_repository"),
+            default_value=DEFAULT_IMAGE_REPOSITORY,
+        ),
     }
 
-    img_repo = _resolve(None, "image_repository")
-    if img_repo[0]:
-        resolved["image_repository"] = img_repo
-
-    # Validate: fail on ALL missing required values at once
-    required_keys = ["database", "warehouse", "compute_pool", "build_eai"]
-    missing = [key for key in required_keys if not resolved[key][0]]
-    if missing:
-        flag_map = {
-            "database": "--database",
-            "warehouse": "--warehouse",
-            "compute_pool": "--compute-pool",
-            "build_eai": "--build-eai",
-        }
-        flags = ", ".join(flag_map[k] for k in missing)
+    # ── Validate required values ─────────────────────────────────────
+    # TODO: database, warehouse, and schema cannot be passed as arguments
+    # yet — they must come from account parameters, config table, or the
+    # current session.
+    if not resolved["database"][0]:
         raise ClickException(
-            f"Missing required value(s): {', '.join(missing)}. "
-            f"Pass them using: {flags}"
+            "Missing database. Set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE account parameter or check your connection."
+        )
+    if not resolved["schema"][0]:
+        raise ClickException(
+            "Missing schema. Set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA account parameter or check your connection."
+        )
+    if not resolved["warehouse"][0]:
+        raise ClickException(
+            "Missing warehouse. Set the DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE account parameter or check your connection."
+        )
+    if not resolved["build_compute_pool"][0]:
+        raise ClickException(
+            "Missing build compute pool. Pass --compute-pool or set the DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL account parameter."
+        )
+    if not resolved["service_compute_pool"][0]:
+        raise ClickException(
+            "Missing service compute pool. Pass --compute-pool or set the DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL account parameter."
+        )
+    if not resolved["build_eai"][0]:
+        raise ClickException(
+            "Missing build EAI. Pass --build-eai or set the DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION account parameter."
         )
 
     resolved_values = {k: v[0] for k, v in resolved.items()}

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -26,15 +26,16 @@ def _generate_snowflake_yml(
     """Generate snowflake.yml content from pre-resolved configuration values.
 
     All required keys (``database``, ``schema``, ``warehouse``,
-    ``compute_pool``, ``build_eai``) must be present and non-empty in
-    *resolved*.  The optional key ``image_repository`` is included only
-    when provided.
+    ``build_compute_pool``, ``service_compute_pool``, ``build_eai``) must
+    be present and non-empty in *resolved*.  The optional key
+    ``image_repository`` is included only when provided.
     """
 
     database = resolved["database"]
     schema = resolved["schema"]
     warehouse = resolved["warehouse"]
-    compute_pool = resolved["compute_pool"]
+    build_compute_pool = resolved["build_compute_pool"]
+    service_compute_pool = resolved["service_compute_pool"]
     build_eai = resolved["build_eai"]
     image_repository = resolved.get("image_repository")
 
@@ -73,9 +74,9 @@ def _generate_snowflake_yml(
 
             query_warehouse: {warehouse}
             build_compute_pool:
-              name: {compute_pool}
+              name: {build_compute_pool}
             service_compute_pool:
-              name: {compute_pool}
+              name: {service_compute_pool}
             build_eai:
               name: {build_eai}{repo_lines}
             code_stage:

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, TypeVar
 
+from snowflake.cli._plugins.apps.generate import IS_PERSONAL_DB_SUPPORTED
 from snowflake.cli._plugins.apps.snowflake_app_entity_model import DEFAULT_APP_PORT
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ from snowflake.cli.api.project.project_paths import ProjectPaths
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import DictCursor
+from snowflake.connector.errors import ProgrammingError
 
 log = logging.getLogger(__name__)
 
@@ -46,15 +48,22 @@ SNOWFLAKE_APP_ENTITY_TYPE = "snowflake-app"
 # TODO: Update to "app" after migration from __app
 _APP_COMMAND_NAME = "__app"
 
-# Default resource names for Snowflake Apps
-SNOW_APPS_COMPUTE_POOL = "SNOW_APPS_DEFAULT_COMPUTE_POOL"
-DEFAULT_EXTERNAL_ACCESS = "SNOW_APPS_DEFAULT_EXTERNAL_ACCESS"
 DEFAULT_IMAGE_REPOSITORY = "IMAGE_REPO"
-DEFAULT_IMAGE_REPO_DATABASE = "APPS"
-DEFAULT_IMAGE_REPO_SCHEMA = "PUBLIC"
 
+# TODO: Remove config table once DEFAULT_SNOWFLAKE_APPS_* account parameters
+# are rolled out to production and configurable in Snowsight (week of 2026-04-06).
 APP_DEFAULTS_TABLE = "APPS.PUBLIC.SNOW_APP_DEFAULTS"
 APP_DEFAULTS_INTEGRATION = "snowflake-apps"
+
+# Mapping from SHOW PARAMETERS result names to internal resolution keys.
+_SNOW_APPS_PARAM_MAP = {
+    "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE": "query_warehouse",
+    "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL": "build_compute_pool",
+    "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL": "service_compute_pool",
+    "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION": "build_eai",
+    "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE": "database",
+    "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA": "schema",
+}
 
 _BUILD_IMAGE = "/snowflake/images/snowflake_images/sf-image-build:0.0.1"
 _SERVICE_PLACEHOLDER_IMAGE = "/snowflake/images/snowflake_images/sf-image-build:0.0.1"
@@ -127,47 +136,17 @@ def _object_exists(object_type: str, name: str) -> bool:
         return False
 
 
-def _get_compute_pool() -> Optional[str]:
-    """
-    Get the compute pool to use for Snowflake Apps.
-
-    Returns SNOW_APPS_DEFAULT_COMPUTE_POOL if it exists, otherwise None.
-    """
-    if _object_exists("compute-pool", SNOW_APPS_COMPUTE_POOL):
-        return SNOW_APPS_COMPUTE_POOL
-    return None
-
-
-def _get_external_access(app_id: str) -> Optional[str]:
-    """
-    Get the external access integration to use for Snow Apps.
-
-    Checks in order:
-    1. SNOW_APPS_DEFAULT_EXTERNAL_ACCESS
-    2. SNOW_APPS_<APP_ID>_EXTERNAL_ACCESS
-
-    Returns None if neither exists.
-    """
-    if _object_exists("external-access-integration", DEFAULT_EXTERNAL_ACCESS):
-        return DEFAULT_EXTERNAL_ACCESS
-
-    app_specific_eai = f"SNOW_APPS_{app_id.upper()}_EXTERNAL_ACCESS"
-    if _object_exists("external-access-integration", app_specific_eai):
-        return app_specific_eai
-
-    return None
-
-
 def _resolve_deploy_defaults(
     entity: "SnowflakeAppEntityModel",
     manager: "SnowflakeAppManager",
 ) -> Dict[str, Optional[str]]:
-    """Resolve deploy defaults using a four-tier precedence:
+    """Resolve deploy defaults using a five-tier precedence:
 
     1. Values explicitly set in ``snowflake.yml`` (highest priority)
-    2. Values from the current connection context
+    2. SnowApps parameters (``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``)
     3. Values from the ``APP_DEFAULTS_TABLE`` config table
-    4. Built-in defaults (object-existence checks, lowest priority)
+    4. Built-in defaults (personal DB for database, IMAGE_REPO for image repository)
+    5. Current session values (lowest priority)
 
     Returns a dict with keys ``query_warehouse``, ``build_compute_pool``,
     ``service_compute_pool``, ``build_eai``, ``image_repository``,
@@ -178,7 +157,6 @@ def _resolve_deploy_defaults(
 
     # ── 1. snowflake.yml values ───────────────────────────────────────
     fqn = entity.fqn
-    app_name = fqn.name
     yml_vals: Dict[str, Optional[str]] = {
         "query_warehouse": entity.query_warehouse,
         "build_compute_pool": (
@@ -201,17 +179,18 @@ def _resolve_deploy_defaults(
         "schema": fqn.schema,
     }
 
-    # ── 2. Current connection values ──────────────────────────────────
-    ctx = get_cli_context()
-    conn = ctx.connection_context
-    conn_vals: Dict[str, Optional[str]] = {
-        "query_warehouse": conn.warehouse,
-        "database": conn.database,
-        "schema": conn.schema,
-    }
+    # ── 2. SnowApps parameters (user-level) ──────────────────────────
+    param_vals: Dict[str, Optional[str]] = {}
+    raw_params = manager.fetch_snow_apps_parameters()
+    if raw_params:
+        cli_console.step(
+            "Loaded SnowApps parameters: "
+            + ", ".join(f"{k}={v}" for k, v in raw_params.items())
+        )
+        param_vals = dict(raw_params)
 
     # ── 3. Config-table values ────────────────────────────────────────
-    table_vals: Dict[str, Optional[str]] = {}
+    config_table_vals: Dict[str, Optional[str]] = {}
     role = manager.current_role()
     if role:
         raw = manager.fetch_config_table_defaults(role)
@@ -220,7 +199,7 @@ def _resolve_deploy_defaults(
                 f"Loaded config-table defaults for role {role}: "
                 + ", ".join(f"{k}={v}" for k, v in raw.items())
             )
-        table_vals = {
+        config_table_vals = {
             "query_warehouse": raw.get("warehouse"),
             "build_compute_pool": raw.get("compute_pool"),
             "service_compute_pool": raw.get("compute_pool"),
@@ -232,19 +211,41 @@ def _resolve_deploy_defaults(
             "schema": raw.get("schema"),
         }
 
-    # ── 4. Built-in defaults ──────────────────────────────────────────
-    builtin_vals: Dict[str, Optional[str]] = {
-        "build_compute_pool": _get_compute_pool(),
-        "service_compute_pool": _get_compute_pool(),
-        "build_eai": _get_external_access(app_name),
+    # ── 4. Built-in defaults ────────────────────────────────────────────
+    from snowflake.cli.api.project.util import get_env_username
+
+    default_vals: Dict[str, Optional[str]] = {
         "image_repository": DEFAULT_IMAGE_REPOSITORY,
+    }
+    if IS_PERSONAL_DB_SUPPORTED:
+        default_vals["database"] = f"USER${get_env_username().upper()}"
+
+    # ── 5. Current session values ─────────────────────────────────────
+    ctx = get_cli_context()
+    conn = ctx.connection_context
+    curr_session_vals: Dict[str, Optional[str]] = {
+        "query_warehouse": conn.warehouse,
+        "database": conn.database,
+        "schema": conn.schema,
     }
 
     # ── Merge (first non-None wins) ──────────────────────────────────
-    all_keys = set(yml_vals) | set(conn_vals) | set(table_vals) | set(builtin_vals)
+    all_keys = (
+        set(yml_vals)
+        | set(param_vals)
+        | set(config_table_vals)
+        | set(default_vals)
+        | set(curr_session_vals)
+    )
     resolved: Dict[str, Optional[str]] = {}
     for key in all_keys:
-        for source in (yml_vals, conn_vals, table_vals, builtin_vals):
+        for source in (
+            yml_vals,
+            param_vals,
+            config_table_vals,
+            default_vals,
+            curr_session_vals,
+        ):
             val = source.get(key)
             if val is not None:
                 resolved[key] = val
@@ -252,13 +253,11 @@ def _resolve_deploy_defaults(
         else:
             resolved[key] = None
 
-    # Default image repo lives in TEMP.APPS; user-specified repos without
-    # explicit db/schema will fall back to the entity db/schema in the caller.
-    if resolved["image_repository"] == DEFAULT_IMAGE_REPOSITORY:
-        if not resolved.get("image_repo_database"):
-            resolved["image_repo_database"] = DEFAULT_IMAGE_REPO_DATABASE
-        if not resolved.get("image_repo_schema"):
-            resolved["image_repo_schema"] = DEFAULT_IMAGE_REPO_SCHEMA
+    # Image repo db/schema default to the resolved database/schema.
+    if not resolved.get("image_repo_database"):
+        resolved["image_repo_database"] = resolved.get("database")
+    if not resolved.get("image_repo_schema"):
+        resolved["image_repo_schema"] = resolved.get("schema")
 
     return resolved
 
@@ -715,6 +714,36 @@ class SnowflakeAppManager(SqlExecutionMixin):
                 return url
         return None
 
+    def fetch_snow_apps_parameters(self) -> Dict[str, str]:
+        """Fetch SnowApps default parameters for the current user.
+
+        Runs ``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``
+        and returns a dict whose keys match the internal resolution names
+        (``query_warehouse``, ``build_compute_pool``, etc.).
+
+        Empty-string parameter values are treated as "not set" and omitted.
+        Returns an empty dict on any error (e.g. insufficient privileges).
+        """
+        try:
+            cursor = self.execute_query(
+                "SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER",
+                cursor_class=DictCursor,
+            )
+            result: Dict[str, str] = {}
+            for row in cursor:
+                param_name = (row.get("key") or row.get("KEY") or "").upper()
+                param_value = row.get("value") or row.get("VALUE") or ""
+                mapped_key = _SNOW_APPS_PARAM_MAP.get(param_name)
+                if mapped_key and param_value:
+                    result[mapped_key] = param_value
+            return result
+        except ProgrammingError:
+            log.warning(
+                "Could not fetch SnowApps user parameters – skipping.",
+                exc_info=True,
+            )
+            return {}
+
     def fetch_config_table_defaults(
         self, role: str, integration: str = APP_DEFAULTS_INTEGRATION
     ) -> Dict[str, str]:
@@ -749,7 +778,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
             if not isinstance(defaults, dict):
                 return {}
 
-            return {k: str(v) for k, v in defaults.items() if v is not None}
+            return {k: str(v) for k, v in defaults.items() if v is not None and v != ""}
         except Exception:
             log.debug(
                 "Could not read %s (table may not "

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -21,9 +21,7 @@ from snowflake.cli._plugins.apps.generate import (
 from snowflake.cli._plugins.apps.manager import (
     SNOWFLAKE_APP_ENTITY_TYPE,
     SnowflakeAppManager,
-    _get_compute_pool,
     _get_entity,
-    _get_external_access,
     _get_snowflake_app_entities,
     _object_exists,
     _poll_until,
@@ -42,6 +40,10 @@ EXECUTE_QUERY = "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.execute
 OBJECT_EXISTS = "snowflake.cli._plugins.apps.manager._object_exists"
 GET_CLI_CONTEXT = "snowflake.cli._plugins.apps.manager.get_cli_context"
 GET_ENV_USERNAME = "snowflake.cli._plugins.apps.commands.get_env_username"
+FETCH_SNOW_APPS_PARAMS = (
+    "snowflake.cli._plugins.apps.manager.SnowflakeAppManager"
+    ".fetch_snow_apps_parameters"
+)
 
 
 # ── Feature flag tests ────────────────────────────────────────────────
@@ -75,40 +77,6 @@ class TestObjectExists:
     def test_returns_false_on_exception(self, mock_object_manager):
         mock_object_manager().object_exists.side_effect = Exception("error")
         assert _object_exists("compute-pool", "MY_POOL") is False
-
-
-class TestGetComputePool:
-    @patch(OBJECT_EXISTS)
-    def test_returns_default_pool_when_exists(self, mock_exists):
-        mock_exists.return_value = True
-        result = _get_compute_pool()
-        assert result == "SNOW_APPS_DEFAULT_COMPUTE_POOL"
-
-    @patch(OBJECT_EXISTS)
-    def test_returns_none_when_no_pool_exists(self, mock_exists):
-        mock_exists.return_value = False
-        result = _get_compute_pool()
-        assert result is None
-
-
-class TestGetExternalAccess:
-    @patch(OBJECT_EXISTS)
-    def test_returns_default_eai_when_exists(self, mock_exists):
-        mock_exists.return_value = True
-        result = _get_external_access("my_app")
-        assert result == "SNOW_APPS_DEFAULT_EXTERNAL_ACCESS"
-
-    @patch(OBJECT_EXISTS)
-    def test_returns_app_specific_eai_when_default_not_found(self, mock_exists):
-        mock_exists.side_effect = [False, True]
-        result = _get_external_access("my_app")
-        assert result == "SNOW_APPS_MY_APP_EXTERNAL_ACCESS"
-
-    @patch(OBJECT_EXISTS)
-    def test_returns_none_when_no_eai_exists(self, mock_exists):
-        mock_exists.return_value = False
-        result = _get_external_access("my_app")
-        assert result is None
 
 
 class TestGetSnowflakeAppEntities:
@@ -342,7 +310,8 @@ class TestGenerateSnowflakeYml:
         "database": "TEST_DB",
         "schema": "SNOW_APPS",
         "warehouse": "TEST_WH",
-        "compute_pool": "MY_POOL",
+        "build_compute_pool": "MY_POOL",
+        "service_compute_pool": "MY_POOL",
         "build_eai": "MY_EAI",
     }
 
@@ -1213,6 +1182,113 @@ class TestFetchConfigTableDefaults:
         assert "'ENGINEER'" in query
 
 
+# ── fetch_snow_apps_parameters tests ──────────────────────────────────
+
+
+class TestFetchSnowAppsParameters:
+    @patch(EXECUTE_QUERY)
+    def test_returns_mapped_parameters(self, mock_execute):
+        cursor = Mock()
+        cursor.__iter__ = Mock(
+            return_value=iter(
+                [
+                    {"key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "value": "MY_WH"},
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
+                        "value": "MY_POOL",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL",
+                        "value": "SVC_POOL",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION",
+                        "value": "MY_EAI",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE",
+                        "value": "MY_DB",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA",
+                        "value": "MY_SCHEMA",
+                    },
+                ]
+            )
+        )
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {
+            "query_warehouse": "MY_WH",
+            "build_compute_pool": "MY_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "MY_DB",
+            "schema": "MY_SCHEMA",
+        }
+        query = mock_execute.call_args[0][0]
+        assert "SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER" in query
+
+    @patch(EXECUTE_QUERY)
+    def test_ignores_empty_string_values(self, mock_execute):
+        cursor = Mock()
+        cursor.__iter__ = Mock(
+            return_value=iter(
+                [
+                    {"key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "value": "MY_WH"},
+                    {"key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL", "value": ""},
+                ]
+            )
+        )
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {"query_warehouse": "MY_WH"}
+        assert "build_compute_pool" not in result
+
+    @patch(EXECUTE_QUERY)
+    def test_ignores_unknown_parameters(self, mock_execute):
+        cursor = Mock()
+        cursor.__iter__ = Mock(
+            return_value=iter(
+                [
+                    {"key": "DEFAULT_SNOWFLAKE_APPS_UNKNOWN_PARAM", "value": "FOO"},
+                    {"key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "value": "MY_WH"},
+                ]
+            )
+        )
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {"query_warehouse": "MY_WH"}
+
+    @patch(
+        EXECUTE_QUERY,
+        side_effect=ProgrammingError("permission denied"),
+    )
+    def test_returns_empty_dict_on_error(self, mock_execute):
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {}
+
+    @patch(EXECUTE_QUERY)
+    def test_returns_empty_dict_when_no_params_set(self, mock_execute):
+        cursor = Mock()
+        cursor.__iter__ = Mock(return_value=iter([]))
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {}
+
+    @patch(EXECUTE_QUERY)
+    def test_handles_uppercase_column_names(self, mock_execute):
+        cursor = Mock()
+        cursor.__iter__ = Mock(
+            return_value=iter(
+                [{"KEY": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "VALUE": "MY_WH"}]
+            )
+        )
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {"query_warehouse": "MY_WH"}
+
+
 # ── _resolve_deploy_defaults tests ────────────────────────────────────
 
 
@@ -1264,12 +1340,12 @@ class TestResolveDeployDefaults:
             entity.build_eai.name = build_eai
         return entity
 
-    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(FETCH_CONFIG_DEFAULTS, return_value={})
     @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
     def test_yml_values_take_precedence(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
+        self, mock_ctx, mock_role, mock_fetch, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
@@ -1285,7 +1361,7 @@ class TestResolveDeployDefaults:
         assert result["service_compute_pool"] == "YML_SVC_POOL"
         assert result["build_eai"] == "YML_EAI"
 
-    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(
         FETCH_CONFIG_DEFAULTS,
         return_value={
@@ -1299,7 +1375,7 @@ class TestResolveDeployDefaults:
     @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
     def test_config_table_fills_gaps(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
+        self, mock_ctx, mock_role, mock_fetch, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
@@ -1312,30 +1388,70 @@ class TestResolveDeployDefaults:
         assert result["database"] == "TABLE_DB"
         assert result["schema"] == "TABLE_SCHEMA"
 
-    @patch(OBJECT_EXISTS, return_value=True)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            "build_eai": "PARAM_EAI",
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+        },
+    )
     @patch(FETCH_CONFIG_DEFAULTS, return_value={})
     @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    def test_builtin_defaults_fill_remaining_gaps(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
-    ):
+    def test_parameters_fill_gaps(self, mock_ctx, mock_role, mock_fetch, mock_params):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
-        entity = self._make_entity()
+        entity = self._make_entity(database=None, schema=None)
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
-        assert result["build_compute_pool"] == "SNOW_APPS_DEFAULT_COMPUTE_POOL"
-        assert result["service_compute_pool"] == "SNOW_APPS_DEFAULT_COMPUTE_POOL"
-        assert result["build_eai"] == "SNOW_APPS_DEFAULT_EXTERNAL_ACCESS"
+        assert result["query_warehouse"] == "PARAM_WH"
+        assert result["build_compute_pool"] == "PARAM_POOL"
+        assert result["service_compute_pool"] == "PARAM_SVC_POOL"
+        assert result["build_eai"] == "PARAM_EAI"
+        assert result["database"] == "PARAM_DB"
+        assert result["schema"] == "PARAM_SCHEMA"
 
-    @patch(OBJECT_EXISTS, return_value=True)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            "build_eai": "PARAM_EAI",
+        },
+    )
     @patch(
         FETCH_CONFIG_DEFAULTS,
         return_value={"compute_pool": "TABLE_POOL", "warehouse": "TABLE_WH"},
     )
     @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    def test_yml_beats_conn_beats_table_beats_builtin(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
+    def test_parameters_beat_config_table(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity()
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        assert result["query_warehouse"] == "PARAM_WH"
+        assert result["build_compute_pool"] == "PARAM_POOL"
+        assert result["build_eai"] == "PARAM_EAI"
+
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={"query_warehouse": "PARAM_WH", "build_eai": "PARAM_EAI"},
+    )
+    @patch(
+        FETCH_CONFIG_DEFAULTS,
+        return_value={"compute_pool": "TABLE_POOL", "warehouse": "TABLE_WH"},
+    )
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    def test_yml_beats_params_beats_table_beats_session(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
@@ -1343,17 +1459,16 @@ class TestResolveDeployDefaults:
             query_warehouse="YML_WH",
         )
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
-        assert result["query_warehouse"] == "YML_WH"
-        assert result["build_compute_pool"] == "TABLE_POOL"
-        assert result["service_compute_pool"] == "TABLE_POOL"
-        assert result["build_eai"] == "SNOW_APPS_DEFAULT_EXTERNAL_ACCESS"
+        assert result["query_warehouse"] == "YML_WH"  # yml wins over param
+        assert result["build_compute_pool"] == "TABLE_POOL"  # table fills gap
+        assert result["build_eai"] == "PARAM_EAI"  # param wins over missing table
 
-    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(FETCH_CONFIG_DEFAULTS, return_value={})
     @patch(CURRENT_ROLE, return_value=None)
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
     def test_no_role_skips_config_table(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
+        self, mock_ctx, mock_role, mock_fetch, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
@@ -1362,12 +1477,12 @@ class TestResolveDeployDefaults:
         mock_fetch.assert_not_called()
         assert result["query_warehouse"] is None
 
-    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(FETCH_CONFIG_DEFAULTS, return_value={})
     @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
     def test_preserves_yml_database_and_schema(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
+        self, mock_ctx, mock_role, mock_fetch, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
@@ -1376,7 +1491,7 @@ class TestResolveDeployDefaults:
         assert result["database"] == "MY_DB"
         assert result["schema"] == "MY_SCHEMA"
 
-    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(FETCH_CONFIG_DEFAULTS, return_value={})
     @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(
@@ -1385,8 +1500,8 @@ class TestResolveDeployDefaults:
             warehouse="CONN_WH", database="CONN_DB", schema="CONN_SCHEMA"
         ),
     )
-    def test_connection_fills_gaps_before_table(
-        self, mock_ctx, mock_role, mock_fetch, mock_exists
+    def test_session_fills_gaps_after_params_and_table(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
@@ -1396,7 +1511,10 @@ class TestResolveDeployDefaults:
         assert result["database"] == "CONN_DB"
         assert result["schema"] == "CONN_SCHEMA"
 
-    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={"query_warehouse": "PARAM_WH", "database": "PARAM_DB"},
+    )
     @patch(
         FETCH_CONFIG_DEFAULTS,
         return_value={"warehouse": "TABLE_WH", "database": "TABLE_DB"},
@@ -1406,13 +1524,30 @@ class TestResolveDeployDefaults:
         GET_CLI_CONTEXT,
         return_value=_mock_connection_context(warehouse="CONN_WH"),
     )
-    def test_connection_beats_table(self, mock_ctx, mock_role, mock_fetch, mock_exists):
+    def test_params_beat_table_beat_session(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
+    ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(database=None, schema=None)
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
-        assert result["query_warehouse"] == "CONN_WH"
-        assert result["database"] == "TABLE_DB"
+        assert result["query_warehouse"] == "PARAM_WH"  # param beats table and session
+        assert result["database"] == "PARAM_DB"  # param beats table
+
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
+    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    def test_returns_none_when_no_source_provides_value(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity()
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        assert result["build_compute_pool"] is None
+        assert result["service_compute_pool"] is None
+        assert result["build_eai"] is None
 
 
 # ── CLI command tests ─────────────────────────────────────────────────
@@ -1427,6 +1562,7 @@ class TestSetupCommand:
     def test_init_creates_file(self, mock_mgr_cls, mock_gen, runner, tmp_path):
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
         mock_mgr.fetch_config_table_defaults.return_value = {
             "database": "CFG_DB",
             "warehouse": "CFG_WH",
@@ -1447,7 +1583,7 @@ class TestSetupCommand:
         resolved = mock_gen.call_args[0][1]
         assert resolved["database"] == "CFG_DB"
         assert resolved["warehouse"] == "CFG_WH"
-        assert resolved["compute_pool"] == "CFG_POOL"
+        assert resolved["build_compute_pool"] == "CFG_POOL"
         assert resolved["build_eai"] == "CFG_EAI"
 
     @patch(
@@ -1461,6 +1597,7 @@ class TestSetupCommand:
         """Config table values should have higher priority than connection values."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
         mock_mgr.fetch_config_table_defaults.return_value = {
             "database": "CFG_DB",
             "warehouse": "CFG_WH",
@@ -1489,6 +1626,7 @@ class TestSetupCommand:
     ):
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = None
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
 
@@ -1519,10 +1657,16 @@ class TestSetupCommand:
                 assert "already exists" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_fails_on_all_missing_values(self, mock_mgr_cls, runner, tmp_path):
-        """Validation should report ALL missing values, not just the first."""
+    def test_fails_on_missing_compute_pool(self, mock_mgr_cls, runner, tmp_path):
+        """Setup should fail when compute pool cannot be resolved."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.current_role.return_value = None
+        mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "query_warehouse": "PARAM_WH",
+            "build_eai": "PARAM_EAI",
+        }
+        mock_mgr.fetch_config_table_defaults.return_value = {}
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
             from tests_common import change_directory
@@ -1530,13 +1674,34 @@ class TestSetupCommand:
             with change_directory(tmp_path):
                 result = runner.invoke(["__app", "setup", "--app-name", "my_app"])
                 assert result.exit_code == 1
-                assert "compute_pool" in result.output
-                assert "build_eai" in result.output
+                assert "--compute-pool" in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_fails_on_missing_build_eai(self, mock_mgr_cls, runner, tmp_path):
+        """Setup should fail when build EAI cannot be resolved."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_POOL",
+        }
+        mock_mgr.fetch_config_table_defaults.return_value = {}
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "setup", "--app-name", "my_app"])
+                assert result.exit_code == 1
+                assert "--build-eai" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_dry_run_does_not_create_file(self, mock_mgr_cls, runner, tmp_path):
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
         mock_mgr.fetch_config_table_defaults.return_value = {
             "database": "CFG_DB",
             "warehouse": "CFG_WH",
@@ -1562,6 +1727,7 @@ class TestSetupCommand:
 
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
         mock_mgr.fetch_config_table_defaults.return_value = {
             "database": "CFG_DB",
             "warehouse": "CFG_WH",
@@ -1589,7 +1755,7 @@ class TestSetupCommand:
                 assert parsed["success"] is False
                 assert parsed["database"] == "CFG_DB"
                 assert parsed["warehouse"] == "CFG_WH"
-                assert parsed["compute_pool"] == "CFG_POOL"
+                assert parsed["build_compute_pool"] == "CFG_POOL"
                 assert parsed["build_eai"] == "CFG_EAI"
 
     @patch(
@@ -1604,6 +1770,7 @@ class TestSetupCommand:
 
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
         mock_mgr.fetch_config_table_defaults.return_value = {
             "database": "CFG_DB",
             "warehouse": "CFG_WH",
@@ -1641,6 +1808,7 @@ class TestSetupCommand:
     ):
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
         mock_mgr.fetch_config_table_defaults.return_value = {
             "database": "CFG_DB",
             "warehouse": "CFG_WH",
@@ -1656,7 +1824,116 @@ class TestSetupCommand:
                 assert result.exit_code == 0, result.output
                 assert "database: CFG_DB" in result.output
                 assert "warehouse: CFG_WH" in result.output
-                assert "compute_pool: CFG_POOL" in result.output
+                assert "build_compute_pool: CFG_POOL" in result.output
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_parameters_beat_config_table(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """SnowApps parameters should override config table values."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            "build_eai": "PARAM_EAI",
+            "database": "PARAM_DB",
+        }
+        mock_mgr.fetch_config_table_defaults.return_value = {
+            "database": "CFG_DB",
+            "warehouse": "CFG_WH",
+            "compute_pool": "CFG_POOL",
+            "eai": "CFG_EAI",
+        }
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "setup", "--app-name", "my_app"])
+                assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["database"] == "PARAM_DB"
+        assert resolved["warehouse"] == "PARAM_WH"
+        assert resolved["build_compute_pool"] == "PARAM_POOL"
+        assert resolved["build_eai"] == "PARAM_EAI"
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_flags_beat_parameters(self, mock_mgr_cls, mock_gen, runner, tmp_path):
+        """CLI flags should override SnowApps parameters."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            "build_eai": "PARAM_EAI",
+            "database": "PARAM_DB",
+            "query_warehouse": "PARAM_WH",
+        }
+        mock_mgr.fetch_config_table_defaults.return_value = {}
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(
+                    [
+                        "__app",
+                        "setup",
+                        "--app-name",
+                        "my_app",
+                        "--compute-pool",
+                        "FLAG_POOL",
+                        "--build-eai",
+                        "FLAG_EAI",
+                    ]
+                )
+                assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["build_compute_pool"] == "FLAG_POOL"
+        assert resolved["build_eai"] == "FLAG_EAI"
+        # These come from params since no flag overrides them
+        assert resolved["database"] == "PARAM_DB"
+        assert resolved["warehouse"] == "PARAM_WH"
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_setup_shows_parameter_provenance(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """Resolved values from SnowApps parameters should show 'account parameter' provenance."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.current_role.return_value = "TEST_ROLE"
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            "build_eai": "PARAM_EAI",
+            "database": "PARAM_DB",
+        }
+        mock_mgr.fetch_config_table_defaults.return_value = {}
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            from tests_common import change_directory
+
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "setup", "--app-name", "my_app"])
+                assert result.exit_code == 0, result.output
+                assert "account parameter" in result.output
 
 
 # ── perform_bundle tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Read `DEFAULT_SNOWFLAKE_APPS_*` parameters via `SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER`
- New precedence: **snowflake.yml > SnowApps parameters > config table > defaults > current session**
- **Breaking change**: config table now wins over current session values (intentional — explicit admin config should override session)
- **Breaking change (intentional)**: `IMAGE_REPO` is now assumed under `<resolved-db>.<resolved-schema>` instead of the previously hardcoded `APPS.PUBLIC`. This means if a user's resolved database is e.g. `USER$JOHN_DOE`, the image repo will be `USER$JOHN_DOE.<schema>.IMAGE_REPO`. This is intended — apps should use an image repo co-located with the app, not a shared `APPS.PUBLIC` location.
- Add `fetch_snow_apps_parameters()` to `SnowflakeAppManager`
- Remove hardcoded defaults (`_get_compute_pool`, `_get_external_access`)
- Resolve build and service compute pools separately (account parameters can differ)
- Provenance labels in `--dry-run`: `user input`, `account parameter`, `config table`, `default`, `current session`

## Test plan
- [x] All 174 unit tests pass
- [x] Tests for `fetch_snow_apps_parameters()`, precedence ordering, setup validation
- [x] Manually tested on Snowhouse with account parameters set

Companion skill PR: https://github.com/snowflake-eng/cortex-code-skills/pull/1318
Previous review on apps-dev: https://github.com/snowflakedb/snowflake-cli/pull/2856

🤖 Generated with [Claude Code](https://claude.com/claude-code)