### PR TITLE
 DCM: Speed up file upload to temporary stage by parallelizing it

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -18,7 +18,7 @@ from typing import List
 from snowflake.cli._plugins.dcm.models import MANIFEST_FILE_NAME, SOURCES_FOLDER
 from snowflake.cli._plugins.dcm.utils import collect_output
 from snowflake.cli._plugins.stage.manager import StageManager
-from snowflake.cli.api.artifacts.upload import sync_artifacts_with_stage
+from snowflake.cli.api.artifacts.utils import bundle_artifacts
 from snowflake.cli.api.commands.utils import parse_key_value_variables
 from snowflake.cli.api.console.console import cli_console
 from snowflake.cli.api.constants import (
@@ -258,13 +258,30 @@ class DCMProjectManager(SqlExecutionMixin):
             stage_fqn = FQN.from_resource(
                 ObjectType.DCM_PROJECT, project_identifier, "TMP_STAGE"
             )
-            sync_artifacts_with_stage(
-                project_paths=ProjectPaths(project_root=source_path.path),
-                stage_root=stage_fqn.identifier,
-                use_temporary_stage=True,
-                artifacts=artifacts,
-                pattern_type=PatternMatchingType.GLOB,
+            project_paths = ProjectPaths(project_root=source_path.path)
+            project_paths.remove_up_bundle_root()
+            SecurePath(project_paths.bundle_root).mkdir(parents=True, exist_ok=True)
+            bundle_artifacts(
+                project_paths, artifacts, pattern_type=PatternMatchingType.GLOB
             )
+
+            try:
+                stage_manager = StageManager()
+                stage_manager.create(
+                    fqn=FQN.from_stage(stage_fqn.identifier), temporary=True
+                )
+                for result in stage_manager.put_recursive(
+                    local_path=project_paths.bundle_root,
+                    stage_path=stage_fqn.identifier,
+                    temp_directory=project_paths.bundle_root,
+                ):
+                    log.info(
+                        "Uploaded %s to %s",
+                        result["source"],
+                        result["target"],
+                    )
+            finally:
+                project_paths.clean_up_output()
 
         log.info(
             "Finished syncing DCM files (project_identifier=%s, stage=%s).",
@@ -282,9 +299,6 @@ class DCMProjectManager(SqlExecutionMixin):
 
         sources_path = source_path / SOURCES_FOLDER
         if sources_path.exists() and sources_path.is_dir():
-            for file in sources_path.rglob("*"):
-                if file.is_file():
-                    relative_path = file.relative_to(source_path)
-                    artifacts.append(PathMapping(src=str(relative_path)))
+            artifacts.append(PathMapping(src=SOURCES_FOLDER))
 
         return artifacts

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -261,11 +261,12 @@ class DCMProjectManager(SqlExecutionMixin):
             project_paths = ProjectPaths(project_root=source_path.path)
             project_paths.remove_up_bundle_root()
             SecurePath(project_paths.bundle_root).mkdir(parents=True, exist_ok=True)
-            bundle_artifacts(
-                project_paths, artifacts, pattern_type=PatternMatchingType.GLOB
-            )
 
             try:
+                bundle_artifacts(
+                    project_paths, artifacts, pattern_type=PatternMatchingType.GLOB
+                )
+
                 stage_manager = StageManager()
                 stage_manager.create(
                     fqn=FQN.from_stage(stage_fqn.identifier), temporary=True

--- a/src/snowflake/cli/api/artifacts/upload.py
+++ b/src/snowflake/cli/api/artifacts/upload.py
@@ -13,7 +13,6 @@ from snowflake.cli.api.secure_path import SecurePath
 def sync_artifacts_with_stage(
     project_paths: ProjectPaths,
     stage_root: str,
-    use_temporary_stage: bool = False,
     prune: bool = False,
     artifacts: Optional[List[PathMapping]] = None,
     pattern_type: PatternMatchingType = PatternMatchingType.GLOB,
@@ -34,7 +33,6 @@ def sync_artifacts_with_stage(
         prune=prune,
         recursive=True,
         stage_path_parts=stage_path_parts,
-        use_temporary_stage=use_temporary_stage,
         print_diff=True,
     )
     project_paths.clean_up_output()

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -23,7 +23,6 @@ from snowflake.cli._plugins.dcm.manager import (
     DCMProjectManager,
 )
 from snowflake.cli._plugins.dcm.models import MANIFEST_FILE_NAME
-from snowflake.cli.api.constants import PatternMatchingType
 from snowflake.cli.api.identifiers import FQN
 
 execute_queries = "snowflake.cli._plugins.dcm.manager.DCMProjectManager.execute_query"
@@ -529,48 +528,48 @@ def test_purge_project_with_alias(mock_execute_query):
 
 
 class TestSyncLocalFiles:
-    @mock.patch("snowflake.cli._plugins.dcm.manager.sync_artifacts_with_stage")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
-    def test_calls_sync_artifacts_with_stage(
+    def test_uploads_to_temporary_stage(
         self,
-        _mock_create_stage,
-        mock_sync_artifacts_with_stage,
+        mock_create_stage,
+        mock_bundle_artifacts,
+        mock_put_recursive,
         project_directory,
         mock_connect,
         mock_cursor,
         mock_from_resource,
     ):
+        mock_put_recursive.return_value = iter([])
+
         with project_directory("dcm_project") as project_dir:
-            DCMProjectManager.sync_local_files(project_identifier=TEST_PROJECT)
+            result = DCMProjectManager.sync_local_files(project_identifier=TEST_PROJECT)
 
-            mock_sync_artifacts_with_stage.assert_called_once()
+            mock_create_stage.assert_called_once()
+            create_call = mock_create_stage.call_args
+            assert create_call.kwargs["temporary"] is True
 
-            call_args = mock_sync_artifacts_with_stage.call_args
-            assert call_args.kwargs["stage_root"] == str(mock_from_resource())
+            mock_put_recursive.assert_called_once()
+            put_call = mock_put_recursive.call_args
+            assert put_call.kwargs["stage_path"] == str(mock_from_resource())
 
-            artifacts = call_args.kwargs["artifacts"]
-            artifact_srcs = {a.src for a in artifacts}
-            assert MANIFEST_FILE_NAME in artifact_srcs
-            assert any(SOURCES_FOLDER in src for src in artifact_srcs)
+            assert result == str(mock_from_resource())
 
-            assert call_args.kwargs["pattern_type"] == PatternMatchingType.GLOB
-            assert call_args.kwargs["use_temporary_stage"] is True
-
-            actual_project_root = call_args.kwargs["project_paths"].project_root
-            expected_project_root = project_dir.resolve()
-            assert actual_project_root.resolve() == expected_project_root.resolve()
-
-    @mock.patch("snowflake.cli._plugins.dcm.manager.sync_artifacts_with_stage")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
     def test_sync_local_files_with_source_directory(
         self,
         _mock_create_stage,
-        mock_sync_artifacts_with_stage,
+        mock_bundle_artifacts,
+        mock_put_recursive,
         tmp_path,
         mock_connect,
         mock_cursor,
         mock_from_resource,
     ):
+        mock_put_recursive.return_value = iter([])
         source_dir = tmp_path / "custom_source"
         source_dir.mkdir()
 
@@ -590,29 +589,25 @@ class TestSyncLocalFiles:
             project_identifier=TEST_PROJECT, source_directory=str(source_dir)
         )
 
-        mock_sync_artifacts_with_stage.assert_called_once()
-        call_args = mock_sync_artifacts_with_stage.call_args
-        actual_project_root = call_args.kwargs["project_paths"].project_root
+        mock_bundle_artifacts.assert_called_once()
+        call_args = mock_bundle_artifacts.call_args
+        actual_project_root = call_args.args[0].project_root
         assert actual_project_root.resolve() == source_dir.resolve()
 
-        artifacts = call_args.kwargs["artifacts"]
-        artifact_srcs = [a.src for a in artifacts]
-        assert MANIFEST_FILE_NAME in artifact_srcs
-        assert any(
-            SOURCES_FOLDER in src and "custom_query.sql" in src for src in artifact_srcs
-        )
-
-    @mock.patch("snowflake.cli._plugins.dcm.manager.sync_artifacts_with_stage")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
     def test_sync_local_files_with_relative_source_directory(
         self,
         _mock_create_stage,
-        mock_sync_artifacts_with_stage,
+        mock_bundle_artifacts,
+        mock_put_recursive,
         tmp_path,
         mock_connect,
         mock_cursor,
         mock_from_resource,
     ):
+        mock_put_recursive.return_value = iter([])
         source_dir = tmp_path / "relative_source"
         source_dir.mkdir()
 
@@ -629,26 +624,28 @@ class TestSyncLocalFiles:
                 source_directory="relative_source",
             )
 
-            mock_sync_artifacts_with_stage.assert_called_once()
-            call_args = mock_sync_artifacts_with_stage.call_args
-
-            actual_project_root = call_args.kwargs["project_paths"].project_root
+            mock_bundle_artifacts.assert_called_once()
+            call_args = mock_bundle_artifacts.call_args
+            actual_project_root = call_args.args[0].project_root
             assert actual_project_root.is_absolute()
             assert actual_project_root.resolve() == source_dir.resolve()
         finally:
             os.chdir(original_cwd)
 
-    @mock.patch("snowflake.cli._plugins.dcm.manager.sync_artifacts_with_stage")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
     def test_sync_local_files_includes_all_files_in_sources(
         self,
         _mock_create_stage,
-        mock_sync_artifacts_with_stage,
+        mock_bundle_artifacts,
+        mock_put_recursive,
         tmp_path,
         mock_connect,
         mock_cursor,
         mock_from_resource,
     ):
+        mock_put_recursive.return_value = iter([])
         source_dir = tmp_path / "project_with_sources"
         source_dir.mkdir()
 
@@ -674,14 +671,10 @@ class TestSyncLocalFiles:
             project_identifier=TEST_PROJECT, source_directory=str(source_dir)
         )
 
-        mock_sync_artifacts_with_stage.assert_called_once()
-        call_args = mock_sync_artifacts_with_stage.call_args
-
-        artifacts = call_args.kwargs["artifacts"]
+        mock_bundle_artifacts.assert_called_once()
+        call_args = mock_bundle_artifacts.call_args
+        artifacts = call_args.args[1]
         artifact_srcs = [a.src for a in artifacts]
 
         assert MANIFEST_FILE_NAME in artifact_srcs
-        assert any("definitions" in src and "table.sql" in src for src in artifact_srcs)
-        assert any("macros" in src and "helpers.sql" in src for src in artifact_srcs)
-        assert any("macros" in src and "utils.jinja" in src for src in artifact_srcs)
-        assert any("dbt_project.yml" in src for src in artifact_srcs)
+        assert SOURCES_FOLDER in artifact_srcs


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
#### Summary
- Replace per-file sequential PUT uploads in dcm plan/dcm deploy with directory-level `put_recursive`, matching the pattern already used by SPCS services
- Simplify `_collect_artifacts` to pass the `sources/` directory as a single artifact instead of enumerating individual files
- Remove unused `use_temporary_stage` parameter from `sync_artifacts_with_stage` (DCM was the only caller)

#### Performance
The previous implementation issued one `PUT SQL` command per file (102 round-trips in sample benchmark). The new implementation uses `put_recursive` which batches files by directory into a single `PUT file://dir/*` command, reducing round-trips and enabling parallel file transfer within each command.
Also, the previous implementation executed `LIST @stage` command after the stage creation, and computed MD5 hashes for every local file (never compared against anything) .

##### Benchmarks
Input
Benchmarked with 100 definition files (~10KB each) uploaded to a temporary stage:

##### Scenario 1
100 flat files in `sources/definitions`
> Before: 129s
> After: 9.37s
> Speedup: x14

##### Scenario 2
5 subdirs x 20 files in `sources/definitions`
> Before: 189s
> After: 12s
> Speedup: x16

There is still room for improvement, as the current implementation uses a level of parallelism of 4 (the default). I experimented with 16, and we can reduce the time by 30%.


