### PR TITLE
Snowflake Apps: Stream build and deploy logs during artifact repo deploy

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -544,6 +544,11 @@ def deploy(
         help="Run only the deploy phase (assumes the container image has already been built). "
         "Skips the upload and build phases.",
     ),
+    hide_logs: bool = typer.Option(
+        False,
+        "--hide-logs",
+        help="Disable live log streaming during the build and deploy phases.",
+    ),
     **options,
 ) -> CommandResult:
     """
@@ -731,7 +736,9 @@ def deploy(
                         f"  SELECT * FROM TABLE("
                         f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
                     ),
-                    on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
+                    on_poll=None
+                    if hide_logs
+                    else _make_build_log_streamer(manager, artifact_build_job_fqn),
                 )
         else:
             with metrics.span("snowflake_app.build"):
@@ -815,7 +822,9 @@ def deploy(
             url = d.get("url", "")
             return bool(url) and "provisioning in progress" not in url.lower()
 
-        deploy_log_streamer = _make_deploy_log_streamer(manager, service_fqn)
+        deploy_log_streamer = (
+            None if hide_logs else _make_deploy_log_streamer(manager, service_fqn)
+        )
 
         with metrics.span("snowflake_app.endpoint_provision"):
             if did_upgrade:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -487,7 +487,7 @@ def _make_build_log_streamer(
             return
         new_lines = logs[seen_count:]
         for line in new_lines:
-            log.info(line)
+            cli_console.step(line)
         seen_count = len(logs)
 
     return _stream
@@ -516,7 +516,7 @@ def _make_deploy_log_streamer(
         lines = raw.splitlines()
         new_lines = lines[seen_count:]
         for line in new_lines:
-            log.info(line)
+            cli_console.step(line)
         seen_count = len(lines)
 
     return _stream

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -15,7 +15,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import typer
 from click import ClickException
@@ -53,6 +53,8 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.api.project.util import get_env_username, identifier_for_url
 from snowflake.connector.errors import ProgrammingError
+
+log = __import__("logging").getLogger(__name__)
 
 # ── Source provenance labels ──────────────────────────────────────────
 SOURCE_USER_INPUT = "user input"
@@ -465,6 +467,58 @@ def events(
     return MessageResult(logs)
 
 
+def _make_build_log_streamer(
+    manager: SnowflakeAppManager, build_job_fqn: FQN
+) -> Callable:
+    """Return an ``on_poll`` callback that prints new build log lines.
+
+    Each invocation of ``SPCS_GET_LOGS`` returns the *full* log history.
+    We track how many lines were already printed and emit only the delta.
+    """
+    seen_count: list[int] = [0]
+
+    def _stream(_status) -> None:
+        try:
+            logs = manager.get_build_job_logs(build_job_fqn)
+        except Exception:
+            log.debug("Failed to fetch build logs", exc_info=True)
+            return
+        new_lines = logs[seen_count[0] :]
+        for line in new_lines:
+            cli_console.step(line)
+        seen_count[0] = len(logs)
+
+    return _stream
+
+
+def _make_deploy_log_streamer(
+    manager: SnowflakeAppManager, service_fqn: FQN
+) -> Callable:
+    """Return an ``on_poll`` callback that prints new deploy log lines.
+
+    ``SYSTEM$GET_APPLICATION_SERVICE_LOGS`` returns one long string
+    containing all log output.  We split by newlines, track what has
+    already been printed, and emit only new lines.
+    """
+    seen_count: list[int] = [0]
+
+    def _stream(_status) -> None:
+        try:
+            raw = manager.get_app_service_logs(service_fqn.identifier)
+        except Exception:
+            log.debug("Failed to fetch deploy logs", exc_info=True)
+            return
+        if not raw:
+            return
+        lines = raw.splitlines()
+        new_lines = lines[seen_count[0] :]
+        for line in new_lines:
+            cli_console.step(line)
+        seen_count[0] = len(lines)
+
+    return _stream
+
+
 @app.command(requires_connection=True)
 def deploy(
     entity_id: Optional[str] = typer.Option(
@@ -677,6 +731,7 @@ def deploy(
                         f"  SELECT * FROM TABLE("
                         f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
                     ),
+                    on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
                 )
         else:
             with metrics.span("snowflake_app.build"):
@@ -760,6 +815,8 @@ def deploy(
             url = d.get("url", "")
             return bool(url) and "provisioning in progress" not in url.lower()
 
+        deploy_log_streamer = _make_deploy_log_streamer(manager, service_fqn)
+
         with metrics.span("snowflake_app.endpoint_provision"):
             if did_upgrade:
                 cli_console.step("Waiting for upgrade to complete...")
@@ -774,6 +831,7 @@ def deploy(
                         f"Upgrade timed out. Check logs:\n"
                         f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
                     ),
+                    on_poll=deploy_log_streamer,
                 )
             else:
                 cli_console.step("Waiting for application service endpoint...")
@@ -786,6 +844,7 @@ def deploy(
                         f"Endpoint provisioning timed out. "
                         f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
                     ),
+                    on_poll=deploy_log_streamer,
                 )
 
         endpoint_url = desc.get("url", "")

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -471,11 +471,7 @@ def events(
 def _make_build_log_streamer(
     manager: SnowflakeAppManager, build_job_fqn: FQN
 ) -> Callable:
-    """Return an ``on_poll`` callback that prints new build log lines.
-
-    Each invocation of ``SPCS_GET_LOGS`` returns the *full* log history.
-    We track how many lines were already printed and emit only the delta.
-    """
+    """Return an ``on_poll`` callback that streams new build log lines."""
     seen_count = 0
 
     def _stream() -> None:
@@ -496,12 +492,7 @@ def _make_build_log_streamer(
 def _make_deploy_log_streamer(
     manager: SnowflakeAppManager, service_fqn: FQN
 ) -> Callable:
-    """Return an ``on_poll`` callback that prints new deploy log lines.
-
-    ``SYSTEM$GET_APPLICATION_SERVICE_LOGS`` returns one long string
-    containing all log output.  We split by newlines, track what has
-    already been printed, and emit only new lines.
-    """
+    """Return an ``on_poll`` callback that streams new deploy log lines."""
     seen_count = 0
 
     def _stream() -> None:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -487,7 +487,7 @@ def _make_build_log_streamer(
             return
         new_lines = logs[seen_count:]
         for line in new_lines:
-            cli_console.step(line)
+            log.info(line)
         seen_count = len(logs)
 
     return _stream
@@ -516,7 +516,7 @@ def _make_deploy_log_streamer(
         lines = raw.splitlines()
         new_lines = lines[seen_count:]
         for line in new_lines:
-            cli_console.step(line)
+            log.info(line)
         seen_count = len(lines)
 
     return _stream
@@ -546,11 +546,6 @@ def deploy(
         "--deploy-only",
         help="Run only the deploy phase (assumes the container image has already been built). "
         "Skips the upload and build phases.",
-    ),
-    hide_logs: bool = typer.Option(
-        False,
-        "--hide-logs",
-        help="Disable live log streaming during the build and deploy phases.",
     ),
     **options,
 ) -> CommandResult:
@@ -739,9 +734,7 @@ def deploy(
                         f"  SELECT * FROM TABLE("
                         f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
                     ),
-                    on_poll=None
-                    if hide_logs
-                    else _make_build_log_streamer(manager, artifact_build_job_fqn),
+                    on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
                 )
         else:
             with metrics.span("snowflake_app.build"):
@@ -825,9 +818,7 @@ def deploy(
             url = d.get("url", "")
             return bool(url) and "provisioning in progress" not in url.lower()
 
-        deploy_log_streamer = (
-            None if hide_logs else _make_deploy_log_streamer(manager, service_fqn)
-        )
+        deploy_log_streamer = _make_deploy_log_streamer(manager, service_fqn)
 
         with metrics.span("snowflake_app.endpoint_provision"):
             if did_upgrade:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -487,7 +487,7 @@ def _make_build_log_streamer(
             return
         new_lines = logs[seen_count:]
         for line in new_lines:
-            cli_console.step(line)
+            log.info(line)
         seen_count = len(logs)
 
     return _stream
@@ -516,7 +516,7 @@ def _make_deploy_log_streamer(
         lines = raw.splitlines()
         new_lines = lines[seen_count:]
         for line in new_lines:
-            cli_console.step(line)
+            log.info(line)
         seen_count = len(lines)
 
     return _stream

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -477,7 +477,7 @@ def _make_build_log_streamer(
     """
     seen_count: list[int] = [0]
 
-    def _stream(_status) -> None:
+    def _stream() -> None:
         try:
             logs = manager.get_build_job_logs(build_job_fqn)
         except Exception:
@@ -502,7 +502,7 @@ def _make_deploy_log_streamer(
     """
     seen_count: list[int] = [0]
 
-    def _stream(_status) -> None:
+    def _stream() -> None:
         try:
             raw = manager.get_app_service_logs(service_fqn.identifier)
         except Exception:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Callable, Optional
@@ -54,7 +55,7 @@ from snowflake.cli.api.output.types import (
 from snowflake.cli.api.project.util import get_env_username, identifier_for_url
 from snowflake.connector.errors import ProgrammingError
 
-log = __import__("logging").getLogger(__name__)
+log = logging.getLogger(__name__)
 
 # ── Source provenance labels ──────────────────────────────────────────
 SOURCE_USER_INPUT = "user input"
@@ -475,18 +476,19 @@ def _make_build_log_streamer(
     Each invocation of ``SPCS_GET_LOGS`` returns the *full* log history.
     We track how many lines were already printed and emit only the delta.
     """
-    seen_count: list[int] = [0]
+    seen_count = 0
 
     def _stream() -> None:
+        nonlocal seen_count
         try:
             logs = manager.get_build_job_logs(build_job_fqn)
         except Exception:
             log.debug("Failed to fetch build logs", exc_info=True)
             return
-        new_lines = logs[seen_count[0] :]
+        new_lines = logs[seen_count:]
         for line in new_lines:
             cli_console.step(line)
-        seen_count[0] = len(logs)
+        seen_count = len(logs)
 
     return _stream
 
@@ -500,9 +502,10 @@ def _make_deploy_log_streamer(
     containing all log output.  We split by newlines, track what has
     already been printed, and emit only new lines.
     """
-    seen_count: list[int] = [0]
+    seen_count = 0
 
     def _stream() -> None:
+        nonlocal seen_count
         try:
             raw = manager.get_app_service_logs(service_fqn.identifier)
         except Exception:
@@ -511,10 +514,10 @@ def _make_deploy_log_streamer(
         if not raw:
             return
         lines = raw.splitlines()
-        new_lines = lines[seen_count[0] :]
+        new_lines = lines[seen_count:]
         for line in new_lines:
             cli_console.step(line)
-        seen_count[0] = len(lines)
+        seen_count = len(lines)
 
     return _stream
 

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -951,16 +951,10 @@ class SnowflakeAppManager(SqlExecutionMixin):
     def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
         """Fetch build logs via the build job's ``SPCS_GET_LOGS`` table function.
 
-        Runs ``SELECT * FROM TABLE(<build_job_fqn>!SPCS_GET_LOGS())`` and
+        Runs ``SELECT LOG FROM TABLE(<build_job_fqn>!SPCS_GET_LOGS())`` and
         returns the LOG column values as an ordered list of strings.
         """
         cursor = self.execute_query(
-            f"SELECT * FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
-            cursor_class=DictCursor,
+            f"SELECT LOG FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
         )
-        logs: list[str] = []
-        for row in cursor:
-            log_val = row.get("LOG") or row.get("log") or ""
-            if log_val:
-                logs.append(str(log_val))
-        return logs
+        return [str(row[0]) for row in cursor if row[0]]

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -83,6 +83,7 @@ def _poll_until(
     max_attempts: int = 240,
     interval_seconds: int = 5,
     timeout_message: str = "Operation timed out.",
+    on_poll: Optional[Callable[[T], None]] = None,
 ) -> T:
     """Poll *poll_fn* until the result satisfies a done condition.
 
@@ -96,6 +97,10 @@ def _poll_until(
         Call *is_done(result)* each iteration.  Optionally supply *is_error*
         to detect error values.
 
+    If *on_poll* is provided, it is called with the poll result after each
+    iteration.  Exceptions from *on_poll* are logged and swallowed so they
+    do not interrupt the polling loop.
+
     Raises ``CliError`` on error or timeout.  Returns the final value on
     success.
     """
@@ -103,6 +108,12 @@ def _poll_until(
         time.sleep(interval_seconds)
         result = poll_fn()
         cli_console.step(f"Status: {format_status(result)}")
+
+        if on_poll is not None:
+            try:
+                on_poll(result)
+            except Exception:
+                log.debug("on_poll callback failed", exc_info=True)
 
         if is_done is not None:
             # ── Predicate mode ────────────────────────────────────
@@ -932,3 +943,20 @@ class SnowflakeAppManager(SqlExecutionMixin):
         )
         row = cursor.fetchone()
         return row[0] if row else ""
+
+    def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
+        """Fetch build logs via the build job's ``SPCS_GET_LOGS`` table function.
+
+        Runs ``SELECT * FROM TABLE(<build_job_fqn>!SPCS_GET_LOGS())`` and
+        returns the LOG column values as an ordered list of strings.
+        """
+        cursor = self.execute_query(
+            f"SELECT * FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
+            cursor_class=DictCursor,
+        )
+        logs: list[str] = []
+        for row in cursor:
+            log_val = row.get("LOG") or row.get("log") or ""
+            if log_val:
+                logs.append(str(log_val))
+        return logs

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -83,7 +83,7 @@ def _poll_until(
     max_attempts: int = 240,
     interval_seconds: int = 5,
     timeout_message: str = "Operation timed out.",
-    on_poll: Optional[Callable[[T], None]] = None,
+    on_poll: Optional[Callable[[], None]] = None,
 ) -> T:
     """Poll *poll_fn* until the result satisfies a done condition.
 
@@ -97,23 +97,27 @@ def _poll_until(
         Call *is_done(result)* each iteration.  Optionally supply *is_error*
         to detect error values.
 
-    If *on_poll* is provided, it is called with the poll result after each
-    iteration.  Exceptions from *on_poll* are logged and swallowed so they
-    do not interrupt the polling loop.
+    If *on_poll* is provided it is called every second between status
+    checks, so log output streams continuously rather than in bursts
+    every *interval_seconds*.  Exceptions from *on_poll* are logged and
+    swallowed so they never interrupt the polling loop.
 
     Raises ``CliError`` on error or timeout.  Returns the final value on
     success.
     """
     for _attempt in range(max_attempts):
-        time.sleep(interval_seconds)
+        if on_poll is not None:
+            for _ in range(interval_seconds):
+                time.sleep(1)
+                try:
+                    on_poll()
+                except Exception:
+                    log.debug("on_poll callback failed", exc_info=True)
+        else:
+            time.sleep(interval_seconds)
+
         result = poll_fn()
         cli_console.step(f"Status: {format_status(result)}")
-
-        if on_poll is not None:
-            try:
-                on_poll(result)
-            except Exception:
-                log.debug("on_poll callback failed", exc_info=True)
 
         if is_done is not None:
             # ── Predicate mode ────────────────────────────────────

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -949,11 +949,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         return row[0] if row else ""
 
     def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
-        """Fetch build logs via the build job's ``SPCS_GET_LOGS`` table function.
-
-        Runs ``SELECT LOG FROM TABLE(<build_job_fqn>!SPCS_GET_LOGS())`` and
-        returns the LOG column values as an ordered list of strings.
-        """
+        """Fetch build logs for a build job service."""
         cursor = self.execute_query(
             f"SELECT LOG FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
         )

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -118,8 +118,6 @@
   | --deploy-only                Run only the deploy phase (assumes the          |
   |                              container image has already been built). Skips  |
   |                              the upload and build phases.                    |
-  | --hide-logs                  Disable live log streaming during the build and |
-  |                              deploy phases.                                  |
   | --help         -h            Show this message and exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -118,6 +118,8 @@
   | --deploy-only                Run only the deploy phase (assumes the          |
   |                              container image has already been built). Skips  |
   |                              the upload and build phases.                    |
+  | --hide-logs                  Disable live log streaming during the build and |
+  |                              deploy phases.                                  |
   | --help         -h            Show this message and exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 from snowflake.cli._plugins.apps.commands import (
@@ -322,7 +322,7 @@ class TestPollUntilOnPoll:
         )
         assert on_poll.call_count == 3
         assert mock_sleep.call_count == 3
-        mock_sleep.assert_called_with(1)
+        assert all(c == call(1) for c in mock_sleep.call_args_list)
 
     @patch("snowflake.cli._plugins.apps.manager.time.sleep")
     def test_on_poll_exception_does_not_interrupt_polling(self, mock_sleep):

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -375,25 +375,25 @@ class TestBuildLogStreamer:
         fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
 
         streamer = _make_build_log_streamer(manager, fqn)
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             streamer()
 
-        assert mock_console.step.call_count == 3
-        mock_console.step.assert_any_call("line1")
-        mock_console.step.assert_any_call("line2")
-        mock_console.step.assert_any_call("line3")
+        assert mock_log.info.call_count == 3
+        mock_log.info.assert_any_call("line1")
+        mock_log.info.assert_any_call("line2")
+        mock_log.info.assert_any_call("line3")
 
     def test_subsequent_call_prints_only_new_lines(self):
         manager = Mock()
         fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
         streamer = _make_build_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_build_job_logs.return_value = ["line1", "line2"]
             streamer()
-            assert mock_console.step.call_count == 2
+            assert mock_log.info.call_count == 2
 
-            mock_console.step.reset_mock()
+            mock_log.info.reset_mock()
             manager.get_build_job_logs.return_value = [
                 "line1",
                 "line2",
@@ -401,23 +401,23 @@ class TestBuildLogStreamer:
                 "line4",
             ]
             streamer()
-            assert mock_console.step.call_count == 2
-            mock_console.step.assert_any_call("line3")
-            mock_console.step.assert_any_call("line4")
+            assert mock_log.info.call_count == 2
+            mock_log.info.assert_any_call("line3")
+            mock_log.info.assert_any_call("line4")
 
     def test_no_new_lines_prints_nothing(self):
         manager = Mock()
         fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
         streamer = _make_build_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_build_job_logs.return_value = ["line1"]
             streamer()
-            mock_console.step.reset_mock()
+            mock_log.info.reset_mock()
 
             manager.get_build_job_logs.return_value = ["line1"]
             streamer()
-            mock_console.step.assert_not_called()
+            mock_log.info.assert_not_called()
 
     def test_empty_logs_prints_nothing(self):
         manager = Mock()
@@ -425,9 +425,9 @@ class TestBuildLogStreamer:
         fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
         streamer = _make_build_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             streamer()
-            mock_console.step.assert_not_called()
+            mock_log.info.assert_not_called()
 
     def test_exception_is_swallowed(self):
         manager = Mock()
@@ -442,21 +442,21 @@ class TestBuildLogStreamer:
         fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
         streamer = _make_build_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_build_job_logs.return_value = ["line1", "line2"]
             streamer()
-            assert mock_console.step.call_count == 2
+            assert mock_log.info.call_count == 2
 
-            mock_console.step.reset_mock()
+            mock_log.info.reset_mock()
             manager.get_build_job_logs.side_effect = RuntimeError("transient")
             streamer()
-            mock_console.step.assert_not_called()
+            mock_log.info.assert_not_called()
 
             manager.get_build_job_logs.side_effect = None
             manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
             streamer()
-            assert mock_console.step.call_count == 1
-            mock_console.step.assert_called_with("line3")
+            assert mock_log.info.call_count == 1
+            mock_log.info.assert_called_with("line3")
 
 
 class TestDeployLogStreamer:
@@ -468,45 +468,45 @@ class TestDeployLogStreamer:
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
 
         streamer = _make_deploy_log_streamer(manager, fqn)
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             streamer()
 
         manager.get_app_service_logs.assert_called_with("DB.SCHEMA.MY_APP")
-        assert mock_console.step.call_count == 3
-        mock_console.step.assert_any_call("line1")
-        mock_console.step.assert_any_call("line2")
-        mock_console.step.assert_any_call("line3")
+        assert mock_log.info.call_count == 3
+        mock_log.info.assert_any_call("line1")
+        mock_log.info.assert_any_call("line2")
+        mock_log.info.assert_any_call("line3")
 
     def test_subsequent_call_prints_only_new_lines(self):
         manager = Mock()
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
         streamer = _make_deploy_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_app_service_logs.return_value = "a\nb"
             streamer()
-            assert mock_console.step.call_count == 2
+            assert mock_log.info.call_count == 2
 
-            mock_console.step.reset_mock()
+            mock_log.info.reset_mock()
             manager.get_app_service_logs.return_value = "a\nb\nc\nd"
             streamer()
-            assert mock_console.step.call_count == 2
-            mock_console.step.assert_any_call("c")
-            mock_console.step.assert_any_call("d")
+            assert mock_log.info.call_count == 2
+            mock_log.info.assert_any_call("c")
+            mock_log.info.assert_any_call("d")
 
     def test_no_new_lines_prints_nothing(self):
         manager = Mock()
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
         streamer = _make_deploy_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_app_service_logs.return_value = "line1"
             streamer()
-            mock_console.step.reset_mock()
+            mock_log.info.reset_mock()
 
             manager.get_app_service_logs.return_value = "line1"
             streamer()
-            mock_console.step.assert_not_called()
+            mock_log.info.assert_not_called()
 
     def test_empty_string_prints_nothing(self):
         manager = Mock()
@@ -514,9 +514,9 @@ class TestDeployLogStreamer:
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
         streamer = _make_deploy_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             streamer()
-            mock_console.step.assert_not_called()
+            mock_log.info.assert_not_called()
 
     def test_exception_is_swallowed(self):
         manager = Mock()
@@ -531,34 +531,34 @@ class TestDeployLogStreamer:
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
         streamer = _make_deploy_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_app_service_logs.return_value = "a\nb"
             streamer()
-            assert mock_console.step.call_count == 2
+            assert mock_log.info.call_count == 2
 
-            mock_console.step.reset_mock()
+            mock_log.info.reset_mock()
             manager.get_app_service_logs.side_effect = RuntimeError("transient")
             streamer()
-            mock_console.step.assert_not_called()
+            mock_log.info.assert_not_called()
 
             manager.get_app_service_logs.side_effect = None
             manager.get_app_service_logs.return_value = "a\nb\nc"
             streamer()
-            assert mock_console.step.call_count == 1
-            mock_console.step.assert_called_with("c")
+            assert mock_log.info.call_count == 1
+            mock_log.info.assert_called_with("c")
 
     def test_multiline_with_various_line_endings(self):
         manager = Mock()
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
         streamer = _make_deploy_log_streamer(manager, fqn)
 
-        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
             manager.get_app_service_logs.return_value = "a\r\nb\nc"
             streamer()
-            assert mock_console.step.call_count == 3
-            mock_console.step.assert_any_call("a")
-            mock_console.step.assert_any_call("b")
-            mock_console.step.assert_any_call("c")
+            assert mock_log.info.call_count == 3
+            mock_log.info.assert_any_call("a")
+            mock_log.info.assert_any_call("b")
+            mock_log.info.assert_any_call("c")
 
 
 # ── _generate_snowflake_yml tests ─────────────────────────────────────

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -15,6 +15,10 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from snowflake.cli._plugins.apps.commands import (
+    _make_build_log_streamer,
+    _make_deploy_log_streamer,
+)
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
 )
@@ -300,6 +304,255 @@ class TestPollUntilStateSetMode:
                 timeout_message="timed out",
             )
         assert mock_sleep.call_count == 2
+
+
+class TestPollUntilOnPoll:
+    """Tests for the on_poll callback that streams logs between status checks."""
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_called_every_second_between_status_checks(self, mock_sleep):
+        on_poll = Mock()
+        _poll_until(
+            poll_fn=lambda: "DONE",
+            done_states={"DONE"},
+            known_pending_states={"PENDING"},
+            timeout_message="timed out",
+            interval_seconds=3,
+            on_poll=on_poll,
+        )
+        assert on_poll.call_count == 3
+        assert mock_sleep.call_count == 3
+        mock_sleep.assert_called_with(1)
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_exception_does_not_interrupt_polling(self, mock_sleep):
+        on_poll = Mock(side_effect=RuntimeError("log fetch failed"))
+        result = _poll_until(
+            poll_fn=lambda: "DONE",
+            done_states={"DONE"},
+            known_pending_states={"PENDING"},
+            timeout_message="timed out",
+            interval_seconds=2,
+            on_poll=on_poll,
+        )
+        assert result == "DONE"
+        assert on_poll.call_count == 2
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_called_across_multiple_iterations(self, mock_sleep):
+        values = iter(["PENDING", "DONE"])
+        on_poll = Mock()
+        _poll_until(
+            poll_fn=lambda: next(values),
+            done_states={"DONE"},
+            known_pending_states={"PENDING"},
+            timeout_message="timed out",
+            interval_seconds=5,
+            on_poll=on_poll,
+        )
+        assert on_poll.call_count == 10
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_no_on_poll_uses_single_sleep(self, mock_sleep):
+        _poll_until(
+            poll_fn=lambda: "DONE",
+            done_states={"DONE"},
+            timeout_message="timed out",
+            interval_seconds=5,
+        )
+        mock_sleep.assert_called_once_with(5)
+
+
+# ── Log streamer tests ────────────────────────────────────────────────
+
+
+class TestBuildLogStreamer:
+    """Tests for _make_build_log_streamer incremental log diffing."""
+
+    def test_first_call_prints_all_lines(self):
+        manager = Mock()
+        manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+
+        streamer = _make_build_log_streamer(manager, fqn)
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            streamer()
+
+        assert mock_console.step.call_count == 3
+        mock_console.step.assert_any_call("line1")
+        mock_console.step.assert_any_call("line2")
+        mock_console.step.assert_any_call("line3")
+
+    def test_subsequent_call_prints_only_new_lines(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_build_job_logs.return_value = ["line1", "line2"]
+            streamer()
+            assert mock_console.step.call_count == 2
+
+            mock_console.step.reset_mock()
+            manager.get_build_job_logs.return_value = [
+                "line1",
+                "line2",
+                "line3",
+                "line4",
+            ]
+            streamer()
+            assert mock_console.step.call_count == 2
+            mock_console.step.assert_any_call("line3")
+            mock_console.step.assert_any_call("line4")
+
+    def test_no_new_lines_prints_nothing(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_build_job_logs.return_value = ["line1"]
+            streamer()
+            mock_console.step.reset_mock()
+
+            manager.get_build_job_logs.return_value = ["line1"]
+            streamer()
+            mock_console.step.assert_not_called()
+
+    def test_empty_logs_prints_nothing(self):
+        manager = Mock()
+        manager.get_build_job_logs.return_value = []
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            streamer()
+            mock_console.step.assert_not_called()
+
+    def test_exception_is_swallowed(self):
+        manager = Mock()
+        manager.get_build_job_logs.side_effect = RuntimeError("connection lost")
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        streamer()  # should not raise
+
+    def test_exception_does_not_reset_seen_count(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_build_job_logs.return_value = ["line1", "line2"]
+            streamer()
+            assert mock_console.step.call_count == 2
+
+            mock_console.step.reset_mock()
+            manager.get_build_job_logs.side_effect = RuntimeError("transient")
+            streamer()
+            mock_console.step.assert_not_called()
+
+            manager.get_build_job_logs.side_effect = None
+            manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
+            streamer()
+            assert mock_console.step.call_count == 1
+            mock_console.step.assert_called_with("line3")
+
+
+class TestDeployLogStreamer:
+    """Tests for _make_deploy_log_streamer incremental log diffing."""
+
+    def test_first_call_prints_all_lines(self):
+        manager = Mock()
+        manager.get_app_service_logs.return_value = "line1\nline2\nline3"
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+
+        streamer = _make_deploy_log_streamer(manager, fqn)
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            streamer()
+
+        manager.get_app_service_logs.assert_called_with("DB.SCHEMA.MY_APP")
+        assert mock_console.step.call_count == 3
+
+    def test_subsequent_call_prints_only_new_lines(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_deploy_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_app_service_logs.return_value = "a\nb"
+            streamer()
+            assert mock_console.step.call_count == 2
+
+            mock_console.step.reset_mock()
+            manager.get_app_service_logs.return_value = "a\nb\nc\nd"
+            streamer()
+            assert mock_console.step.call_count == 2
+            mock_console.step.assert_any_call("c")
+            mock_console.step.assert_any_call("d")
+
+    def test_no_new_lines_prints_nothing(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_deploy_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_app_service_logs.return_value = "line1"
+            streamer()
+            mock_console.step.reset_mock()
+
+            manager.get_app_service_logs.return_value = "line1"
+            streamer()
+            mock_console.step.assert_not_called()
+
+    def test_empty_string_prints_nothing(self):
+        manager = Mock()
+        manager.get_app_service_logs.return_value = ""
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_deploy_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            streamer()
+            mock_console.step.assert_not_called()
+
+    def test_exception_is_swallowed(self):
+        manager = Mock()
+        manager.get_app_service_logs.side_effect = RuntimeError("connection lost")
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_deploy_log_streamer(manager, fqn)
+
+        streamer()  # should not raise
+
+    def test_exception_does_not_reset_seen_count(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_deploy_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_app_service_logs.return_value = "a\nb"
+            streamer()
+            assert mock_console.step.call_count == 2
+
+            mock_console.step.reset_mock()
+            manager.get_app_service_logs.side_effect = RuntimeError("transient")
+            streamer()
+            mock_console.step.assert_not_called()
+
+            manager.get_app_service_logs.side_effect = None
+            manager.get_app_service_logs.return_value = "a\nb\nc"
+            streamer()
+            assert mock_console.step.call_count == 1
+            mock_console.step.assert_called_with("c")
+
+    def test_multiline_with_various_line_endings(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_deploy_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            manager.get_app_service_logs.return_value = "a\r\nb\nc"
+            streamer()
+            assert mock_console.step.call_count == 3
 
 
 # ── _generate_snowflake_yml tests ─────────────────────────────────────

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -473,6 +473,9 @@ class TestDeployLogStreamer:
 
         manager.get_app_service_logs.assert_called_with("DB.SCHEMA.MY_APP")
         assert mock_console.step.call_count == 3
+        mock_console.step.assert_any_call("line1")
+        mock_console.step.assert_any_call("line2")
+        mock_console.step.assert_any_call("line3")
 
     def test_subsequent_call_prints_only_new_lines(self):
         manager = Mock()
@@ -553,6 +556,9 @@ class TestDeployLogStreamer:
             manager.get_app_service_logs.return_value = "a\r\nb\nc"
             streamer()
             assert mock_console.step.call_count == 3
+            mock_console.step.assert_any_call("a")
+            mock_console.step.assert_any_call("b")
+            mock_console.step.assert_any_call("c")
 
 
 # ── _generate_snowflake_yml tests ─────────────────────────────────────


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

When calling `snow __app deploy --verbose` we now show live log streaming of the build and application so users see deploy output incrementally instead of waiting in silence.