### PR TITLE
Stream build logs during deploy polling instead of status-only messages

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -54,6 +54,29 @@ from snowflake.cli.api.output.types import (
 from snowflake.cli.api.project.util import get_env_username, identifier_for_url
 from snowflake.connector.errors import ProgrammingError
 
+
+def _make_build_log_streamer(
+    manager: SnowflakeAppManager, job_fqn, label: str = "build"
+):
+    """Return a callback that streams new build logs each time it is called.
+
+    Meant to be passed as ``on_poll`` to :func:`_poll_until`.
+    """
+    state = {"since": ""}
+
+    def _stream():
+        lines, new_since = manager.get_build_logs(
+            job_fqn, since_timestamp=state["since"]
+        )
+        if lines:
+            cli_console.step(f"── {label} logs ──")
+            for line in lines:
+                cli_console.step(line)
+        state["since"] = new_since
+
+    return _stream
+
+
 # ── Source provenance labels ──────────────────────────────────────────
 SOURCE_USER_INPUT = "user input"
 SOURCE_ACCOUNT_PARAM = "account parameter"
@@ -661,6 +684,9 @@ def deploy(
                 done_states={"DONE"},
                 error_states={"FAILED", "IDLE"},
                 known_pending_states={"PENDING", "RUNNING"},
+                on_poll=_make_build_log_streamer(
+                    manager, artifact_build_job_fqn, label="artifact build"
+                ),
                 timeout_message=(
                     f"Artifact repo build timed out. Check build logs:\n"
                     f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
@@ -687,6 +713,7 @@ def deploy(
                 done_states={"DONE"},
                 error_states={"FAILED", "IDLE"},
                 known_pending_states={"PENDING", "RUNNING"},
+                on_poll=_make_build_log_streamer(manager, build_job_fqn),
                 timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
             )
 

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -20,7 +20,17 @@ import re
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
 from snowflake.cli._plugins.apps.generate import IS_PERSONAL_DB_SUPPORTED
 from snowflake.cli._plugins.apps.snowflake_app_entity_model import DEFAULT_APP_PORT
@@ -80,6 +90,7 @@ def _poll_until(
     is_done: Optional[Callable[[T], bool]] = None,
     is_error: Optional[Callable[[T], bool]] = None,
     format_status: Callable[[T], str] = str,
+    on_poll: Optional[Callable[[], None]] = None,
     max_attempts: int = 240,
     interval_seconds: int = 5,
     timeout_message: str = "Operation timed out.",
@@ -96,6 +107,10 @@ def _poll_until(
         Call *is_done(result)* each iteration.  Optionally supply *is_error*
         to detect error values.
 
+    If *on_poll* is provided it is called after each status check,
+    regardless of mode.  This is useful for side-effects such as
+    streaming logs while waiting.
+
     Raises ``CliError`` on error or timeout.  Returns the final value on
     success.
     """
@@ -103,6 +118,9 @@ def _poll_until(
         time.sleep(interval_seconds)
         result = poll_fn()
         cli_console.step(f"Status: {format_status(result)}")
+
+        if on_poll is not None:
+            on_poll()
 
         if is_done is not None:
             # ── Predicate mode ────────────────────────────────────
@@ -636,6 +654,44 @@ class SnowflakeAppManager(SqlExecutionMixin):
                 return row["status"]
 
         return "IDLE"
+
+    def get_build_logs(
+        self,
+        job_fqn: FQN,
+        since_timestamp: str = "",
+        num_lines: int = 500,
+    ) -> Tuple[List[str], str]:
+        """Fetch new log lines from the build job service since *since_timestamp*.
+
+        Returns ``(new_lines, updated_since_timestamp)`` so the caller can
+        pass the timestamp back on the next call for incremental fetching.
+        """
+        try:
+            cursor = self.execute_query(
+                f"CALL SYSTEM$GET_SERVICE_LOGS("
+                f"'{job_fqn.identifier}', '0', 'main', "
+                f"{num_lines}, FALSE, '{since_timestamp}', TRUE)"
+            )
+            row = cursor.fetchone()
+            raw = row[0] if row else ""
+        except Exception:  # noqa: BLE001
+            # Logs may not be available yet (e.g. container not started)
+            return [], since_timestamp
+
+        if not raw or not raw.strip():
+            return [], since_timestamp
+
+        lines = [line for line in raw.split("\n") if line.strip()]
+        if not lines:
+            return [], since_timestamp
+
+        # Each line with timestamps starts with an ISO timestamp followed by a space.
+        # Use the timestamp from the last line as the new since_timestamp.
+        last_line = lines[-1]
+        parts = last_line.split(" ", 1)
+        new_since = parts[0] if len(parts) > 1 else since_timestamp
+
+        return lines, new_since
 
     def create_service(
         self,

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -301,8 +301,29 @@ class TestPollUntilStateSetMode:
             )
         assert mock_sleep.call_count == 2
 
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_called_each_iteration(self, mock_sleep):
+        values = iter(["PENDING", "DONE"])
+        on_poll = Mock()
+        _poll_until(
+            poll_fn=lambda: next(values),
+            done_states={"DONE"},
+            error_states={"FAILED"},
+            known_pending_states={"PENDING"},
+            on_poll=on_poll,
+            timeout_message="timed out",
+        )
+        assert on_poll.call_count == 2
 
-# ── _generate_snowflake_yml tests ─────────────────────────────────────
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_not_called_when_none(self, mock_sleep):
+        """Verify backward compatibility: no on_poll means no extra calls."""
+        _poll_until(
+            poll_fn=lambda: "DONE",
+            done_states={"DONE"},
+            timeout_message="timed out",
+        )
+        # No error means it worked without on_poll
 
 
 class TestGenerateSnowflakeYml:
@@ -906,6 +927,59 @@ class TestSnowflakeAppManager:
         fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
         status = SnowflakeAppManager().get_build_status(fqn)
         assert status == "DONE"
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_logs_returns_lines_and_timestamp(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = (
+            "2024-01-01T00:00:01Z Building layer 1\n"
+            "2024-01-01T00:00:02Z Building layer 2\n",
+        )
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        lines, since = SnowflakeAppManager().get_build_logs(fqn)
+        assert len(lines) == 2
+        assert "Building layer 1" in lines[0]
+        assert "Building layer 2" in lines[1]
+        assert since == "2024-01-01T00:00:02Z"
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_logs_with_since_timestamp(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("2024-01-01T00:00:03Z Building layer 3\n",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        lines, since = SnowflakeAppManager().get_build_logs(
+            fqn, since_timestamp="2024-01-01T00:00:02Z"
+        )
+        assert len(lines) == 1
+        assert "Building layer 3" in lines[0]
+        assert since == "2024-01-01T00:00:03Z"
+        # Verify since_timestamp was passed to the query
+        query = mock_execute.call_args[0][0]
+        assert "2024-01-01T00:00:02Z" in query
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_logs_empty_result(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        lines, since = SnowflakeAppManager().get_build_logs(fqn)
+        assert lines == []
+        assert since == ""
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_logs_handles_exception(self, mock_execute):
+        mock_execute.side_effect = Exception("container not ready")
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        lines, since = SnowflakeAppManager().get_build_logs(fqn)
+        assert lines == []
+        assert since == ""
 
     @patch(EXECUTE_QUERY)
     def test_create_service_basic(self, mock_execute):


### PR DESCRIPTION
Add on_poll callback to _poll_until and a get_build_logs method to SnowflakeAppManager that fetches incremental logs via SYSTEM$GET_SERVICE_LOGS. Both build polling sites (artifact repo and SPCS job) now stream the latest build container logs each polling iteration.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
...
