### PR TITLE
SNOW-2422874 Add snow connection generate-workload-identity-token command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@
 ## Deprecations
 
 ## New additions
+* Added `snow connection generate-workload-identity-token` command to generate a workload identity token for the current environment. Supports AWS, GCP, Azure, and OIDC providers via `--workload-identity-provider` flag or connection configuration.
 * Added `snow custom-image validate` command to validate custom Docker images against configured rules (entrypoint, environment variables, Python packages, dependency health). Supports an optional `--scan-vulnerabilities` flag to run Grype vulnerability scanning.
 
 ## Fixes and improvements

--- a/src/snowflake/cli/_app/loggers.py
+++ b/src/snowflake/cli/_app/loggers.py
@@ -44,7 +44,7 @@ class LoggerConfig:
 @dataclass
 class DefaultLoggingConfig:
     version: int = 1
-    disable_existing_loggers: bool = True
+    disable_existing_loggers: bool = False
     formatters: Dict[str, LogFormatterConfig] = field(
         default_factory=lambda: {
             "default_formatter": LogFormatterConfig(

--- a/src/snowflake/cli/_app/loggers.py
+++ b/src/snowflake/cli/_app/loggers.py
@@ -44,7 +44,7 @@ class LoggerConfig:
 @dataclass
 class DefaultLoggingConfig:
     version: int = 1
-    disable_existing_loggers: bool = False
+    disable_existing_loggers: bool = True
     formatters: Dict[str, LogFormatterConfig] = field(
         default_factory=lambda: {
             "default_formatter": LogFormatterConfig(

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -466,7 +466,7 @@ def generate_jwt(
 def generate_workload_identity_token(
     **options,
 ) -> CommandResult:
-    """Generate a workload identity token for authenticating to Snowflake via a WIF provider (AWS, GCP, Azure, or OIDC). The token is printed to stdout."""
+    """Generate a workload identity token for authenticating to Snowflake via a Workload Identity Federation (WIF) provider (AWS, AZURE, GCP, or OIDC). The token is printed to stdout."""
     from snowflake.connector.wif_util import AttestationProvider, create_attestation
 
     connection_details = get_cli_context().connection_context.update_from_config()
@@ -502,5 +502,5 @@ def generate_workload_identity_token(
         return MessageResult(attestation.credential)
     except (UsageError, ClickException):
         raise
-    except (ValueError, TypeError) as err:
+    except (ValueError, TypeError, ProgrammingError) as err:
         raise ClickException(str(err))

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -64,13 +64,14 @@ from snowflake.cli.api.config import (
 )
 from snowflake.cli.api.config_ng.masking import mask_sensitive_value
 from snowflake.cli.api.console import cli_console
-from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB, ObjectType
 from snowflake.cli.api.output.types import (
     CollectionResult,
     CommandResult,
     MessageResult,
     ObjectResult,
 )
+from snowflake.cli.api.secure_path import SecurePath
 from snowflake.connector import ProgrammingError
 from snowflake.connector.constants import CONNECTIONS_FILE
 
@@ -465,7 +466,7 @@ def generate_jwt(
 def generate_workload_identity_token(
     **options,
 ) -> CommandResult:
-    """Generate a workload identity token, which will be printed out and displayed."""
+    """Generate a workload identity token for authenticating to Snowflake via a WIF provider (AWS, GCP, Azure, or OIDC). The token is printed to stdout."""
     from snowflake.connector.wif_util import AttestationProvider, create_attestation
 
     connection_details = get_cli_context().connection_context.update_from_config()
@@ -476,19 +477,30 @@ def generate_workload_identity_token(
             "but required for workload identity token generation."
         )
 
-    provider = AttestationProvider.from_string(
-        connection_details.workload_identity_provider
-    )
-
-    token = None
-    if provider == AttestationProvider.OIDC:
-        if connection_details.token:
-            token = connection_details.token
-        elif connection_details.token_file_path:
-            token = Path(connection_details.token_file_path).read_text().strip()
-
     try:
+        provider = AttestationProvider.from_string(
+            connection_details.workload_identity_provider
+        )
+
+        token = None
+        if provider == AttestationProvider.OIDC:
+            if connection_details.token:
+                token = connection_details.token
+            elif connection_details.token_file_path:
+                token = (
+                    SecurePath(connection_details.token_file_path)
+                    .read_text(file_size_limit_mb=DEFAULT_SIZE_LIMIT_MB)
+                    .strip()
+                )
+            else:
+                raise UsageError(
+                    "OIDC provider requires a token. "
+                    "Set --token-file-path or configure 'token' in the connection."
+                )
+
         attestation = create_attestation(provider=provider, token=token)
         return MessageResult(attestation.credential)
-    except Exception as err:
+    except (UsageError, ClickException):
+        raise
+    except (ValueError, TypeError) as err:
         raise ClickException(str(err))

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -459,3 +459,36 @@ def generate_jwt(
         return MessageResult(token)
     except (ValueError, TypeError) as err:
         raise ClickException(str(err))
+
+
+@app.command(requires_connection=True)
+def generate_workload_identity_token(
+    **options,
+) -> CommandResult:
+    """Generate a workload identity token, which will be printed out and displayed."""
+    from snowflake.connector.wif_util import AttestationProvider, create_attestation
+
+    connection_details = get_cli_context().connection_context.update_from_config()
+
+    if not connection_details.workload_identity_provider:
+        raise UsageError(
+            "Workload identity provider is not set in the connection context, "
+            "but required for workload identity token generation."
+        )
+
+    provider = AttestationProvider.from_string(
+        connection_details.workload_identity_provider
+    )
+
+    token = None
+    if provider == AttestationProvider.OIDC:
+        if connection_details.token:
+            token = connection_details.token
+        elif connection_details.token_file_path:
+            token = Path(connection_details.token_file_path).read_text().strip()
+
+    try:
+        attestation = create_attestation(provider=provider, token=token)
+        return MessageResult(attestation.credential)
+    except Exception as err:
+        raise ClickException(str(err))

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5054,7 +5054,8 @@
                                                                                   
    Usage: root connection generate-workload-identity-token [OPTIONS]              
                                                                                   
-   Generate a workload identity token, which will be printed out and displayed.   
+   Generate a workload identity token for authenticating to Snowflake via a WIF   
+   provider (AWS, GCP, Azure, or OIDC). The token is printed to stdout.           
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |
@@ -5468,8 +5469,10 @@
   | add                                Adds a connection to configuration file.  |
   | generate-jwt                       Generate a JWT token, which will be       |
   |                                    printed out and displayed..               |
-  | generate-workload-identity-token   Generate a workload identity token, which |
-  |                                    will be printed out and displayed.        |
+  | generate-workload-identity-token   Generate a workload identity token for    |
+  |                                    authenticating to Snowflake via a WIF     |
+  |                                    provider (AWS, GCP, Azure, or OIDC). The  |
+  |                                    token is printed to stdout.               |
   | list                               Lists configured connections.             |
   | remove                             Removes a connection from configuration   |
   |                                    file.                                     |
@@ -23988,8 +23991,10 @@
   | add                                Adds a connection to configuration file.  |
   | generate-jwt                       Generate a JWT token, which will be       |
   |                                    printed out and displayed..               |
-  | generate-workload-identity-token   Generate a workload identity token, which |
-  |                                    will be printed out and displayed.        |
+  | generate-workload-identity-token   Generate a workload identity token for    |
+  |                                    authenticating to Snowflake via a WIF     |
+  |                                    provider (AWS, GCP, Azure, or OIDC). The  |
+  |                                    token is printed to stdout.               |
   | list                               Lists configured connections.             |
   | remove                             Removes a connection from configuration   |
   |                                    file.                                     |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5054,8 +5054,9 @@
                                                                                   
    Usage: root connection generate-workload-identity-token [OPTIONS]              
                                                                                   
-   Generate a workload identity token for authenticating to Snowflake via a WIF   
-   provider (AWS, GCP, Azure, or OIDC). The token is printed to stdout.           
+   Generate a workload identity token for authenticating to Snowflake via a       
+   Workload Identity Federation (WIF) provider (AWS, AZURE, GCP, or OIDC). The    
+   token is printed to stdout.                                                    
                                                                                   
   +- Options --------------------------------------------------------------------+
   | --help  -h        Show this message and exit.                                |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5471,8 +5471,9 @@
   | generate-jwt                       Generate a JWT token, which will be       |
   |                                    printed out and displayed..               |
   | generate-workload-identity-token   Generate a workload identity token for    |
-  |                                    authenticating to Snowflake via a WIF     |
-  |                                    provider (AWS, GCP, Azure, or OIDC). The  |
+  |                                    authenticating to Snowflake via a         |
+  |                                    Workload Identity Federation (WIF)        |
+  |                                    provider (AWS, AZURE, GCP, or OIDC). The  |
   |                                    token is printed to stdout.               |
   | list                               Lists configured connections.             |
   | remove                             Removes a connection from configuration   |
@@ -23993,8 +23994,9 @@
   | generate-jwt                       Generate a JWT token, which will be       |
   |                                    printed out and displayed..               |
   | generate-workload-identity-token   Generate a workload identity token for    |
-  |                                    authenticating to Snowflake via a WIF     |
-  |                                    provider (AWS, GCP, Azure, or OIDC). The  |
+  |                                    authenticating to Snowflake via a         |
+  |                                    Workload Identity Federation (WIF)        |
+  |                                    provider (AWS, AZURE, GCP, or OIDC). The  |
   |                                    token is printed to stdout.               |
   | list                               Lists configured connections.             |
   | remove                             Removes a connection from configuration   |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5049,6 +5049,141 @@
   
   '''
 # ---
+# name: test_help_messages[connection.generate-workload-identity-token]
+  '''
+                                                                                  
+   Usage: root connection generate-workload-identity-token [OPTIONS]              
+                                                                                  
+   Generate a workload identity token, which will be printed out and displayed.   
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --help  -h        Show this message and exit.                                |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment    -c      TEXT     Name of the connection, as    |
+  |                                                defined in your config.toml   |
+  |                                                file. Default: default.       |
+  | --host                                TEXT     Host address for the          |
+  |                                                connection. Overrides the     |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --account,--accountname               TEXT     Name assigned to your         |
+  |                                                Snowflake account. Overrides  |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --user,--username                     TEXT     Username to connect to        |
+  |                                                Snowflake. Overrides the      |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --password                            TEXT     Snowflake password. Overrides |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --authenticator                       TEXT     Snowflake authenticator.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --workload-identity-provider          TEXT     Workload identity provider    |
+  |                                                (AWS, AZURE, GCP, OIDC).      |
+  |                                                Overrides the value specified |
+  |                                                for the connection            |
+  | --private-key-file,--privat…          TEXT     Snowflake private key file    |
+  |                                                path. Overrides the value     |
+  |                                                specified for the connection. |
+  | --token                               TEXT     OAuth token to use when       |
+  |                                                connecting to Snowflake.      |
+  | --token-file-path                     TEXT     Path to file with an OAuth    |
+  |                                                token to use when connecting  |
+  |                                                to Snowflake.                 |
+  | --database,--dbname                   TEXT     Database to use. Overrides    |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --schema,--schemaname                 TEXT     Database schema to use.       |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --role,--rolename                     TEXT     Role to use. Overrides the    |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --warehouse                           TEXT     Warehouse to use. Overrides   |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --temporary-connection        -x               Uses a connection defined     |
+  |                                                with command-line parameters, |
+  |                                                instead of one defined in     |
+  |                                                config                        |
+  | --mfa-passcode                        TEXT     Token to use for multi-factor |
+  |                                                authentication (MFA)          |
+  | --enable-diag                                  Whether to generate a         |
+  |                                                connection diagnostic report. |
+  | --diag-log-path                       TEXT     Path for the generated        |
+  |                                                report. Defaults to system    |
+  |                                                temporary directory.          |
+  | --diag-allowlist-path                 TEXT     Path to a JSON file that      |
+  |                                                contains allowlist            |
+  |                                                parameters.                   |
+  | --oauth-client-id                     TEXT     Value of client id provided   |
+  |                                                by the Identity Provider for  |
+  |                                                Snowflake integration.        |
+  | --oauth-client-secret                 TEXT     Value of the client secret    |
+  |                                                provided by the Identity      |
+  |                                                Provider for Snowflake        |
+  |                                                integration.                  |
+  | --oauth-authorization-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the authorization   |
+  |                                                code to the driver.           |
+  | --oauth-token-request-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the access tokens   |
+  |                                                to the driver.                |
+  | --oauth-redirect-uri                  TEXT     URI to use for authorization  |
+  |                                                code redirection.             |
+  | --oauth-scope                         TEXT     Scope requested in the        |
+  |                                                Identity Provider             |
+  |                                                authorization request.        |
+  | --oauth-disable-pkce                           Disables Proof Key for Code   |
+  |                                                Exchange (PKCE). Default:     |
+  |                                                False.                        |
+  | --oauth-enable-refresh-toke…                   Enables a silent              |
+  |                                                re-authentication when the    |
+  |                                                actual access token becomes   |
+  |                                                outdated. Default: False.     |
+  | --oauth-enable-single-use-r…                   Whether to opt-in to          |
+  |                                                single-use refresh token      |
+  |                                                semantics. Default: False.    |
+  | --client-store-temporary-cr…                   Store the temporary           |
+  |                                                credential.                   |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
+  |                                CSV]                   format.                |
+  |                                                       [default: TABLE]       |
+  | --verbose              -v                             Displays log entries   |
+  |                                                       for log levels info    |
+  |                                                       and higher.            |
+  | --debug                                               Displays log entries   |
+  |                                                       for log levels debug   |
+  |                                                       and higher; debug logs |
+  |                                                       contain additional     |
+  |                                                       information.           |
+  | --silent                                              Turns off intermediate |
+  |                                                       output to console.     |
+  | --enhanced-exit-codes                                 Differentiate exit     |
+  |                                                       error codes based on   |
+  |                                                       failure type.          |
+  |                                                       [env var:              |
+  |                                                       SNOWFLAKE_ENHANCED_EX… |
+  | --decimal-precision            INTEGER                Number of decimal      |
+  |                                                       places to display for  |
+  |                                                       decimal values. Uses   |
+  |                                                       Python's default       |
+  |                                                       precision if not       |
+  |                                                       specified. [env var:   |
+  |                                                       SNOWFLAKE_DECIMAL_PRE… |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[connection.list]
   '''
                                                                                   
@@ -5330,13 +5465,17 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | add            Adds a connection to configuration file.                      |
-  | generate-jwt   Generate a JWT token, which will be printed out and           |
-  |                displayed..                                                   |
-  | list           Lists configured connections.                                 |
-  | remove         Removes a connection from configuration file.                 |
-  | set-default    Changes default connection to provided value.                 |
-  | test           Tests the connection to Snowflake.                            |
+  | add                                Adds a connection to configuration file.  |
+  | generate-jwt                       Generate a JWT token, which will be       |
+  |                                    printed out and displayed..               |
+  | generate-workload-identity-token   Generate a workload identity token, which |
+  |                                    will be printed out and displayed.        |
+  | list                               Lists configured connections.             |
+  | remove                             Removes a connection from configuration   |
+  |                                    file.                                     |
+  | set-default                        Changes default connection to provided    |
+  |                                    value.                                    |
+  | test                               Tests the connection to Snowflake.        |
   +------------------------------------------------------------------------------+
   
   
@@ -23846,13 +23985,17 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
-  | add            Adds a connection to configuration file.                      |
-  | generate-jwt   Generate a JWT token, which will be printed out and           |
-  |                displayed..                                                   |
-  | list           Lists configured connections.                                 |
-  | remove         Removes a connection from configuration file.                 |
-  | set-default    Changes default connection to provided value.                 |
-  | test           Tests the connection to Snowflake.                            |
+  | add                                Adds a connection to configuration file.  |
+  | generate-jwt                       Generate a JWT token, which will be       |
+  |                                    printed out and displayed..               |
+  | generate-workload-identity-token   Generate a workload identity token, which |
+  |                                    will be printed out and displayed.        |
+  | list                               Lists configured connections.             |
+  | remove                             Removes a connection from configuration   |
+  |                                    file.                                     |
+  | set-default                        Changes default connection to provided    |
+  |                                    value.                                    |
+  | test                               Tests the connection to Snowflake.        |
   +------------------------------------------------------------------------------+
   
   

--- a/tests/test.toml
+++ b/tests/test.toml
@@ -56,6 +56,10 @@ private_key_file = "/private/key"
 [connections.wif]
 workload_identity_provider = "GCP"
 
+[connections.wif_oidc]
+workload_identity_provider = "OIDC"
+token = "my-oidc-config-token"
+
 [cli.features]
 dummy_flag = true
 wrong_type_flag = "not_true"

--- a/tests/test.toml
+++ b/tests/test.toml
@@ -53,6 +53,9 @@ account = "testing_account"
 authenticator = "SNOWFLAKE_JWT"
 private_key_file = "/private/key"
 
+[connections.wif]
+workload_identity_provider = "GCP"
+
 [cli.features]
 dummy_flag = true
 wrong_type_flag = "not_true"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,10 @@ def test_get_all_connections(test_snowcli_config):
         "wif": {
             "workload_identity_provider": "GCP",
         },
+        "wif_oidc": {
+            "workload_identity_provider": "OIDC",
+            "token": "my-oidc-config-token",
+        },
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,6 +177,9 @@ def test_get_all_connections(test_snowcli_config):
             "private_key_file": "/private/key",
             "user": "jdoe",
         },
+        "wif": {
+            "workload_identity_provider": "GCP",
+        },
     }
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1489,6 +1489,11 @@ def test_generate_workload_identity_token(mock_create_attestation, runner):
 
     assert result.exit_code == 0, result.output
     assert "test-wif-token" in result.output
+    from snowflake.connector.wif_util import AttestationProvider
+
+    mock_create_attestation.assert_called_once_with(
+        provider=AttestationProvider.GCP, token=None
+    )
 
 
 @mock.patch("snowflake.connector.wif_util.create_attestation")
@@ -1608,6 +1613,20 @@ def test_generate_workload_identity_token_oidc_missing_token(runner):
 
     assert result.exit_code != 0
     assert "OIDC provider requires a token" in result.output
+
+
+def test_generate_workload_identity_token_invalid_provider_string(runner):
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--workload-identity-provider",
+            "INVALID",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Error" in result.output
 
 
 @mock.patch("snowflake.connector.wif_util.create_attestation")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -365,6 +365,13 @@ def test_lists_connection_information(mock_get_default_conn_name, runner):
                 "user": "jdoe",
             },
         },
+        {
+            "connection_name": "wif",
+            "is_default": False,
+            "parameters": {
+                "workload_identity_provider": "GCP",
+            },
+        },
     ]
 
 
@@ -477,6 +484,13 @@ def test_connection_list_does_not_print_too_many_env_variables(
                 "authenticator": "SNOWFLAKE_JWT",
                 "private_key_file": "/private/key",
                 "user": "jdoe",
+            },
+        },
+        {
+            "connection_name": "wif",
+            "is_default": False,
+            "parameters": {
+                "workload_identity_provider": "GCP",
             },
         },
     ]
@@ -1442,6 +1456,116 @@ def test_generate_jwt_raises_error_if_required_parameter_is_missing(
             f"{attribute.capitalize().replace('_', ' ')} is not set in the connection context"
             in result.output
         )
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token(mock_create_attestation, runner):
+    mock_create_attestation.return_value = mock.MagicMock(credential="test-wif-token")
+
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--workload-identity-provider",
+            "GCP",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "test-wif-token" in result.output
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token_uses_config(mock_create_attestation, runner):
+    mock_create_attestation.return_value = mock.MagicMock(credential="test-wif-token")
+
+    result = runner.invoke(
+        ["connection", "generate-workload-identity-token", "--connection", "wif"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "test-wif-token" in result.output
+
+
+def test_generate_workload_identity_token_missing_provider(runner):
+    result = runner.invoke(
+        ["connection", "generate-workload-identity-token", "--connection", "empty"],
+    )
+
+    assert result.exit_code != 0
+    assert "Workload identity provider is not set" in result.output
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token_cli_overrides_config(
+    mock_create_attestation, runner
+):
+    mock_create_attestation.return_value = mock.MagicMock(credential="test-wif-token")
+
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--connection",
+            "wif",
+            "--workload-identity-provider",
+            "AWS",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    from snowflake.connector.wif_util import AttestationProvider
+
+    mock_create_attestation.assert_called_once_with(
+        provider=AttestationProvider.AWS, token=None
+    )
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token_oidc_with_token(
+    mock_create_attestation, runner, named_temporary_file
+):
+    mock_create_attestation.return_value = mock.MagicMock(credential="oidc-token")
+
+    with named_temporary_file() as f:
+        f.write_text("my-oidc-jwt-token")
+        result = runner.invoke(
+            [
+                "connection",
+                "generate-workload-identity-token",
+                "--workload-identity-provider",
+                "OIDC",
+                "--token-file-path",
+                f,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "oidc-token" in result.output
+    from snowflake.connector.wif_util import AttestationProvider
+
+    mock_create_attestation.assert_called_once_with(
+        provider=AttestationProvider.OIDC, token="my-oidc-jwt-token"
+    )
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token_error_handling(
+    mock_create_attestation, runner
+):
+    mock_create_attestation.side_effect = Exception("No AWS credentials were found.")
+
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--workload-identity-provider",
+            "AWS",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No AWS credentials were found." in result.output
 
 
 @mock.patch("snowflake.cli._plugins.connection.commands.add_connection_to_proper_file")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -372,6 +372,14 @@ def test_lists_connection_information(mock_get_default_conn_name, runner):
                 "workload_identity_provider": "GCP",
             },
         },
+        {
+            "connection_name": "wif_oidc",
+            "is_default": False,
+            "parameters": {
+                "workload_identity_provider": "OIDC",
+                "token": "****",
+            },
+        },
     ]
 
 
@@ -491,6 +499,14 @@ def test_connection_list_does_not_print_too_many_env_variables(
             "is_default": False,
             "parameters": {
                 "workload_identity_provider": "GCP",
+            },
+        },
+        {
+            "connection_name": "wif_oidc",
+            "is_default": False,
+            "parameters": {
+                "workload_identity_provider": "OIDC",
+                "token": "****",
             },
         },
     ]
@@ -1485,6 +1501,11 @@ def test_generate_workload_identity_token_uses_config(mock_create_attestation, r
 
     assert result.exit_code == 0, result.output
     assert "test-wif-token" in result.output
+    from snowflake.connector.wif_util import AttestationProvider
+
+    mock_create_attestation.assert_called_once_with(
+        provider=AttestationProvider.GCP, token=None
+    )
 
 
 def test_generate_workload_identity_token_missing_provider(runner):
@@ -1550,10 +1571,50 @@ def test_generate_workload_identity_token_oidc_with_token(
 
 
 @mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token_oidc_with_config_token(
+    mock_create_attestation, runner
+):
+    mock_create_attestation.return_value = mock.MagicMock(
+        credential="oidc-config-token"
+    )
+
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--connection",
+            "wif_oidc",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "oidc-config-token" in result.output
+    from snowflake.connector.wif_util import AttestationProvider
+
+    mock_create_attestation.assert_called_once_with(
+        provider=AttestationProvider.OIDC, token="my-oidc-config-token"
+    )
+
+
+def test_generate_workload_identity_token_oidc_missing_token(runner):
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--workload-identity-provider",
+            "OIDC",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "OIDC provider requires a token" in result.output
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
 def test_generate_workload_identity_token_error_handling(
     mock_create_attestation, runner
 ):
-    mock_create_attestation.side_effect = Exception("No AWS credentials were found.")
+    mock_create_attestation.side_effect = ValueError("No AWS credentials were found.")
 
     result = runner.invoke(
         [


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Add a new `generate-workload-identity-token` command under `snow connection` that wraps the Python connector's `create_attestation` function.

- Supports all WIF providers (AWS, GCP, Azure, OIDC) via `--workload-identity-provider` flag or connection config
- For OIDC, resolves tokens from `--token-file-path` or connection config's `token` field
- Added 6 unit tests covering: basic usage, config-based usage, missing provider error, CLI override of config, OIDC with token file, error handling
- Updated 2 existing connection list tests to include the new `wif` test connection