### PR TITLE
Snowflake Apps telemetry spans

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -69,19 +69,6 @@ app = SnowTyperFactory(
 )
 
 
-def _fetch_and_print_failure_logs(
-    manager: SnowflakeAppManager, service_fqn: FQN, label: str
-) -> None:
-    """Fetch container logs from a failed service and print them."""
-    logs = manager.get_container_logs(service_fqn)
-    if logs and logs.strip():
-        cli_console.warning(f"{label} logs:")
-        for line in logs.strip().splitlines():
-            cli_console.step(f"  {line}")
-    else:
-        cli_console.warning(f"No {label.lower()} logs available.")
-
-
 @app.command("setup", requires_connection=True)
 def setup(
     app_name: str = typer.Option(
@@ -709,17 +696,13 @@ def deploy(
 
                 # Poll for build completion
                 cli_console.step("Waiting for build to complete...")
-                try:
-                    _poll_until(
-                        poll_fn=lambda: manager.get_build_status(build_job_fqn),
-                        done_states={"DONE"},
-                        error_states={"FAILED", "IDLE"},
-                        known_pending_states={"PENDING", "RUNNING"},
-                        timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
-                    )
-                except CliError:
-                    _fetch_and_print_failure_logs(manager, build_job_fqn, "Build job")
-                    raise
+                _poll_until(
+                    poll_fn=lambda: manager.get_build_status(build_job_fqn),
+                    done_states={"DONE"},
+                    error_states={"FAILED", "IDLE"},
+                    known_pending_states={"PENDING", "RUNNING"},
+                    timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
+                )
 
     if build_only:
         return MessageResult("Build completed successfully.")
@@ -836,17 +819,13 @@ def deploy(
 
             # Poll until service is RUNNING
             cli_console.step("Waiting for service to be ready...")
-            try:
-                _poll_until(
-                    poll_fn=lambda: manager.get_service_status(service_fqn),
-                    done_states={"RUNNING"},
-                    error_states={"FAILED", "IDLE"},
-                    known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
-                    timeout_message=f"Service timed out. Check service status: {service_fqn}",
-                )
-            except CliError:
-                _fetch_and_print_failure_logs(manager, service_fqn, "Service")
-                raise
+            _poll_until(
+                poll_fn=lambda: manager.get_service_status(service_fqn),
+                done_states={"RUNNING"},
+                error_states={"FAILED", "IDLE"},
+                known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
+                timeout_message=f"Service timed out. Check service status: {service_fqn}",
+            )
 
     # ── Get endpoint URL (non-artifact-repo path only) ────────────────
     with metrics.span("snowflake_app.endpoint_provision"):

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -116,11 +116,13 @@ def setup(
     conn_config = get_connection_dict(connection_name)
 
     manager = SnowflakeAppManager()
-    params = manager.fetch_snow_apps_parameters()
-    config_table = {}
-    role = manager.current_role()
-    if role:
-        config_table = manager.fetch_config_table_defaults(role)
+    metrics = ctx.metrics
+    with metrics.span("snowflake_app.setup.resolve_defaults"):
+        params = manager.fetch_snow_apps_parameters()
+        config_table = {}
+        role = manager.current_role()
+        if role:
+            config_table = manager.fetch_config_table_defaults(role)
 
     def _resolve(
         user_input=None,

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -651,42 +651,44 @@ def deploy(
 
     if run_build:
         if use_artifact_repo:
-            cli_console.step("Building app using artifact repository...")
-            build_result = manager.build_app_artifact_repo(
-                stage_fqn=stage_fqn,
-                artifact_repo_fqn=artifact_repo_fqn_str,
-                app_id=app_name,
-                compute_pool=build_compute_pool,
-                database=database,
-                schema=schema,
-                runtime_image=entity.runtime_image,
-                query_warehouse=query_warehouse,
-                build_eai=build_eai,
-            )
-            cli_console.step(
-                f"SPCS_TEST_BUILD_APP_ARTIFACT_REPO output:\n{build_result}"
-            )
-
-            match = re.search(r"Build job submitted:\s*(\S+)", build_result)
-            if not match:
-                raise CliError(
-                    f"Could not parse build job name from output: {build_result}"
+            with metrics.span("snowflake_app.build"):
+                cli_console.step("Building app using artifact repository...")
+                build_result = manager.build_app_artifact_repo(
+                    stage_fqn=stage_fqn,
+                    artifact_repo_fqn=artifact_repo_fqn_str,
+                    app_id=app_name,
+                    compute_pool=build_compute_pool,
+                    database=database,
+                    schema=schema,
+                    runtime_image=entity.runtime_image,
+                    query_warehouse=query_warehouse,
+                    build_eai=build_eai,
                 )
-            artifact_build_job_fqn = FQN.from_string(match.group(1))
-            cli_console.step(
-                f"Waiting for artifact repo build to complete: "
-                f"{artifact_build_job_fqn}..."
-            )
-            _poll_until(
-                poll_fn=lambda: manager.get_build_status(artifact_build_job_fqn),
-                done_states={"DONE"},
-                error_states={"FAILED", "IDLE"},
-                known_pending_states={"PENDING", "RUNNING"},
-                timeout_message=(
-                    f"Artifact repo build timed out. Check build logs:\n"
-                    f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
-                ),
-            )
+                cli_console.step(
+                    f"SPCS_TEST_BUILD_APP_ARTIFACT_REPO output:\n{build_result}"
+                )
+
+                match = re.search(r"Build job submitted:\s*(\S+)", build_result)
+                if not match:
+                    raise CliError(
+                        f"Could not parse build job name from output: {build_result}"
+                    )
+                artifact_build_job_fqn = FQN.from_string(match.group(1))
+                cli_console.step(
+                    f"Waiting for artifact repo build to complete: "
+                    f"{artifact_build_job_fqn}..."
+                )
+                _poll_until(
+                    poll_fn=lambda: manager.get_build_status(artifact_build_job_fqn),
+                    done_states={"DONE"},
+                    error_states={"FAILED", "IDLE"},
+                    known_pending_states={"PENDING", "RUNNING"},
+                    timeout_message=(
+                        f"Artifact repo build timed out. Check build logs:\n"
+                        f"  SELECT * FROM TABLE("
+                        f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
+                    ),
+                )
         else:
             with metrics.span("snowflake_app.build"):
                 # Drop existing build job if present
@@ -734,33 +736,34 @@ def deploy(
     app_comment = json.dumps(comment_data)
 
     if use_artifact_repo:
-        eai_list = [build_eai] if build_eai else None
+        with metrics.span("snowflake_app.deploy_service"):
+            eai_list = [build_eai] if build_eai else None
 
-        did_upgrade = False
-        cli_console.step("Creating application service...")
-        try:
-            manager.create_app_service(
-                service_fqn=service_fqn,
-                artifact_repo_fqn=artifact_repo_fqn_str,
-                package_name=app_name,
-                compute_pool=service_compute_pool,
-                version="LATEST",
-                query_warehouse=query_warehouse,
-                external_access_integrations=eai_list,
-                comment=app_comment,
-            )
-        except ProgrammingError as e:
-            if e.errno == 2002 and "already exists" in str(e).lower():
-                cli_console.step(
-                    f"Application service {app_name} already exists. Upgrading..."
-                )
-                manager.upgrade_app_service(
+            did_upgrade = False
+            cli_console.step("Creating application service...")
+            try:
+                manager.create_app_service(
                     service_fqn=service_fqn,
+                    artifact_repo_fqn=artifact_repo_fqn_str,
+                    package_name=app_name,
+                    compute_pool=service_compute_pool,
                     version="LATEST",
+                    query_warehouse=query_warehouse,
+                    external_access_integrations=eai_list,
+                    comment=app_comment,
                 )
-                did_upgrade = True
-            else:
-                raise
+            except ProgrammingError as e:
+                if e.errno == 2002 and "already exists" in str(e).lower():
+                    cli_console.step(
+                        f"Application service {app_name} already exists. Upgrading..."
+                    )
+                    manager.upgrade_app_service(
+                        service_fqn=service_fqn,
+                        version="LATEST",
+                    )
+                    did_upgrade = True
+                else:
+                    raise
 
         def _svc_is_upgrading(d: dict) -> bool:
             return str(d.get("is_upgrading", "")).lower() in ("true", "1", "yes")
@@ -772,38 +775,38 @@ def deploy(
             url = d.get("url", "")
             return bool(url) and "provisioning in progress" not in url.lower()
 
-        if did_upgrade:
-            cli_console.step("Waiting for upgrade to complete...")
-            desc = _poll_until(
-                poll_fn=lambda: manager.describe_app_service(service_fqn),
-                is_done=lambda d: not _svc_is_upgrading(d) and _url_is_ready(d),
-                is_error=_svc_has_failed,
-                format_status=lambda d: (
-                    "upgrading" if _svc_is_upgrading(d) else "ready"
-                ),
-                timeout_message=(
-                    f"Upgrade timed out. Check logs:\n"
-                    f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
-                ),
-            )
-        else:
-            cli_console.step("Waiting for application service endpoint...")
-            desc = _poll_until(
-                poll_fn=lambda: manager.describe_app_service(service_fqn),
-                is_done=_url_is_ready,
-                is_error=_svc_has_failed,
-                format_status=lambda d: d.get("url") or "url not yet available",
-                timeout_message=(
-                    f"Endpoint provisioning timed out. "
-                    f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
-                ),
-            )
+        with metrics.span("snowflake_app.endpoint_provision"):
+            if did_upgrade:
+                cli_console.step("Waiting for upgrade to complete...")
+                desc = _poll_until(
+                    poll_fn=lambda: manager.describe_app_service(service_fqn),
+                    is_done=lambda d: not _svc_is_upgrading(d) and _url_is_ready(d),
+                    is_error=_svc_has_failed,
+                    format_status=lambda d: (
+                        "upgrading" if _svc_is_upgrading(d) else "ready"
+                    ),
+                    timeout_message=(
+                        f"Upgrade timed out. Check logs:\n"
+                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
+                    ),
+                )
+            else:
+                cli_console.step("Waiting for application service endpoint...")
+                desc = _poll_until(
+                    poll_fn=lambda: manager.describe_app_service(service_fqn),
+                    is_done=_url_is_ready,
+                    is_error=_svc_has_failed,
+                    format_status=lambda d: d.get("url") or "url not yet available",
+                    timeout_message=(
+                        f"Endpoint provisioning timed out. "
+                        f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
+                    ),
+                )
 
         endpoint_url = desc.get("url", "")
         if endpoint_url and not endpoint_url.startswith(("http://", "https://")):
             endpoint_url = f"https://{endpoint_url}"
         return MessageResult(f"App ready at {endpoint_url}")
-
     else:
         assert image_repo_url is not None
         repo_path = "/" + "/".join(image_repo_url.split("/")[1:])

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -69,6 +69,19 @@ app = SnowTyperFactory(
 )
 
 
+def _fetch_and_print_failure_logs(
+    manager: SnowflakeAppManager, service_fqn: FQN, label: str
+) -> None:
+    """Fetch container logs from a failed service and print them."""
+    logs = manager.get_container_logs(service_fqn)
+    if logs and logs.strip():
+        cli_console.warning(f"{label} logs:")
+        for line in logs.strip().splitlines():
+            cli_console.step(f"  {line}")
+    else:
+        cli_console.warning(f"No {label.lower()} logs available.")
+
+
 @app.command("setup", requires_connection=True)
 def setup(
     app_name: str = typer.Option(
@@ -694,13 +707,17 @@ def deploy(
 
                 # Poll for build completion
                 cli_console.step("Waiting for build to complete...")
-                _poll_until(
-                    poll_fn=lambda: manager.get_build_status(build_job_fqn),
-                    done_states={"DONE"},
-                    error_states={"FAILED", "IDLE"},
-                    known_pending_states={"PENDING", "RUNNING"},
-                    timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
-                )
+                try:
+                    _poll_until(
+                        poll_fn=lambda: manager.get_build_status(build_job_fqn),
+                        done_states={"DONE"},
+                        error_states={"FAILED", "IDLE"},
+                        known_pending_states={"PENDING", "RUNNING"},
+                        timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
+                    )
+                except CliError:
+                    _fetch_and_print_failure_logs(manager, build_job_fqn, "Build job")
+                    raise
 
     if build_only:
         return MessageResult("Build completed successfully.")
@@ -816,13 +833,17 @@ def deploy(
 
             # Poll until service is RUNNING
             cli_console.step("Waiting for service to be ready...")
-            _poll_until(
-                poll_fn=lambda: manager.get_service_status(service_fqn),
-                done_states={"RUNNING"},
-                error_states={"FAILED", "IDLE"},
-                known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
-                timeout_message=f"Service timed out. Check service status: {service_fqn}",
-            )
+            try:
+                _poll_until(
+                    poll_fn=lambda: manager.get_service_status(service_fqn),
+                    done_states={"RUNNING"},
+                    error_states={"FAILED", "IDLE"},
+                    known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
+                    timeout_message=f"Service timed out. Check service status: {service_fqn}",
+                )
+            except CliError:
+                _fetch_and_print_failure_logs(manager, service_fqn, "Service")
+                raise
 
     # ── Get endpoint URL (non-artifact-repo path only) ────────────────
     with metrics.span("snowflake_app.endpoint_provision"):

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -598,6 +598,8 @@ def deploy(
             image_repository, database=image_repo_database, schema=image_repo_schema
         )
 
+    metrics = get_cli_context().metrics
+
     # ── Upload phase ──────────────────────────────────────────────────
 
     if run_upload:
@@ -608,18 +610,24 @@ def deploy(
             cli_console.step(f"Creating stage @{stage_fqn}")
             manager.create_stage(stage_fqn, encryption_type)
 
-        project_paths = perform_bundle(resolved_entity_id, entity)
+        # Step 3: Bundle artifact files
+        with metrics.span("snowflake_app.bundle"):
+            project_paths = perform_bundle(resolved_entity_id, entity)
 
+        # Step 4: Upload bundled files to stage
         try:
-            cli_console.step(f"Uploading bundled files to @{stage_fqn}")
-            for result in stage_manager.put_recursive(
-                local_path=project_paths.bundle_root,
-                stage_path=f"@{stage_fqn}",
-                overwrite=True,
-                auto_compress=False,
-                temp_directory=project_paths.bundle_root,
-            ):
-                cli_console.step(f"  Uploaded {result['source']} -> {result['target']}")
+            with metrics.span("snowflake_app.upload"):
+                cli_console.step(f"Uploading bundled files to @{stage_fqn}")
+                for result in stage_manager.put_recursive(
+                    local_path=project_paths.bundle_root,
+                    stage_path=f"@{stage_fqn}",
+                    overwrite=True,
+                    auto_compress=False,
+                    temp_directory=project_paths.bundle_root,
+                ):
+                    cli_console.step(
+                        f"  Uploaded {result['source']} -> {result['target']}"
+                    )
         finally:
             project_paths.clean_up_output()
 
@@ -667,28 +675,32 @@ def deploy(
                 ),
             )
         else:
-            cli_console.step(f"Dropping service if exists: {build_job_fqn}")
-            manager.drop_service_if_exists(build_job_fqn)
+            with metrics.span("snowflake_app.build"):
+                # Drop existing build job if present
+                cli_console.step(f"Dropping service if exists: {build_job_fqn}")
+                manager.drop_service_if_exists(build_job_fqn)
 
-            cli_console.step(f"Executing build job service: {build_job_fqn}")
-            manager.execute_build_job(
-                job_service_name=build_job_fqn,
-                compute_pool=build_compute_pool,
-                code_stage=stage_fqn,
-                image_repo_url=image_repo_url,
-                app_id=app_name,
-                external_access_integration=build_eai,
-                build_image=entity.build_image,
-            )
+                # Execute build job service
+                cli_console.step(f"Executing build job service: {build_job_fqn}")
+                manager.execute_build_job(
+                    job_service_name=build_job_fqn,
+                    compute_pool=build_compute_pool,
+                    code_stage=stage_fqn,
+                    image_repo_url=image_repo_url,
+                    app_id=app_name,
+                    external_access_integration=build_eai,
+                    build_image=entity.build_image,
+                )
 
-            cli_console.step("Waiting for build to complete...")
-            _poll_until(
-                poll_fn=lambda: manager.get_build_status(build_job_fqn),
-                done_states={"DONE"},
-                error_states={"FAILED", "IDLE"},
-                known_pending_states={"PENDING", "RUNNING"},
-                timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
-            )
+                # Poll for build completion
+                cli_console.step("Waiting for build to complete...")
+                _poll_until(
+                    poll_fn=lambda: manager.get_build_status(build_job_fqn),
+                    done_states={"DONE"},
+                    error_states={"FAILED", "IDLE"},
+                    known_pending_states={"PENDING", "RUNNING"},
+                    timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
+                )
 
     if build_only:
         return MessageResult("Build completed successfully.")
@@ -780,46 +792,51 @@ def deploy(
         repo_path = "/" + "/".join(image_repo_url.split("/")[1:])
         image_url = f"{repo_path}/{app_name.lower()}:latest"
 
-        cli_console.step(f"Creating service {service_fqn} if it doesn't exist")
-        manager.create_service(
-            service_name=service_fqn,
-            compute_pool=service_compute_pool,
-            query_warehouse=query_warehouse,
-            app_comment=app_comment,
-            execute_as_caller=entity.execute_as_caller,
-        )
+        with metrics.span("snowflake_app.deploy_service"):
+            cli_console.step(f"Creating service {service_fqn} if it doesn't exist")
+            manager.create_service(
+                service_name=service_fqn,
+                compute_pool=service_compute_pool,
+                query_warehouse=query_warehouse,
+                app_comment=app_comment,
+                execute_as_caller=entity.execute_as_caller,
+            )
 
-        cli_console.step(f"Updating service with image: {image_url}")
-        manager.alter_service_spec(
-            service_name=service_fqn,
-            image_url=image_url,
-            execute_as_caller=entity.execute_as_caller,
-        )
+            # Alter service with built image
+            cli_console.step(f"Updating service with image: {image_url}")
+            manager.alter_service_spec(
+                service_name=service_fqn,
+                image_url=image_url,
+                execute_as_caller=entity.execute_as_caller,
+            )
 
-        cli_console.step("Resuming service")
-        manager.resume_service(service_fqn)
+            # Resume service
+            cli_console.step("Resuming service")
+            manager.resume_service(service_fqn)
 
-        cli_console.step("Waiting for service to be ready...")
-        _poll_until(
-            poll_fn=lambda: manager.get_service_status(service_fqn),
-            done_states={"RUNNING"},
-            error_states={"FAILED", "IDLE"},
-            known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
-            timeout_message=f"Service timed out. Check service status: {service_fqn}",
-        )
+            # Poll until service is RUNNING
+            cli_console.step("Waiting for service to be ready...")
+            _poll_until(
+                poll_fn=lambda: manager.get_service_status(service_fqn),
+                done_states={"RUNNING"},
+                error_states={"FAILED", "IDLE"},
+                known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
+                timeout_message=f"Service timed out. Check service status: {service_fqn}",
+            )
 
     # ── Get endpoint URL (non-artifact-repo path only) ────────────────
-    cli_console.step("Getting endpoint URL")
-    endpoint_url = _poll_until(
-        poll_fn=lambda: manager.get_service_endpoint_url(
-            service_fqn, endpoint_name="app-endpoint"
-        ),
-        is_done=lambda url: url is not None
-        and "provisioning in progress" not in url.lower(),
-        format_status=lambda url: url or "Endpoint URL not yet available",
-        timeout_message=(
-            f"Endpoint provisioning timed out. "
-            f'Check with: snow sql -q "SHOW ENDPOINTS IN SERVICE {service_fqn}"'
-        ),
-    )
+    with metrics.span("snowflake_app.endpoint_provision"):
+        cli_console.step("Getting endpoint URL")
+        endpoint_url = _poll_until(
+            poll_fn=lambda: manager.get_service_endpoint_url(
+                service_fqn, endpoint_name="app-endpoint"
+            ),
+            is_done=lambda url: url is not None
+            and "provisioning in progress" not in url.lower(),
+            format_status=lambda url: url or "Endpoint URL not yet available",
+            timeout_message=(
+                f"Endpoint provisioning timed out. "
+                f'Check with: snow sql -q "SHOW ENDPOINTS IN SERVICE {service_fqn}"'
+            ),
+        )
     return MessageResult(f"App ready at {endpoint_url}")

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1096,40 +1096,40 @@ class TestSnowflakeAppManager:
         assert not url.startswith("https://")
 
     @patch(EXECUTE_QUERY)
-    def test_get_service_logs_returns_log_text(self, mock_execute):
+    def test_get_container_logs_returns_log_text(self, mock_execute):
         cursor = Mock()
         cursor.fetchone.return_value = ("Error: container crashed\nExit code 1",)
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        logs = SnowflakeAppManager().get_service_logs(fqn)
+        logs = SnowflakeAppManager().get_container_logs(fqn)
         assert logs == "Error: container crashed\nExit code 1"
         mock_execute.assert_called_once_with(
             "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.SVC', '0', 'main', 50)"
         )
 
     @patch(EXECUTE_QUERY)
-    def test_get_service_logs_returns_none_on_empty(self, mock_execute):
+    def test_get_container_logs_returns_none_on_empty(self, mock_execute):
         cursor = Mock()
         cursor.fetchone.return_value = None
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        assert SnowflakeAppManager().get_service_logs(fqn) is None
+        assert SnowflakeAppManager().get_container_logs(fqn) is None
 
     @patch(EXECUTE_QUERY, side_effect=Exception("service not found"))
-    def test_get_service_logs_returns_none_on_error(self, mock_execute):
+    def test_get_container_logs_returns_none_on_error(self, mock_execute):
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        assert SnowflakeAppManager().get_service_logs(fqn) is None
+        assert SnowflakeAppManager().get_container_logs(fqn) is None
 
     @patch(EXECUTE_QUERY)
-    def test_get_service_logs_custom_num_lines(self, mock_execute):
+    def test_get_container_logs_custom_num_lines(self, mock_execute):
         cursor = Mock()
         cursor.fetchone.return_value = ("some logs",)
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().get_service_logs(fqn, num_lines=100)
+        SnowflakeAppManager().get_container_logs(fqn, num_lines=100)
         mock_execute.assert_called_once_with(
             "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.SVC', '0', 'main', 100)"
         )
@@ -1141,30 +1141,30 @@ class TestSnowflakeAppManager:
 class TestFetchAndPrintFailureLogs:
     def test_prints_logs_when_available(self):
         manager = Mock()
-        manager.get_service_logs.return_value = "line1\nline2\nline3"
+        manager.get_container_logs.return_value = "line1\nline2\nline3"
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
 
         _fetch_and_print_failure_logs(manager, fqn, "Build job")
 
-        manager.get_service_logs.assert_called_once_with(fqn)
+        manager.get_container_logs.assert_called_once_with(fqn)
 
     def test_prints_warning_when_no_logs(self):
         manager = Mock()
-        manager.get_service_logs.return_value = None
+        manager.get_container_logs.return_value = None
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
 
         _fetch_and_print_failure_logs(manager, fqn, "Service")
 
-        manager.get_service_logs.assert_called_once_with(fqn)
+        manager.get_container_logs.assert_called_once_with(fqn)
 
     def test_prints_warning_when_empty_logs(self):
         manager = Mock()
-        manager.get_service_logs.return_value = "   \n  "
+        manager.get_container_logs.return_value = "   \n  "
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
 
         _fetch_and_print_failure_logs(manager, fqn, "Service")
 
-        manager.get_service_logs.assert_called_once_with(fqn)
+        manager.get_container_logs.assert_called_once_with(fqn)
 
 
 # ── fetch_config_table_defaults tests ─────────────────────────────────

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -15,7 +15,6 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from snowflake.cli._plugins.apps.commands import _fetch_and_print_failure_logs
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
 )
@@ -1094,77 +1093,6 @@ class TestSnowflakeAppManager:
         url = SnowflakeAppManager().get_service_endpoint_url(fqn)
         assert url == "Provisioning in progress... check back later"
         assert not url.startswith("https://")
-
-    @patch(EXECUTE_QUERY)
-    def test_get_container_logs_returns_log_text(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = ("Error: container crashed\nExit code 1",)
-        mock_execute.return_value = cursor
-
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        logs = SnowflakeAppManager().get_container_logs(fqn)
-        assert logs == "Error: container crashed\nExit code 1"
-        mock_execute.assert_called_once_with(
-            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.SVC', '0', 'main', 50)"
-        )
-
-    @patch(EXECUTE_QUERY)
-    def test_get_container_logs_returns_none_on_empty(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = None
-        mock_execute.return_value = cursor
-
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        assert SnowflakeAppManager().get_container_logs(fqn) is None
-
-    @patch(EXECUTE_QUERY, side_effect=Exception("service not found"))
-    def test_get_container_logs_returns_none_on_error(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        assert SnowflakeAppManager().get_container_logs(fqn) is None
-
-    @patch(EXECUTE_QUERY)
-    def test_get_container_logs_custom_num_lines(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = ("some logs",)
-        mock_execute.return_value = cursor
-
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().get_container_logs(fqn, num_lines=100)
-        mock_execute.assert_called_once_with(
-            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.SVC', '0', 'main', 100)"
-        )
-
-
-# ── Failure log helper tests ─────────────────────────────────────────
-
-
-class TestFetchAndPrintFailureLogs:
-    def test_prints_logs_when_available(self):
-        manager = Mock()
-        manager.get_container_logs.return_value = "line1\nline2\nline3"
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-
-        _fetch_and_print_failure_logs(manager, fqn, "Build job")
-
-        manager.get_container_logs.assert_called_once_with(fqn)
-
-    def test_prints_warning_when_no_logs(self):
-        manager = Mock()
-        manager.get_container_logs.return_value = None
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-
-        _fetch_and_print_failure_logs(manager, fqn, "Service")
-
-        manager.get_container_logs.assert_called_once_with(fqn)
-
-    def test_prints_warning_when_empty_logs(self):
-        manager = Mock()
-        manager.get_container_logs.return_value = "   \n  "
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-
-        _fetch_and_print_failure_logs(manager, fqn, "Service")
-
-        manager.get_container_logs.assert_called_once_with(fqn)
 
 
 # ── fetch_config_table_defaults tests ─────────────────────────────────

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -3734,3 +3734,274 @@ class TestDeployCommand:
                 result = runner.invoke(["__app", "deploy", "--build-only"])
                 assert "service_compute_pool is required" not in result.output
                 assert "query_warehouse is required" not in result.output
+
+    # ── Telemetry span tests ─────────────────────────────────────────
+
+    @staticmethod
+    def _make_deploy_mocks(
+        tmp_path,
+        mock_get_ctx,
+        mock_get_entity,
+        mock_manager_cls,
+        mock_perform_bundle,
+        *,
+        use_artifact_repo=False,
+    ):
+        """Wire up the common mocks for a deploy invocation and return (metrics, mock_mgr)."""
+        from snowflake.cli.api.metrics import CLIMetrics
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        metrics = CLIMetrics()
+        mock_ctx = Mock()
+        mock_ctx.metrics = metrics
+        mock_ctx.connection_context.database = "TEST_DB"
+        mock_ctx.connection_context.schema = "TEST_SCHEMA"
+        mock_ctx.connection_context.warehouse = "WH"
+        mock_get_ctx.return_value = mock_ctx
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.build_image = None
+        entity.execute_as_caller = False
+        entity.runtime_image = "runtime:latest"
+
+        if use_artifact_repo:
+            ar_mock = Mock(database="AR_DB", schema_="AR_SCHEMA")
+            ar_mock.name = "AR_REPO"
+            entity.artifact_repository = ar_mock
+            entity.image_repository = None
+            entity.build_compute_pool = None
+            entity.service_compute_pool = None
+            entity.build_eai = None
+            entity.query_warehouse = "WH"
+        else:
+            entity.artifact_repository = None
+            entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
+
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True, exist_ok=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.stage_exists.return_value = False
+        mock_mgr.get_image_repo_url.return_value = (
+            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
+        )
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+
+        return metrics, mock_mgr
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
+    def test_deploy_image_repo_records_telemetry_spans(
+        self,
+        mock_get_ctx,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """Non-artifact-repo deploy records exactly the expected spans in order."""
+        from snowflake.cli.api.metrics import CLIMetricsSpan
+
+        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
+        metrics, _ = self._make_deploy_mocks(
+            tmp_path,
+            mock_get_ctx,
+            mock_get_entity,
+            mock_manager_cls,
+            mock_perform_bundle,
+        )
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy"])
+                assert result.exit_code == 0, result.output
+
+        span_names = [s[CLIMetricsSpan.NAME_KEY] for s in metrics.completed_spans]
+        assert span_names == [
+            "snowflake_app.bundle",
+            "snowflake_app.upload",
+            "snowflake_app.build",
+            "snowflake_app.deploy_service",
+            "snowflake_app.endpoint_provision",
+        ]
+        for span in metrics.completed_spans:
+            assert span[CLIMetricsSpan.ERROR_KEY] is None
+            assert span[CLIMetricsSpan.EXECUTION_TIME_KEY] > 0
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
+    def test_deploy_artifact_repo_records_telemetry_spans(
+        self,
+        mock_get_ctx,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """Artifact-repo deploy records exactly the expected spans in order."""
+        from snowflake.cli.api.metrics import CLIMetricsSpan
+
+        mock_poll.side_effect = [
+            "DONE",
+            {
+                "url": "https://my-app.snowflakecomputing.app",
+                "is_upgrading": "false",
+                "status": "READY",
+            },
+        ]
+        metrics, _ = self._make_deploy_mocks(
+            tmp_path,
+            mock_get_ctx,
+            mock_get_entity,
+            mock_manager_cls,
+            mock_perform_bundle,
+            use_artifact_repo=True,
+        )
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy"])
+                assert result.exit_code == 0, result.output
+
+        span_names = [s[CLIMetricsSpan.NAME_KEY] for s in metrics.completed_spans]
+        assert span_names == [
+            "snowflake_app.bundle",
+            "snowflake_app.upload",
+            "snowflake_app.build",
+            "snowflake_app.deploy_service",
+            "snowflake_app.endpoint_provision",
+        ]
+        for span in metrics.completed_spans:
+            assert span[CLIMetricsSpan.ERROR_KEY] is None
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "image_repository": "IMAGE_REPO",
+            "image_repo_database": "TEST_DB",
+            "image_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
+    def test_deploy_build_failure_records_error_in_span(
+        self,
+        mock_get_ctx,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """When build polling raises CliError, the build span records the error."""
+        from snowflake.cli.api.metrics import CLIMetricsSpan
+
+        def _poll_side_effect(**kwargs):
+            if kwargs.get("done_states") == {"DONE"}:
+                raise CliError("Build timed out.")
+            return "https://my-app.snowflakecomputing.app"
+
+        mock_poll.side_effect = _poll_side_effect
+        metrics, _ = self._make_deploy_mocks(
+            tmp_path,
+            mock_get_ctx,
+            mock_get_entity,
+            mock_manager_cls,
+            mock_perform_bundle,
+        )
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "deploy"])
+                assert result.exit_code == 1
+
+        span_map = {s[CLIMetricsSpan.NAME_KEY]: s for s in metrics.completed_spans}
+        assert "snowflake_app.build" in span_map
+        assert span_map["snowflake_app.build"][CLIMetricsSpan.ERROR_KEY] == "CliError"
+        assert "snowflake_app.bundle" in span_map
+        assert span_map["snowflake_app.bundle"][CLIMetricsSpan.ERROR_KEY] is None

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -15,6 +15,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from snowflake.cli._plugins.apps.commands import _fetch_and_print_failure_logs
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
 )
@@ -1093,6 +1094,77 @@ class TestSnowflakeAppManager:
         url = SnowflakeAppManager().get_service_endpoint_url(fqn)
         assert url == "Provisioning in progress... check back later"
         assert not url.startswith("https://")
+
+    @patch(EXECUTE_QUERY)
+    def test_get_service_logs_returns_log_text(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("Error: container crashed\nExit code 1",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+        logs = SnowflakeAppManager().get_service_logs(fqn)
+        assert logs == "Error: container crashed\nExit code 1"
+        mock_execute.assert_called_once_with(
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.SVC', '0', 'main', 50)"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_get_service_logs_returns_none_on_empty(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = None
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+        assert SnowflakeAppManager().get_service_logs(fqn) is None
+
+    @patch(EXECUTE_QUERY, side_effect=Exception("service not found"))
+    def test_get_service_logs_returns_none_on_error(self, mock_execute):
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+        assert SnowflakeAppManager().get_service_logs(fqn) is None
+
+    @patch(EXECUTE_QUERY)
+    def test_get_service_logs_custom_num_lines(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("some logs",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+        SnowflakeAppManager().get_service_logs(fqn, num_lines=100)
+        mock_execute.assert_called_once_with(
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.SVC', '0', 'main', 100)"
+        )
+
+
+# ── Failure log helper tests ─────────────────────────────────────────
+
+
+class TestFetchAndPrintFailureLogs:
+    def test_prints_logs_when_available(self):
+        manager = Mock()
+        manager.get_service_logs.return_value = "line1\nline2\nline3"
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+
+        _fetch_and_print_failure_logs(manager, fqn, "Build job")
+
+        manager.get_service_logs.assert_called_once_with(fqn)
+
+    def test_prints_warning_when_no_logs(self):
+        manager = Mock()
+        manager.get_service_logs.return_value = None
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+
+        _fetch_and_print_failure_logs(manager, fqn, "Service")
+
+        manager.get_service_logs.assert_called_once_with(fqn)
+
+    def test_prints_warning_when_empty_logs(self):
+        manager = Mock()
+        manager.get_service_logs.return_value = "   \n  "
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+
+        _fetch_and_print_failure_logs(manager, fqn, "Service")
+
+        manager.get_service_logs.assert_called_once_with(fqn)
 
 
 # ── fetch_config_table_defaults tests ─────────────────────────────────


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Wrap key operations in `CLIMetrics.span()` context managers so phase duration and errors are captured in CLI telemetry payloads.

`setup` command:
* `snowflake_app.setup.resolve_defaults` — fetching account parameters, role, and config table defaults

`deploy` command (both artifact-repo and image-repo paths):
* `snowflake_app.bundle` — artifact bundling
* `snowflake_app.upload` — stage upload
* `snowflake_app.build` — build job submission and polling
* `snowflake_app.deploy_service` — service creation/upgrade
* `snowflake_app.endpoint_provision` — endpoint URL polling