### PR TITLE
Auto-create image repository in snow app deploy if it does not exist

### DIFF
--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -554,7 +554,19 @@ class SnowflakeAppManager(SqlExecutionMixin):
         cursor = self.execute_query(show_obj_query, cursor_class=DictCursor)
 
         if cursor.rowcount is None or cursor.rowcount == 0:
-            raise CliError(f"Image repository '{repo_name}' not found")
+            # Auto-create the image repository if it doesn't exist
+            create_repo_fqn = repo_name
+            if database and schema:
+                create_repo_fqn = f"{database}.{schema}.{repo_name}"
+            elif database:
+                create_repo_fqn = f"{database}..{repo_name}"
+            cli_console.step(f"Image repository '{repo_name}' not found. Creating it.")
+            self.execute_query(
+                f"CREATE IMAGE REPOSITORY IF NOT EXISTS {create_repo_fqn}"
+            )
+            cursor = self.execute_query(show_obj_query, cursor_class=DictCursor)
+            if cursor.rowcount is None or cursor.rowcount == 0:
+                raise CliError(f"Image repository '{repo_name}' could not be created")
 
         unqualified_name = unquote_identifier(repo_name)
         rows = cursor.fetchall()

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -513,22 +513,72 @@ class TestSnowflakeAppManager:
         assert result == "host.registry-local.snowflakecomputing.com/db/schema/my_repo"
 
     @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_not_found_empty(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 0
-        mock_execute.return_value = cursor
+    def test_get_image_repo_url_not_found_creates_repo(self, mock_execute):
+        empty_cursor = Mock()
+        empty_cursor.rowcount = 0
 
-        with pytest.raises(CliError, match="Image repository 'MY_REPO' not found"):
+        create_cursor = Mock()
+
+        found_cursor = Mock()
+        found_cursor.rowcount = 1
+        found_cursor.fetchall.return_value = [
+            {
+                "name": "MY_REPO",
+                "repository_url": "host.registry.snowflakecomputing.com/db/schema/my_repo",
+            }
+        ]
+
+        mock_execute.side_effect = [empty_cursor, create_cursor, found_cursor]
+
+        result = SnowflakeAppManager().get_image_repo_url("MY_REPO")
+        assert result == "host.registry-local.snowflakecomputing.com/db/schema/my_repo"
+
+        assert mock_execute.call_count == 3
+        # Second call should be the CREATE statement
+        create_call_args = mock_execute.call_args_list[1]
+        assert "CREATE IMAGE REPOSITORY IF NOT EXISTS MY_REPO" in create_call_args[0][0]
+
+    @patch(EXECUTE_QUERY)
+    def test_get_image_repo_url_not_found_create_fails(self, mock_execute):
+        empty_cursor = Mock()
+        empty_cursor.rowcount = 0
+
+        create_cursor = Mock()
+
+        still_empty_cursor = Mock()
+        still_empty_cursor.rowcount = 0
+
+        mock_execute.side_effect = [empty_cursor, create_cursor, still_empty_cursor]
+
+        with pytest.raises(
+            CliError, match="Image repository 'MY_REPO' could not be created"
+        ):
             SnowflakeAppManager().get_image_repo_url("MY_REPO")
 
     @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_not_found_none_rowcount(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = None
-        mock_execute.return_value = cursor
+    def test_get_image_repo_url_not_found_none_rowcount_creates_repo(
+        self, mock_execute
+    ):
+        none_cursor = Mock()
+        none_cursor.rowcount = None
 
-        with pytest.raises(CliError, match="Image repository 'MY_REPO' not found"):
-            SnowflakeAppManager().get_image_repo_url("MY_REPO")
+        create_cursor = Mock()
+
+        found_cursor = Mock()
+        found_cursor.rowcount = 1
+        found_cursor.fetchall.return_value = [
+            {
+                "name": "MY_REPO",
+                "repository_url": "host.registry.snowflakecomputing.com/db/schema/my_repo",
+            }
+        ]
+
+        mock_execute.side_effect = [none_cursor, create_cursor, found_cursor]
+
+        result = SnowflakeAppManager().get_image_repo_url("MY_REPO")
+        assert result == "host.registry-local.snowflakecomputing.com/db/schema/my_repo"
+
+        assert mock_execute.call_count == 3
 
     @patch(EXECUTE_QUERY)
     def test_get_image_repo_url_with_database_and_schema(self, mock_execute):


### PR DESCRIPTION
Instead of raising an error when the image repository is not found during deploy, automatically create it with CREATE IMAGE REPOSITORY IF NOT EXISTS and retry the lookup. This removes a manual prerequisite step for users.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
...
