### PR TITLE
SNOW-3202214: add custom image register command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 
 ## New additions
 * Added `snow custom-image validate` command to validate custom Docker images against configured rules (entrypoint, environment variables, Python packages, dependency health). Supports an optional `--scan-vulnerabilities` flag to run Grype vulnerability scanning.
+* Added `snow custom-image register` command to tag and push a local Docker image to a Snowflake image registry and optionally create a Custom Runtime Environment (CRE).
 
 ## Fixes and improvements
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.

--- a/src/snowflake/cli/_plugins/custom_images/commands.py
+++ b/src/snowflake/cli/_plugins/custom_images/commands.py
@@ -86,7 +86,7 @@ def register(
     return MessageResult(message)
 
 
-@app.command(requires_connection=False)
+@app.command(requires_connection=True)
 def validate(
     image: str = typer.Argument(
         ...,

--- a/src/snowflake/cli/_plugins/custom_images/commands.py
+++ b/src/snowflake/cli/_plugins/custom_images/commands.py
@@ -43,7 +43,7 @@ def _callback():
     pass
 
 
-@app.command(requires_connection=False)
+@app.command(requires_connection=True)
 def register(
     image: str = typer.Argument(
         ...,

--- a/src/snowflake/cli/_plugins/custom_images/commands.py
+++ b/src/snowflake/cli/_plugins/custom_images/commands.py
@@ -12,13 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import typer
 from click import ClickException
 from snowflake.cli._plugins.custom_images.manager import CustomImageManager
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.output.types import CommandResult, MessageResult
+
+
+class BaseImageType(str, Enum):
+    cpu = "cpu"
+    gpu = "gpu"
+
 
 CONFIG_DIR = Path(__file__).parent / "config"
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "image_validation.yaml"
@@ -33,6 +41,49 @@ app = SnowTyperFactory(
 @app.callback()
 def _callback():
     pass
+
+
+@app.command(requires_connection=False)
+def register(
+    image: str = typer.Argument(
+        ...,
+        help="Local Docker image to push. Accepts image name (e.g., 'myimage:latest') or image ID/hash.",
+    ),
+    registry: str = typer.Argument(
+        ...,
+        help="Full destination registry reference including host (e.g., 'org-acct.registry.snowflakecomputing.com/db/schema/repo/image:tag').",
+    ),
+    skip_validation: bool = typer.Option(
+        False,
+        "--skip-validation",
+        help="Skip custom image validation and only push the image to the registry.",
+    ),
+    base_image_type: Optional[BaseImageType] = typer.Option(
+        None,
+        "--base-image-type",
+        help="Base image type for CRE creation (cpu or gpu). Required when --skip-validation is not set.",
+    ),
+    cre_name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        help="Name for the Custom Runtime Environment. Defaults to 'mlruntimes_<uuid8>' if not provided.",
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Pushes a local Docker image to an image registry.
+
+    Without --skip-validation, also validates the image by creating a Custom Runtime Environment (CRE) in Snowflake.
+    """
+    manager = CustomImageManager(config_path=DEFAULT_CONFIG_PATH)
+    message = manager.register(
+        image=image,
+        registry=registry,
+        skip_validation=skip_validation,
+        base_image_type=base_image_type.value if base_image_type else None,
+        cre_name=cre_name,
+    )
+    return MessageResult(message)
 
 
 @app.command(requires_connection=False)

--- a/src/snowflake/cli/_plugins/custom_images/manager.py
+++ b/src/snowflake/cli/_plugins/custom_images/manager.py
@@ -23,6 +23,7 @@ import yaml
 from click import ClickException
 from snowflake.cli._plugins.custom_images.metrics import CustomImageCounterField
 from snowflake.cli.api.cli_global_context import get_cli_context
+from snowflake.cli.api.project.util import to_identifier
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 
 _FAIL_SEVERITIES = {"high", "critical"}
@@ -609,7 +610,9 @@ class CustomImageManager(SqlExecutionMixin):
         """
         slash_idx = registry.find("/")
         if slash_idx == -1:
-            return registry
+            raise ClickException(
+                f"Invalid registry format '{registry}': expected '<host>/<path>'."
+            )
         return registry[slash_idx:]
 
     def register(
@@ -662,7 +665,7 @@ class CustomImageManager(SqlExecutionMixin):
 
         image_path = self._parse_image_path(registry)
         sql = (
-            f"CREATE CUSTOM RUNTIME ENVIRONMENT {cre_name} "
+            f"CREATE CUSTOM RUNTIME ENVIRONMENT {to_identifier(cre_name)} "
             f"IMAGE_PATH = '{image_path}' "
             f"BASE_IMAGE_TYPE = {base_image_type}"
         )

--- a/src/snowflake/cli/_plugins/custom_images/manager.py
+++ b/src/snowflake/cli/_plugins/custom_images/manager.py
@@ -564,7 +564,6 @@ class CustomImageManager(SqlExecutionMixin):
             message=msg,
         )
 
-
     def _parse_image_path(self, registry: str) -> str:
         """Strip the hostname from a registry URL to get the image path for CRE.
 

--- a/src/snowflake/cli/_plugins/custom_images/manager.py
+++ b/src/snowflake/cli/_plugins/custom_images/manager.py
@@ -14,12 +14,14 @@
 
 import json
 import subprocess
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
 from click import ClickException
+from snowflake.cli.api.sql_execution import SqlExecutionMixin
 
 _FAIL_SEVERITIES = {"high", "critical"}
 
@@ -115,10 +117,11 @@ class ValidationReport:
         self.results.append(result)
 
 
-class CustomImageManager:
+class CustomImageManager(SqlExecutionMixin):
     """Manager for custom image validation operations."""
 
     def __init__(self, config_path: Path):
+        super().__init__()
         self.config_path = config_path
         self.config = self._load_config(self.config_path)
         # Config-driven checks (controlled by image_validation.yaml)
@@ -559,6 +562,79 @@ class CustomImageManager:
             check_name="vulnerability_scan",
             passed=False,
             message=msg,
+        )
+
+
+    def _parse_image_path(self, registry: str) -> str:
+        """Strip the hostname from a registry URL to get the image path for CRE.
+
+        Example: 'host.snowflakecomputing.com/db/schema/repo/image:tag'
+                 -> '/db/schema/repo/image:tag'
+        """
+        slash_idx = registry.find("/")
+        if slash_idx == -1:
+            return registry
+        return registry[slash_idx:]
+
+    def register(
+        self,
+        image: str,
+        registry: str,
+        skip_validation: bool = False,
+        base_image_type: Optional[str] = None,
+        cre_name: Optional[str] = None,
+    ) -> str:
+        """Tag and push a local Docker image to an image registry, optionally creating a CRE.
+
+        Args:
+            image: Local Docker image name or hash.
+            registry: Full destination registry reference (e.g., host/db/schema/repo/image:tag).
+            skip_validation: If True, only push the image without creating a CRE.
+            base_image_type: Required when skip_validation is False. Used for CRE creation.
+            cre_name: Optional CRE name. Defaults to 'mlruntimes_<8-char-uuid>'.
+
+        Returns:
+            A success message string.
+        """
+        if not skip_validation and not base_image_type:
+            raise ClickException(
+                "--base-image-type is required when not using --skip-validation."
+            )
+
+        # Tag the local image with the registry destination
+        returncode, _, stderr = self._run_docker_command(
+            ["docker", "tag", image, registry]
+        )
+        if returncode != 0:
+            raise ClickException(
+                f"Failed to tag image '{image}' as '{registry}': {stderr}"
+            )
+
+        # Push the tagged image to the registry
+        returncode, _, stderr = self._run_docker_command(
+            ["docker", "push", registry], timeout=600
+        )
+        if returncode != 0:
+            raise ClickException(f"Failed to push image to '{registry}': {stderr}")
+
+        if skip_validation:
+            return f"Successfully pushed '{image}' to '{registry}'."
+
+        # Create the Custom Runtime Environment
+        if not cre_name:
+            cre_name = f"mlruntimes_{uuid.uuid4().hex[:8]}"
+
+        image_path = self._parse_image_path(registry)
+        sql = (
+            f"CREATE CUSTOM RUNTIME ENVIRONMENT {cre_name} "
+            f"IMAGE_PATH = '{image_path}' "
+            f"BASE_IMAGE_TYPE = {base_image_type}"
+        )
+        self.execute_query(sql)
+
+        return (
+            f"Successfully pushed '{image}' to '{registry}' "
+            f"and created Custom Runtime Environment '{cre_name}'."
         )
 
 

--- a/src/snowflake/cli/_plugins/custom_images/manager.py
+++ b/src/snowflake/cli/_plugins/custom_images/manager.py
@@ -21,6 +21,8 @@ from typing import Any, Optional
 
 import yaml
 from click import ClickException
+from snowflake.cli._plugins.custom_images.metrics import CustomImageCounterField
+from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 
 _FAIL_SEVERITIES = {"high", "critical"}
@@ -183,6 +185,38 @@ class CustomImageManager(SqlExecutionMixin):
             pass
         return None
 
+    def _record_validate_metrics(self, report: ValidationReport) -> None:
+        """Record validation failure rate and failure reasons as CLI metrics."""
+        metrics = get_cli_context().metrics
+        metrics.set_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE, 1)
+
+        # Map check_name prefixes to their failure counter fields
+        check_counters = {
+            "image_exists": CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_IMAGE_NOT_FOUND,
+            "entrypoint": CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_ENTRYPOINT,
+            "env_": CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_ENV_VARS,
+            "pkg_": CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_PYTHON_PACKAGES,
+            "dependency_health": CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_DEPENDENCY_HEALTH,
+            "script_": CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_REQUIRED_SCRIPTS,
+        }
+
+        # Initialize all failure counters to 0 (check ran, no failure)
+        for counter in check_counters.values():
+            metrics.set_counter_default(counter, 0)
+
+        overall_failed = False
+        for result in report.results:
+            if not result.passed:
+                overall_failed = True
+                for prefix, counter in check_counters.items():
+                    if result.check_name.startswith(prefix):
+                        metrics.set_counter(counter, 1)
+                        break
+
+        metrics.set_counter(
+            CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED, int(overall_failed)
+        )
+
     def validate(
         self, image: str, scan_vulnerabilities: bool = False
     ) -> tuple[ValidationReport, str]:
@@ -206,6 +240,7 @@ class CustomImageManager(SqlExecutionMixin):
                     message=f"Image '{image}' not found. Please ensure the image exists locally.",
                 )
             )
+            self._record_validate_metrics(report)
             return report, format_report(report)
 
         report.add_result(
@@ -228,6 +263,7 @@ class CustomImageManager(SqlExecutionMixin):
             # Stop early if entrypoint check fails (file missing or mismatch)
             # Entrypoint is fundamental - other checks are irrelevant if it's wrong
             if not entrypoint_result.passed:
+                self._record_validate_metrics(report)
                 return report, format_report(report)
 
         for check_name, handler in self._check_handlers.items():
@@ -273,6 +309,7 @@ class CustomImageManager(SqlExecutionMixin):
         if common_passed and notebook_all_passed:
             readiness.append("Notebooks")
 
+        self._record_validate_metrics(report)
         return report, format_report(report, readiness)
 
     def _check_entrypoint(

--- a/src/snowflake/cli/_plugins/custom_images/metrics.py
+++ b/src/snowflake/cli/_plugins/custom_images/metrics.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_CIV = "features.global.custom_image_validate"
+
+
+class CustomImageCounterField:
+    CUSTOM_IMAGE_VALIDATE = _CIV
+    CUSTOM_IMAGE_VALIDATE_FAILED = f"{_CIV}_failed"
+    CUSTOM_IMAGE_VALIDATE_FAIL_IMAGE_NOT_FOUND = f"{_CIV}_fail_image_not_found"
+    CUSTOM_IMAGE_VALIDATE_FAIL_ENTRYPOINT = f"{_CIV}_fail_entrypoint"
+    CUSTOM_IMAGE_VALIDATE_FAIL_ENV_VARS = f"{_CIV}_fail_env_vars"
+    CUSTOM_IMAGE_VALIDATE_FAIL_PYTHON_PACKAGES = f"{_CIV}_fail_python_packages"
+    CUSTOM_IMAGE_VALIDATE_FAIL_DEPENDENCY_HEALTH = f"{_CIV}_fail_dependency_health"
+    CUSTOM_IMAGE_VALIDATE_FAIL_REQUIRED_SCRIPTS = f"{_CIV}_fail_required_scripts"

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -5342,6 +5342,68 @@
   
   '''
 # ---
+# name: test_help_messages[custom-image.register]
+  '''
+                                                                                  
+   Usage: root custom-image register [OPTIONS] IMAGE REGISTRY                     
+                                                                                  
+   Pushes a local Docker image to an image registry.                              
+                                                                                  
+   Without --skip-validation, also validates the image by creating a Custom       
+   Runtime Environment (CRE) in Snowflake.                                        
+                                                                                  
+  +- Arguments ------------------------------------------------------------------+
+  | *    image         TEXT  Local Docker image to push. Accepts image name      |
+  |                          (e.g., 'myimage:latest') or image ID/hash.          |
+  |                          [required]                                          |
+  | *    registry      TEXT  Full destination registry reference including host  |
+  |                          (e.g.,                                              |
+  |                          'org-acct.registry.snowflakecomputing.com/db/schem… |
+  |                          [required]                                          |
+  +------------------------------------------------------------------------------+
+  +- Options --------------------------------------------------------------------+
+  | --skip-validation                     Skip custom image validation and only  |
+  |                                       push the image to the registry.        |
+  | --base-image-type          [cpu|gpu]  Base image type for CRE creation (cpu  |
+  |                                       or gpu). Required when                 |
+  |                                       --skip-validation is not set.          |
+  | --name                     TEXT                                              |
+  |                                       Name for the Custom Runtime            |
+  |                                       Environment. Defaults to 'mlruntimes_' |
+  |                                       if not provided.                       |
+  | --help             -h                 Show this message and exit.            |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
+  |                                CSV]                   format.                |
+  |                                                       [default: TABLE]       |
+  | --verbose              -v                             Displays log entries   |
+  |                                                       for log levels info    |
+  |                                                       and higher.            |
+  | --debug                                               Displays log entries   |
+  |                                                       for log levels debug   |
+  |                                                       and higher; debug logs |
+  |                                                       contain additional     |
+  |                                                       information.           |
+  | --silent                                              Turns off intermediate |
+  |                                                       output to console.     |
+  | --enhanced-exit-codes                                 Differentiate exit     |
+  |                                                       error codes based on   |
+  |                                                       failure type.          |
+  |                                                       [env var:              |
+  |                                                       SNOWFLAKE_ENHANCED_EX… |
+  | --decimal-precision            INTEGER                Number of decimal      |
+  |                                                       places to display for  |
+  |                                                       decimal values. Uses   |
+  |                                                       Python's default       |
+  |                                                       precision if not       |
+  |                                                       specified. [env var:   |
+  |                                                       SNOWFLAKE_DECIMAL_PRE… |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[custom-image.validate]
   '''
                                                                                   
@@ -5358,6 +5420,100 @@
   | --scan-vulnerabilities            Run vulnerability scan using Grype.        |
   |                                   Requires Grype to be installed.            |
   | --help                  -h        Show this message and exit.                |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment    -c      TEXT     Name of the connection, as    |
+  |                                                defined in your config.toml   |
+  |                                                file. Default: default.       |
+  | --host                                TEXT     Host address for the          |
+  |                                                connection. Overrides the     |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --account,--accountname               TEXT     Name assigned to your         |
+  |                                                Snowflake account. Overrides  |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --user,--username                     TEXT     Username to connect to        |
+  |                                                Snowflake. Overrides the      |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --password                            TEXT     Snowflake password. Overrides |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --authenticator                       TEXT     Snowflake authenticator.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --workload-identity-provider          TEXT     Workload identity provider    |
+  |                                                (AWS, AZURE, GCP, OIDC).      |
+  |                                                Overrides the value specified |
+  |                                                for the connection            |
+  | --private-key-file,--privat…          TEXT     Snowflake private key file    |
+  |                                                path. Overrides the value     |
+  |                                                specified for the connection. |
+  | --token                               TEXT     OAuth token to use when       |
+  |                                                connecting to Snowflake.      |
+  | --token-file-path                     TEXT     Path to file with an OAuth    |
+  |                                                token to use when connecting  |
+  |                                                to Snowflake.                 |
+  | --database,--dbname                   TEXT     Database to use. Overrides    |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --schema,--schemaname                 TEXT     Database schema to use.       |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --role,--rolename                     TEXT     Role to use. Overrides the    |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --warehouse                           TEXT     Warehouse to use. Overrides   |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --temporary-connection        -x               Uses a connection defined     |
+  |                                                with command-line parameters, |
+  |                                                instead of one defined in     |
+  |                                                config                        |
+  | --mfa-passcode                        TEXT     Token to use for multi-factor |
+  |                                                authentication (MFA)          |
+  | --enable-diag                                  Whether to generate a         |
+  |                                                connection diagnostic report. |
+  | --diag-log-path                       TEXT     Path for the generated        |
+  |                                                report. Defaults to system    |
+  |                                                temporary directory.          |
+  | --diag-allowlist-path                 TEXT     Path to a JSON file that      |
+  |                                                contains allowlist            |
+  |                                                parameters.                   |
+  | --oauth-client-id                     TEXT     Value of client id provided   |
+  |                                                by the Identity Provider for  |
+  |                                                Snowflake integration.        |
+  | --oauth-client-secret                 TEXT     Value of the client secret    |
+  |                                                provided by the Identity      |
+  |                                                Provider for Snowflake        |
+  |                                                integration.                  |
+  | --oauth-authorization-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the authorization   |
+  |                                                code to the driver.           |
+  | --oauth-token-request-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the access tokens   |
+  |                                                to the driver.                |
+  | --oauth-redirect-uri                  TEXT     URI to use for authorization  |
+  |                                                code redirection.             |
+  | --oauth-scope                         TEXT     Scope requested in the        |
+  |                                                Identity Provider             |
+  |                                                authorization request.        |
+  | --oauth-disable-pkce                           Disables Proof Key for Code   |
+  |                                                Exchange (PKCE). Default:     |
+  |                                                False.                        |
+  | --oauth-enable-refresh-toke…                   Enables a silent              |
+  |                                                re-authentication when the    |
+  |                                                actual access token becomes   |
+  |                                                outdated. Default: False.     |
+  | --oauth-enable-single-use-r…                   Whether to opt-in to          |
+  |                                                single-use refresh token      |
+  |                                                semantics. Default: False.    |
+  | --client-store-temporary-cr…                   Store the temporary           |
+  |                                                credential.                   |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -5401,6 +5557,7 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
+  | register   Pushes a local Docker image to an image registry.                 |
   | validate   Validates a Docker image against Snowflake custom image           |
   |            requirements.                                                     |
   +------------------------------------------------------------------------------+
@@ -23869,6 +24026,7 @@
   | --help  -h        Show this message and exit.                                |
   +------------------------------------------------------------------------------+
   +- Commands -------------------------------------------------------------------+
+  | register   Pushes a local Docker image to an image registry.                 |
   | validate   Validates a Docker image against Snowflake custom image           |
   |            requirements.                                                     |
   +------------------------------------------------------------------------------+

--- a/tests/custom_images/test_commands.py
+++ b/tests/custom_images/test_commands.py
@@ -347,3 +347,61 @@ class TestRegisterCustomImageCommand:
 
         assert result.exit_code == 2
         assert "invalid" in result.output.lower()
+
+    def test_register_connection_flags_in_help(self, runner):
+        """requires_connection=True means --connection and friends appear in register --help."""
+        result = runner.invoke(["custom-image", "register", "--help"])
+
+        assert result.exit_code == 0
+        assert "--connection" in result.output
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    @mock.patch(
+        "snowflake.cli._plugins.custom_images.manager.CustomImageManager.execute_query"
+    )
+    def test_register_cre_name_with_spaces_is_quoted(
+        self, mock_execute_query, mock_run, runner
+    ):
+        """CRE names containing spaces are double-quoted in the SQL statement."""
+        mock_run.side_effect = create_mock_side_effect()
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--base-image-type",
+                self.BASE_IMAGE_TYPE,
+                "--name",
+                "my cre name",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        sql = mock_execute_query.call_args[0][0]
+        assert '"my cre name"' in sql
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    @mock.patch(
+        "snowflake.cli._plugins.custom_images.manager.CustomImageManager.execute_query"
+    )
+    def test_register_bare_registry_no_slash_fails(
+        self, mock_execute_query, mock_run, runner
+    ):
+        """A registry with no slash raises a clear error instead of producing bogus SQL."""
+        mock_run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                "barehostname",
+                "--base-image-type",
+                self.BASE_IMAGE_TYPE,
+            ]
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid registry format" in result.output

--- a/tests/custom_images/test_commands.py
+++ b/tests/custom_images/test_commands.py
@@ -144,3 +144,206 @@ class TestValidateCustomImageCommand:
 
         assert result.exit_code == 0
         assert "custom-image" in result.output
+
+
+class TestRegisterCustomImageCommand:
+    """Tests for the custom-image register CLI command."""
+
+    REGISTRY = (
+        "org-acct.registry.snowflakecomputing.com/mydb/myschema/myrepo/myimage:latest"
+    )
+    BASE_IMAGE_TYPE = "cpu"
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    @mock.patch(
+        "snowflake.cli._plugins.custom_images.manager.CustomImageManager.execute_query"
+    )
+    def test_register_success_with_cre(self, mock_execute_query, mock_run, runner):
+        """Test successful register: push then create CRE."""
+        mock_run.side_effect = create_mock_side_effect()
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--base-image-type",
+                self.BASE_IMAGE_TYPE,
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Successfully pushed" in result.output
+        assert "Custom Runtime Environment" in result.output
+        mock_execute_query.assert_called_once()
+        sql = mock_execute_query.call_args[0][0]
+        assert "CREATE CUSTOM RUNTIME ENVIRONMENT" in sql
+        assert "/mydb/myschema/myrepo/myimage:latest" in sql
+        assert self.BASE_IMAGE_TYPE in sql
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_register_skip_validation_only_pushes(self, mock_run, runner):
+        """Test register with --skip-validation: only tag and push, no CRE."""
+        mock_run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--skip-validation",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Successfully pushed" in result.output
+        assert "Custom Runtime Environment" not in result.output
+
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        assert any("tag" in cmd for cmd in calls)
+        assert any("push" in cmd for cmd in calls)
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_register_missing_base_image_type_fails(self, mock_run, runner):
+        """Test that missing --base-image-type fails when not using --skip-validation."""
+        mock_run.side_effect = create_mock_side_effect()
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+            ]
+        )
+
+        assert result.exit_code == 1
+        assert "base-image-type" in result.output.lower()
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    @mock.patch(
+        "snowflake.cli._plugins.custom_images.manager.CustomImageManager.execute_query"
+    )
+    def test_register_custom_cre_name(self, mock_execute_query, mock_run, runner):
+        """Test that a custom CRE name is used when provided."""
+        mock_run.side_effect = create_mock_side_effect()
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--base-image-type",
+                self.BASE_IMAGE_TYPE,
+                "--name",
+                "my_custom_cre",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "my_custom_cre" in result.output
+        sql = mock_execute_query.call_args[0][0]
+        assert "my_custom_cre" in sql
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    @mock.patch(
+        "snowflake.cli._plugins.custom_images.manager.CustomImageManager.execute_query"
+    )
+    def test_register_auto_generated_cre_name(
+        self, mock_execute_query, mock_run, runner
+    ):
+        """Test that a CRE name is auto-generated when not provided."""
+        mock_run.side_effect = create_mock_side_effect()
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--base-image-type",
+                self.BASE_IMAGE_TYPE,
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        sql = mock_execute_query.call_args[0][0]
+        assert "mlruntimes_" in sql
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_register_tag_failure(self, mock_run, runner):
+        """Test error when docker tag fails."""
+        mock_run.side_effect = create_mock_side_effect(
+            tag_result=(1, "invalid reference format"),
+        )
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                "bad::registry",
+                "--skip-validation",
+            ]
+        )
+
+        assert result.exit_code == 1
+        assert "Failed to tag" in result.output
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_register_push_failure(self, mock_run, runner):
+        """Test error when docker push fails."""
+        mock_run.side_effect = create_mock_side_effect(
+            push_result=(1, "unauthorized: authentication required"),
+        )
+
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--skip-validation",
+            ]
+        )
+
+        assert result.exit_code == 1
+        assert "Failed to push" in result.output
+
+    def test_register_missing_arguments(self, runner):
+        """Test error when required arguments are missing."""
+        result = runner.invoke(["custom-image", "register"])
+        assert result.exit_code == 2
+        assert "Missing argument" in result.output
+
+        result = runner.invoke(["custom-image", "register", "test-image:latest"])
+        assert result.exit_code == 2
+        assert "Missing argument" in result.output
+
+    def test_register_help_text(self, runner):
+        """Test that help text is displayed correctly."""
+        result = runner.invoke(["custom-image", "register", "--help"])
+
+        assert result.exit_code == 0
+        assert "registry" in result.output.lower()
+        assert "--skip-validation" in result.output
+        assert "--name" in result.output
+
+    def test_register_invalid_base_image_type(self, runner):
+        """Test that an invalid --base-image-type value is rejected."""
+        result = runner.invoke(
+            [
+                "custom-image",
+                "register",
+                "test-image:latest",
+                self.REGISTRY,
+                "--base-image-type",
+                "invalid_type",
+            ]
+        )
+
+        assert result.exit_code == 2
+        assert "invalid" in result.output.lower()

--- a/tests/custom_images/test_helpers.py
+++ b/tests/custom_images/test_helpers.py
@@ -64,6 +64,8 @@ def create_mock_side_effect(
     grype_result: tuple[int, str] = (0, ""),
     grype_error: Exception | None = None,
     missing_scripts: set[str] | None = None,
+    tag_result: tuple[int, str] = (0, ""),
+    push_result: tuple[int, str] = (0, ""),
 ):
     """Build a subprocess.run side_effect that routes docker/grype commands."""
     if inspect_response is None:
@@ -79,6 +81,14 @@ def create_mock_side_effect(
         if cmd[0] == "docker":
             if "inspect" in cmd:
                 return mock.Mock(returncode=0, stdout=inspect_response, stderr="")
+            elif "tag" in cmd:
+                return mock.Mock(
+                    returncode=tag_result[0], stdout="", stderr=tag_result[1]
+                )
+            elif "push" in cmd:
+                return mock.Mock(
+                    returncode=push_result[0], stdout="", stderr=push_result[1]
+                )
             elif "run" in cmd:
                 if "pip list" in cmd_str:
                     return mock.Mock(returncode=0, stdout=pip_list_response, stderr="")

--- a/tests/custom_images/test_manager.py
+++ b/tests/custom_images/test_manager.py
@@ -20,6 +20,8 @@ from unittest import mock
 import pytest
 from click import ClickException
 from snowflake.cli._plugins.custom_images.manager import CustomImageManager
+from snowflake.cli._plugins.custom_images.metrics import CustomImageCounterField
+from snowflake.cli.api.cli_global_context import _CLI_CONTEXT_MANAGER, get_cli_context
 
 from tests.custom_images.test_helpers import (
     create_mock_side_effect,
@@ -30,6 +32,13 @@ from tests.custom_images.test_helpers import (
 
 class TestCustomImageManager:
     """Tests for CustomImageManager validation."""
+
+    @pytest.fixture(autouse=True)
+    def reset_cli_context(self):
+        """Reset the CLI context before each test to get fresh metrics."""
+        token = _CLI_CONTEXT_MANAGER.set(None)
+        yield
+        _CLI_CONTEXT_MANAGER.reset(token)
 
     @pytest.fixture
     def config_path(self, tmp_path) -> Path:
@@ -82,6 +91,18 @@ notebook_checks:
         assert not report.all_passed
         assert any(
             r.check_name == "image_exists" and not r.passed for r in report.results
+        )
+        metrics = get_cli_context().metrics
+        assert metrics.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert (
+            metrics.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED)
+            == 1
+        )
+        assert (
+            metrics.get_counter(
+                CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_IMAGE_NOT_FOUND
+            )
+            == 1
         )
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
@@ -174,6 +195,11 @@ notebook_checks:
         report, _ = manager.validate("test-image:latest")
 
         assert report.all_passed == expected_pass
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(
+            CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED
+        ) == int(not expected_pass)
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
     def test_grype_not_installed(self, mock_run, config_path):
@@ -226,6 +252,9 @@ checks:
         assert "entrypoint" in check_names
         assert "dependency_health" not in check_names
         assert "vulnerability_scan" not in check_names
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 0
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
     def test_notebook_ready_when_script_present(self, mock_run, config_path):
@@ -253,6 +282,9 @@ checks:
         )
         assert script_result.passed
         assert "Ready for: ML Jobs, Notebooks" in output
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 0
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
     def test_ml_job_only_when_script_missing(self, mock_run, config_path):
@@ -282,6 +314,15 @@ checks:
         assert not script_result.passed
         assert "Ready for: ML Jobs" in output
         assert "Notebooks" not in output
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 1
+        assert (
+            m.get_counter(
+                CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_REQUIRED_SCRIPTS
+            )
+            == 1
+        )
 
     @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
     def test_required_scripts_empty_list(self, mock_run, tmp_path):
@@ -325,6 +366,127 @@ notebook_checks:
         check_names = [r.check_name for r in report.results]
         assert not any(name.startswith("script_") for name in check_names)
         assert "Ready for: ML Jobs, Notebooks" in output
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_metrics_entrypoint_failure(self, mock_run, config_path):
+        """Entrypoint mismatch: failed=1, fail_entrypoint=1."""
+        inspect_response = make_docker_inspect_response(
+            entrypoint=["/wrong/entrypoint.sh"],
+            env_vars=["DASHBOARD_PORT=12003"],
+        )
+        mock_run.side_effect = create_mock_side_effect(
+            inspect_response=inspect_response
+        )
+        manager = CustomImageManager(config_path=config_path)
+        manager.validate("test-image:latest")
+
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 1
+        assert (
+            m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_ENTRYPOINT)
+            == 1
+        )
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_metrics_env_var_failure(self, mock_run, config_path):
+        """Missing env var: failed=1, fail_env_vars=1."""
+        inspect_response = make_docker_inspect_response(
+            entrypoint=["/usr/local/bin/entrypoint.sh"],
+            env_vars=[],
+        )
+        pip_list = make_pip_list_response(
+            [
+                {"name": "snowflake-ml-python", "version": "1.0"},
+                {"name": "ray", "version": "2.0"},
+            ]
+        )
+        mock_run.side_effect = create_mock_side_effect(
+            inspect_response=inspect_response,
+            pip_list_response=pip_list,
+        )
+        manager = CustomImageManager(config_path=config_path)
+        manager.validate("test-image:latest")
+
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 1
+        assert (
+            m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_ENV_VARS)
+            == 1
+        )
+        assert (
+            m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_ENTRYPOINT)
+            == 0
+        )
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_metrics_python_package_failure(self, mock_run, config_path):
+        """Missing package: failed=1, fail_python_packages=1."""
+        inspect_response = make_docker_inspect_response(
+            entrypoint=["/usr/local/bin/entrypoint.sh"],
+            env_vars=["DASHBOARD_PORT=12003"],
+        )
+        pip_list = make_pip_list_response(
+            [{"name": "snowflake-ml-python", "version": "1.0"}]  # ray missing
+        )
+        mock_run.side_effect = create_mock_side_effect(
+            inspect_response=inspect_response,
+            pip_list_response=pip_list,
+        )
+        manager = CustomImageManager(config_path=config_path)
+        manager.validate("test-image:latest")
+
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 1
+        assert (
+            m.get_counter(
+                CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_PYTHON_PACKAGES
+            )
+            == 1
+        )
+        assert (
+            m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_ENV_VARS)
+            == 0
+        )
+
+    @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")
+    def test_metrics_dependency_health_failure(self, mock_run, config_path):
+        """Broken dependencies: failed=1, fail_dependency_health=1."""
+        inspect_response = make_docker_inspect_response(
+            entrypoint=["/usr/local/bin/entrypoint.sh"],
+            env_vars=["DASHBOARD_PORT=12003"],
+        )
+        pip_list = make_pip_list_response(
+            [
+                {"name": "snowflake-ml-python", "version": "1.0"},
+                {"name": "ray", "version": "2.0"},
+            ]
+        )
+        mock_run.side_effect = create_mock_side_effect(
+            inspect_response=inspect_response,
+            pip_list_response=pip_list,
+            pip_check_result=(1, "broken-pkg 1.0 requires missing-pkg"),
+        )
+        manager = CustomImageManager(config_path=config_path)
+        manager.validate("test-image:latest")
+
+        m = get_cli_context().metrics
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE) == 1
+        assert m.get_counter(CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAILED) == 1
+        assert (
+            m.get_counter(
+                CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_DEPENDENCY_HEALTH
+            )
+            == 1
+        )
+        assert (
+            m.get_counter(
+                CustomImageCounterField.CUSTOM_IMAGE_VALIDATE_FAIL_PYTHON_PACKAGES
+            )
+            == 0
+        )
 
 
 @mock.patch("snowflake.cli._plugins.custom_images.manager.subprocess.run")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.

### Changes description
1. create a new command to register the custom runtime environment
 `snow custom-image register [local docker image name/hash] [spcs image registry url] [--skip-validarion] [--base-image-type] [--name]`

- `--skip-validation`: if users add this flag, we only push the local images to the spcs image repo; if not, after pushing the local images to the spcs image repo, we will have validation on that image
- `--base-image-type`: this is required if users do not have  the flag `--skip-validation`
2. add metrics for the `snow custom-images validate` and require snowflake connection for `snow custom-images validate`