### PR TITLE
Snowflake Apps: Use artifact repository only

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -627,7 +627,8 @@ def deploy(
             known_pending_states={"PENDING", "RUNNING"},
             timeout_message=(
                 f"Artifact repo build timed out. Check build logs:\n"
-                f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
+                f"  SELECT * FROM TABLE("
+                f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
             ),
         )
 
@@ -712,3 +713,79 @@ def deploy(
     if endpoint_url and not endpoint_url.startswith(("http://", "https://")):
         endpoint_url = f"https://{endpoint_url}"
     return MessageResult(f"App ready at {endpoint_url}")
+
+
+@app.command(requires_connection=True)
+def teardown(
+    entity_id: Optional[str] = typer.Option(
+        None,
+        "--entity-id",
+        help="ID of the snowflake-app entity to tear down. Required if multiple snowflake-app entities exist.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Drop without confirmation prompt.",
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Drops a deployed Snowflake App and its associated objects.
+
+    Reads the entity from snowflake.yml and drops the application service
+    (or SPCS service), the code stage, and the build job service.
+    Unless --force is provided, prompts for confirmation before dropping.
+    """
+    resolved_entity_id = _resolve_entity_id(entity_id)
+    entity = _get_entity(resolved_entity_id)
+
+    fqn = entity.fqn
+    manager = SnowflakeAppManager()
+    defaults = _resolve_deploy_defaults(entity, manager, app_name=fqn.name)
+
+    db = defaults.get("database")
+    schema = defaults.get("schema")
+
+    if not db or not schema:
+        missing = [k for k, v in {"database": db, "schema": schema}.items() if not v]
+        raise CliError(
+            f"Cannot resolve {' or '.join(missing)} for the app. "
+            "Set them in snowflake.yml or in your connection configuration."
+        )
+
+    app_name = fqn.name
+    service_fqn = FQN(database=db, schema=schema, name=app_name)
+    use_artifact_repo = entity.artifact_repository is not None
+
+    stage_name = (
+        entity.code_stage.name if entity.code_stage else f"{app_name}_CODE_STAGE"
+    )
+    stage_fqn = FQN(database=db, schema=schema, name=stage_name)
+    build_job_fqn = FQN(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
+
+    object_kind = "application service" if use_artifact_repo else "service"
+
+    if not force:
+        should_continue = typer.confirm(
+            f"Are you sure you want to drop {object_kind} {service_fqn.identifier}"
+            f" and its associated objects?"
+        )
+        if not should_continue:
+            return MessageResult("Teardown cancelled.")
+
+    cli_console.step(f"Dropping {object_kind} {service_fqn.identifier}")
+    if use_artifact_repo:
+        manager.drop_app_service_if_exists(service_fqn)
+    else:
+        manager.drop_service_if_exists(service_fqn)
+
+    cli_console.step(f"Dropping stage {stage_fqn.identifier}")
+    manager.drop_stage_if_exists(stage_fqn)
+
+    if not use_artifact_repo:
+        cli_console.step(f"Dropping build job service {build_job_fqn.identifier}")
+        manager.drop_service_if_exists(build_job_fqn)
+
+    return MessageResult(
+        f"Successfully dropped {object_kind} {service_fqn.identifier}."
+    )

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import json
-import logging
 import re
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 import typer
 from click import ClickException
@@ -26,7 +25,6 @@ from snowflake.cli._plugins.apps.generate import (
 )
 from snowflake.cli._plugins.apps.manager import (
     _APP_COMMAND_NAME,
-    DEFAULT_IMAGE_REPOSITORY,
     DEFINITION_FILENAME,
     EXPOSE_UNSUPPORTED_SYNTAX,
     SnowflakeAppManager,
@@ -54,8 +52,6 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.api.project.util import get_env_username, identifier_for_url
 from snowflake.connector.errors import ProgrammingError
-
-log = logging.getLogger(__name__)
 
 # ── Source provenance labels ──────────────────────────────────────────
 SOURCE_USER_INPUT = "user input"
@@ -186,11 +182,6 @@ def setup(
         "build_eai": _resolve(
             user_input=build_eai,
             account_param=params.get("build_eai"),
-        ),
-        # TODO: Remove image_repository default once the artifact repo path
-        # replaces the image repo path.
-        "image_repository": _resolve(
-            default_value=DEFAULT_IMAGE_REPOSITORY,
         ),
     }
 
@@ -452,51 +443,6 @@ def events(
     return MessageResult(logs)
 
 
-def _make_build_log_streamer(
-    manager: SnowflakeAppManager, build_job_fqn: FQN
-) -> Callable:
-    """Return an ``on_poll`` callback that streams new build log lines."""
-    seen_count = 0
-
-    def _stream() -> None:
-        nonlocal seen_count
-        try:
-            logs = manager.get_build_job_logs(build_job_fqn)
-        except Exception:
-            log.debug("Failed to fetch build logs", exc_info=True)
-            return
-        new_lines = logs[seen_count:]
-        for line in new_lines:
-            log.info(line)
-        seen_count = len(logs)
-
-    return _stream
-
-
-def _make_deploy_log_streamer(
-    manager: SnowflakeAppManager, service_fqn: FQN
-) -> Callable:
-    """Return an ``on_poll`` callback that streams new deploy log lines."""
-    seen_count = 0
-
-    def _stream() -> None:
-        nonlocal seen_count
-        try:
-            raw = manager.get_app_service_logs(service_fqn.identifier)
-        except Exception:
-            log.debug("Failed to fetch deploy logs", exc_info=True)
-            return
-        if not raw:
-            return
-        lines = raw.splitlines()
-        new_lines = lines[seen_count:]
-        for line in new_lines:
-            log.info(line)
-        seen_count = len(lines)
-
-    return _stream
-
-
 @app.command(requires_connection=True)
 def deploy(
     entity_id: Optional[str] = typer.Option(
@@ -578,7 +524,7 @@ def deploy(
 
     # ── Resolve defaults (snowflake.yml > account parameters > built-in) ──
     manager = SnowflakeAppManager()
-    defaults = _resolve_deploy_defaults(entity, manager)
+    defaults = _resolve_deploy_defaults(entity, manager, app_name=app_name)
 
     database = defaults["database"]
     schema = defaults["schema"]
@@ -587,16 +533,10 @@ def deploy(
     query_warehouse = defaults["query_warehouse"]
     build_eai = defaults["build_eai"]
 
-    image_repository = defaults["image_repository"]
-    image_repo_database = defaults.get("image_repo_database") or database
-    image_repo_schema = defaults.get("image_repo_schema") or schema
-
-    use_artifact_repo = entity.artifact_repository is not None
-    if use_artifact_repo:
-        ar = entity.artifact_repository
-        ar_database = ar.database or database
-        ar_schema = ar.schema_ or schema
-        artifact_repo_fqn_str = f"{ar_database}.{ar_schema}.{ar.name}"
+    ar_name = defaults["artifact_repository"]
+    ar_database = defaults["artifact_repo_database"]
+    ar_schema = defaults["artifact_repo_schema"]
+    artifact_repo_fqn_str = f"{ar_database}.{ar_schema}.{ar_name}"
 
     # ── Validate required configuration ───────────────────────────────
     if run_build and not build_compute_pool:
@@ -611,28 +551,11 @@ def deploy(
             "Please configure it in snowflake.yml."
         )
 
-    if run_deploy and not use_artifact_repo and not query_warehouse:
-        raise CliError(
-            "query_warehouse is required for the deploy phase. "
-            "Please configure it in snowflake.yml."
-        )
-
     # ── Derived names ─────────────────────────────────────────────────
     stage_fqn = FQN(database=database, schema=schema, name=stage_name)
-    build_job_service_name = f"{app_name}_BUILD_JOB"
-    build_job_fqn = FQN(database=database, schema=schema, name=build_job_service_name)
     service_fqn = FQN(database=database, schema=schema, name=app_name)
 
     stage_manager = StageManager()
-    image_repo_url = None
-
-    if (run_build or run_deploy) and not use_artifact_repo:
-        cli_console.step(f"Getting image repository URL for {image_repository}")
-        image_repo_url = manager.get_image_repo_url(
-            image_repository, database=image_repo_database, schema=image_repo_schema
-        )
-
-    metrics = get_cli_context().metrics
 
     # ── Upload phase ──────────────────────────────────────────────────
 
@@ -644,24 +567,18 @@ def deploy(
             cli_console.step(f"Creating stage @{stage_fqn}")
             manager.create_stage(stage_fqn, encryption_type)
 
-        # Step 3: Bundle artifact files
-        with metrics.span("snowflake_app.bundle"):
-            project_paths = perform_bundle(resolved_entity_id, entity)
+        project_paths = perform_bundle(resolved_entity_id, entity)
 
-        # Step 4: Upload bundled files to stage
         try:
-            with metrics.span("snowflake_app.upload"):
-                cli_console.step(f"Uploading bundled files to @{stage_fqn}")
-                for result in stage_manager.put_recursive(
-                    local_path=project_paths.bundle_root,
-                    stage_path=f"@{stage_fqn}",
-                    overwrite=True,
-                    auto_compress=False,
-                    temp_directory=project_paths.bundle_root,
-                ):
-                    cli_console.step(
-                        f"  Uploaded {result['source']} -> {result['target']}"
-                    )
+            cli_console.step(f"Uploading bundled files to @{stage_fqn}")
+            for result in stage_manager.put_recursive(
+                local_path=project_paths.bundle_root,
+                stage_path=f"@{stage_fqn}",
+                overwrite=True,
+                auto_compress=False,
+                temp_directory=project_paths.bundle_root,
+            ):
+                cli_console.step(f"  Uploaded {result['source']} -> {result['target']}")
         finally:
             project_paths.clean_up_output()
 
@@ -671,83 +588,48 @@ def deploy(
     # ── Build phase ───────────────────────────────────────────────────
 
     if run_build:
-        if use_artifact_repo:
-            if not manager.artifact_repo_exists(
-                database=ar_database, schema=ar_schema, repo_name=ar.name
-            ):
-                cli_console.step(
-                    f"Creating artifact repository: {artifact_repo_fqn_str}"
-                )
-                manager.create_artifact_repo(
-                    database=ar_database, schema=ar_schema, repo_name=ar.name
-                )
+        if not manager.artifact_repo_exists(
+            database=ar_database, schema=ar_schema, repo_name=ar_name
+        ):
+            cli_console.step(f"Creating artifact repository: {artifact_repo_fqn_str}")
+            manager.create_artifact_repo(
+                database=ar_database, schema=ar_schema, repo_name=ar_name
+            )
 
-            with metrics.span("snowflake_app.build"):
-                cli_console.step("Building app using artifact repository...")
-                build_result = manager.build_app_artifact_repo(
-                    stage_fqn=stage_fqn,
-                    artifact_repo_fqn=artifact_repo_fqn_str,
-                    app_id=app_name,
-                    compute_pool=build_compute_pool,
-                    database=database,
-                    schema=schema,
-                    runtime_image=entity.runtime_image,
-                    query_warehouse=query_warehouse,
-                    build_eai=build_eai,
-                )
-                cli_console.step(
-                    f"SPCS_TEST_BUILD_APP_ARTIFACT_REPO output:\n{build_result}"
-                )
+        cli_console.step("Building app using artifact repository...")
+        build_result = manager.build_app_artifact_repo(
+            stage_fqn=stage_fqn,
+            artifact_repo_fqn=artifact_repo_fqn_str,
+            app_id=app_name,
+            compute_pool=build_compute_pool,
+            database=database,
+            schema=schema,
+            runtime_image=entity.runtime_image,
+            query_warehouse=query_warehouse,
+            build_eai=build_eai,
+        )
+        cli_console.step(f"SPCS_TEST_BUILD_APP_ARTIFACT_REPO output:\n{build_result}")
 
-                match = re.search(r"Build job submitted:\s*(\S+)", build_result)
-                if not match:
-                    raise CliError(
-                        f"Could not parse build job name from output: {build_result}"
-                    )
-                artifact_build_job_fqn = FQN.from_string(match.group(1))
-                cli_console.step(
-                    f"Waiting for artifact repo build to complete: "
-                    f"{artifact_build_job_fqn}..."
-                )
-                _poll_until(
-                    poll_fn=lambda: manager.get_build_status(artifact_build_job_fqn),
-                    done_states={"DONE"},
-                    error_states={"FAILED", "IDLE"},
-                    known_pending_states={"PENDING", "RUNNING"},
-                    timeout_message=(
-                        f"Artifact repo build timed out. Check build logs:\n"
-                        f"  SELECT * FROM TABLE("
-                        f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
-                    ),
-                    on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
-                )
-        else:
-            with metrics.span("snowflake_app.build"):
-                # Drop existing build job if present
-                cli_console.step(f"Dropping service if exists: {build_job_fqn}")
-                manager.drop_service_if_exists(build_job_fqn)
-
-                # Execute build job service
-                cli_console.step(f"Executing build job service: {build_job_fqn}")
-                manager.execute_build_job(
-                    job_service_name=build_job_fqn,
-                    compute_pool=build_compute_pool,
-                    code_stage=stage_fqn,
-                    image_repo_url=image_repo_url,
-                    app_id=app_name,
-                    external_access_integration=build_eai,
-                    build_image=entity.build_image,
-                )
-
-                # Poll for build completion
-                cli_console.step("Waiting for build to complete...")
-                _poll_until(
-                    poll_fn=lambda: manager.get_build_status(build_job_fqn),
-                    done_states={"DONE"},
-                    error_states={"FAILED", "IDLE"},
-                    known_pending_states={"PENDING", "RUNNING"},
-                    timeout_message=f"Build timed out. Check service logs: {build_job_fqn}",
-                )
+        match = re.search(r"Build job submitted:\s*(\S+)", build_result)
+        if not match:
+            raise CliError(
+                f"Could not parse build job name from output: {build_result}"
+            )
+        artifact_build_job_fqn = FQN.from_string(match.group(1))
+        cli_console.step(
+            f"Waiting for artifact repo build to complete: "
+            f"{artifact_build_job_fqn}..."
+        )
+        _poll_until(
+            poll_fn=lambda: manager.get_build_status(artifact_build_job_fqn),
+            done_states={"DONE"},
+            error_states={"FAILED", "IDLE"},
+            known_pending_states={"PENDING", "RUNNING"},
+            timeout_message=(
+                f"Artifact repo build timed out. Check build logs:\n"
+                f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
+            ),
+        )
 
     if build_only:
         return MessageResult("Build completed successfully.")
@@ -763,208 +645,70 @@ def deploy(
         comment_data["appIcon"] = app_icon
     app_comment = json.dumps(comment_data)
 
-    if use_artifact_repo:
-        with metrics.span("snowflake_app.deploy_service"):
-            eai_list = [build_eai] if build_eai else None
+    eai_list = [build_eai] if build_eai else None
 
-            did_upgrade = False
-            cli_console.step("Creating application service...")
-            try:
-                manager.create_app_service(
-                    service_fqn=service_fqn,
-                    artifact_repo_fqn=artifact_repo_fqn_str,
-                    package_name=app_name,
-                    compute_pool=service_compute_pool,
-                    version="LATEST",
-                    query_warehouse=query_warehouse,
-                    external_access_integrations=eai_list,
-                    comment=app_comment,
-                )
-            except ProgrammingError as e:
-                if e.errno == 2002 and "already exists" in str(e).lower():
-                    cli_console.step(
-                        f"Application service {app_name} already exists. Upgrading..."
-                    )
-                    manager.upgrade_app_service(
-                        service_fqn=service_fqn,
-                        version="LATEST",
-                    )
-                    did_upgrade = True
-                else:
-                    raise
-
-        def _svc_is_upgrading(d: dict) -> bool:
-            return str(d.get("is_upgrading", "")).lower() in ("true", "1", "yes")
-
-        def _svc_has_failed(d: dict) -> bool:
-            return d.get("status", "").upper() == "FAILED"
-
-        def _url_is_ready(d: dict) -> bool:
-            url = d.get("url", "")
-            return bool(url) and "provisioning in progress" not in url.lower()
-
-        deploy_log_streamer = _make_deploy_log_streamer(manager, service_fqn)
-
-        with metrics.span("snowflake_app.endpoint_provision"):
-            if did_upgrade:
-                cli_console.step("Waiting for upgrade to complete...")
-                desc = _poll_until(
-                    poll_fn=lambda: manager.describe_app_service(service_fqn),
-                    is_done=lambda d: not _svc_is_upgrading(d) and _url_is_ready(d),
-                    is_error=_svc_has_failed,
-                    format_status=lambda d: (
-                        "upgrading" if _svc_is_upgrading(d) else "ready"
-                    ),
-                    timeout_message=(
-                        f"Upgrade timed out. Check logs:\n"
-                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
-                    ),
-                    on_poll=deploy_log_streamer,
-                )
-            else:
-                cli_console.step("Waiting for application service endpoint...")
-                desc = _poll_until(
-                    poll_fn=lambda: manager.describe_app_service(service_fqn),
-                    is_done=_url_is_ready,
-                    is_error=_svc_has_failed,
-                    format_status=lambda d: d.get("url") or "url not yet available",
-                    timeout_message=(
-                        f"Endpoint provisioning timed out. "
-                        f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
-                    ),
-                    on_poll=deploy_log_streamer,
-                )
-
-        endpoint_url = desc.get("url", "")
-        if endpoint_url and not endpoint_url.startswith(("http://", "https://")):
-            endpoint_url = f"https://{endpoint_url}"
-        return MessageResult(f"App ready at {endpoint_url}")
-    else:
-        assert image_repo_url is not None
-        repo_path = "/" + "/".join(image_repo_url.split("/")[1:])
-        image_url = f"{repo_path}/{app_name.lower()}:latest"
-
-        with metrics.span("snowflake_app.deploy_service"):
-            cli_console.step(f"Creating service {service_fqn} if it doesn't exist")
-            manager.create_service(
-                service_name=service_fqn,
-                compute_pool=service_compute_pool,
-                query_warehouse=query_warehouse,
-                app_comment=app_comment,
-                execute_as_caller=entity.execute_as_caller,
+    did_upgrade = False
+    cli_console.step("Creating application service...")
+    try:
+        manager.create_app_service(
+            service_fqn=service_fqn,
+            artifact_repo_fqn=artifact_repo_fqn_str,
+            package_name=app_name,
+            compute_pool=service_compute_pool,
+            version="LATEST",
+            query_warehouse=query_warehouse,
+            external_access_integrations=eai_list,
+            comment=app_comment,
+        )
+    except ProgrammingError as e:
+        if e.errno == 2002 and "already exists" in str(e).lower():
+            cli_console.step(
+                f"Application service {app_name} already exists. Upgrading..."
             )
-
-            # Alter service with built image
-            cli_console.step(f"Updating service with image: {image_url}")
-            manager.alter_service_spec(
-                service_name=service_fqn,
-                image_url=image_url,
-                execute_as_caller=entity.execute_as_caller,
+            manager.upgrade_app_service(
+                service_fqn=service_fqn,
+                version="LATEST",
             )
+            did_upgrade = True
+        else:
+            raise
 
-            # Resume service
-            cli_console.step("Resuming service")
-            manager.resume_service(service_fqn)
+    def _svc_is_upgrading(d: dict) -> bool:
+        return str(d.get("is_upgrading", "")).lower() in ("true", "1", "yes")
 
-            # Poll until service is RUNNING
-            cli_console.step("Waiting for service to be ready...")
-            _poll_until(
-                poll_fn=lambda: manager.get_service_status(service_fqn),
-                done_states={"RUNNING"},
-                error_states={"FAILED", "IDLE"},
-                known_pending_states={"PENDING", "SUSPENDING", "SUSPENDED"},
-                timeout_message=f"Service timed out. Check service status: {service_fqn}",
-            )
+    def _svc_has_failed(d: dict) -> bool:
+        return d.get("status", "").upper() == "FAILED"
 
-    # ── Get endpoint URL (non-artifact-repo path only) ────────────────
-    with metrics.span("snowflake_app.endpoint_provision"):
-        cli_console.step("Getting endpoint URL")
-        endpoint_url = _poll_until(
-            poll_fn=lambda: manager.get_service_endpoint_url(
-                service_fqn, endpoint_name="app-endpoint"
+    def _url_is_ready(d: dict) -> bool:
+        url = d.get("url", "")
+        return bool(url) and "provisioning in progress" not in url.lower()
+
+    if did_upgrade:
+        cli_console.step("Waiting for upgrade to complete...")
+        desc = _poll_until(
+            poll_fn=lambda: manager.describe_app_service(service_fqn),
+            is_done=lambda d: not _svc_is_upgrading(d) and _url_is_ready(d),
+            is_error=_svc_has_failed,
+            format_status=lambda d: ("upgrading" if _svc_is_upgrading(d) else "ready"),
+            timeout_message=(
+                f"Upgrade timed out. Check logs:\n"
+                f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
             ),
-            is_done=lambda url: url is not None
-            and "provisioning in progress" not in url.lower(),
-            format_status=lambda url: url or "Endpoint URL not yet available",
+        )
+    else:
+        cli_console.step("Waiting for application service endpoint...")
+        desc = _poll_until(
+            poll_fn=lambda: manager.describe_app_service(service_fqn),
+            is_done=_url_is_ready,
+            is_error=_svc_has_failed,
+            format_status=lambda d: d.get("url") or "url not yet available",
             timeout_message=(
                 f"Endpoint provisioning timed out. "
-                f'Check with: snow sql -q "SHOW ENDPOINTS IN SERVICE {service_fqn}"'
+                f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
             ),
         )
+
+    endpoint_url = desc.get("url", "")
+    if endpoint_url and not endpoint_url.startswith(("http://", "https://")):
+        endpoint_url = f"https://{endpoint_url}"
     return MessageResult(f"App ready at {endpoint_url}")
-
-
-@app.command(requires_connection=True)
-def teardown(
-    entity_id: Optional[str] = typer.Option(
-        None,
-        "--entity-id",
-        help="ID of the snowflake-app entity to tear down. Required if multiple snowflake-app entities exist.",
-    ),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        help="Drop without confirmation prompt.",
-    ),
-    **options,
-) -> CommandResult:
-    """
-    Drops a deployed Snowflake App and its associated objects.
-
-    Reads the entity from snowflake.yml and drops the application service
-    (or SPCS service), the code stage, and the build job service.
-    Unless --force is provided, prompts for confirmation before dropping.
-    """
-    resolved_entity_id = _resolve_entity_id(entity_id)
-    entity = _get_entity(resolved_entity_id)
-
-    fqn = entity.fqn
-    manager = SnowflakeAppManager()
-    defaults = _resolve_deploy_defaults(entity, manager)
-
-    db = defaults.get("database")
-    schema = defaults.get("schema")
-
-    if not db or not schema:
-        missing = [k for k, v in {"database": db, "schema": schema}.items() if not v]
-        raise CliError(
-            f"Cannot resolve {' or '.join(missing)} for the app. "
-            "Set them in snowflake.yml or in your connection configuration."
-        )
-
-    app_name = fqn.name
-    service_fqn = FQN(database=db, schema=schema, name=app_name)
-    use_artifact_repo = entity.artifact_repository is not None
-
-    stage_name = (
-        entity.code_stage.name if entity.code_stage else f"{app_name}_CODE_STAGE"
-    )
-    stage_fqn = FQN(database=db, schema=schema, name=stage_name)
-    build_job_fqn = FQN(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
-
-    object_kind = "application service" if use_artifact_repo else "service"
-
-    if not force:
-        should_continue = typer.confirm(
-            f"Are you sure you want to drop {object_kind} {service_fqn.identifier}"
-            f" and its associated objects?"
-        )
-        if not should_continue:
-            return MessageResult("Teardown cancelled.")
-
-    cli_console.step(f"Dropping {object_kind} {service_fqn.identifier}")
-    if use_artifact_repo:
-        manager.drop_app_service_if_exists(service_fqn)
-    else:
-        manager.drop_service_if_exists(service_fqn)
-
-    cli_console.step(f"Dropping stage {stage_fqn.identifier}")
-    manager.drop_stage_if_exists(stage_fqn)
-
-    if not use_artifact_repo:
-        cli_console.step(f"Dropping build job service {build_job_fqn.identifier}")
-        manager.drop_service_if_exists(build_job_fqn)
-
-    return MessageResult(
-        f"Successfully dropped {object_kind} {service_fqn.identifier}."
-    )

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from textwrap import dedent
 from typing import Dict
+
+log = logging.getLogger(__name__)
 
 # Feature flags
 IS_PERSONAL_DB_SUPPORTED = False  # Will be enabled in the future
@@ -27,9 +30,17 @@ def _generate_snowflake_yml(
 
     All required keys (``database``, ``schema``, ``warehouse``,
     ``build_compute_pool``, ``service_compute_pool``, ``build_eai``) must
-    be present and non-empty in *resolved*.  The optional key
-    ``image_repository`` is included only when provided.
+    be present and non-empty in *resolved*.  The artifact repository is
+    omitted from the generated YAML; the CLI will default to
+    ``<app-id>_REPO`` at deploy time.
     """
+
+    if resolved.get("image_repository"):
+        log.warning(
+            "image_repository is configured but is no longer included in "
+            "generated snowflake.yml. The CLI defaults to <app-id>_REPO at "
+            "deploy time. You can remove the image_repository setting."
+        )
 
     database = resolved["database"]
     schema = resolved["schema"]
@@ -37,15 +48,8 @@ def _generate_snowflake_yml(
     build_compute_pool = resolved["build_compute_pool"]
     service_compute_pool = resolved["service_compute_pool"]
     build_eai = resolved["build_eai"]
-    image_repository = resolved.get("image_repository")
 
     code_stage = f"{app_id.upper()}_CODE"
-
-    repo_lines = ""
-    if image_repository:
-        repo_lines = (
-            f"\n            image_repository:\n              name: {image_repository}"
-        )
 
     return dedent(
         f"""\
@@ -78,7 +82,7 @@ def _generate_snowflake_yml(
             service_compute_pool:
               name: {service_compute_pool}
             build_eai:
-              name: {build_eai}{repo_lines}
+              name: {build_eai}
             code_stage:
               name: {code_stage}
         """

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, TypeVar
 
 from snowflake.cli._plugins.apps.generate import IS_PERSONAL_DB_SUPPORTED
-from snowflake.cli._plugins.apps.snowflake_app_entity_model import DEFAULT_APP_PORT
 
 if TYPE_CHECKING:
     from snowflake.cli._plugins.apps.snowflake_app_entity_model import (
@@ -48,7 +47,6 @@ SNOWFLAKE_APP_ENTITY_TYPE = "snowflake-app"
 # TODO: Update to "app" after migration from __app
 _APP_COMMAND_NAME = "__app"
 
-DEFAULT_IMAGE_REPOSITORY = "IMAGE_REPO"
 
 # Mapping from SHOW PARAMETERS result names to internal resolution keys.
 _SNOW_APPS_PARAM_MAP = {
@@ -59,9 +57,6 @@ _SNOW_APPS_PARAM_MAP = {
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE": "database",
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA": "schema",
 }
-
-_BUILD_IMAGE = "/snowflake/images/snowflake_images/sf-image-build:0.0.1"
-_SERVICE_PLACEHOLDER_IMAGE = "/snowflake/images/snowflake_images/sf-image-build:0.0.1"
 
 T = TypeVar("T")
 
@@ -78,7 +73,6 @@ def _poll_until(
     max_attempts: int = 240,
     interval_seconds: int = 5,
     timeout_message: str = "Operation timed out.",
-    on_poll: Optional[Callable[[], None]] = None,
 ) -> T:
     """Poll *poll_fn* until the result satisfies a done condition.
 
@@ -92,25 +86,11 @@ def _poll_until(
         Call *is_done(result)* each iteration.  Optionally supply *is_error*
         to detect error values.
 
-    If *on_poll* is provided it is called every second between status
-    checks, so log output streams continuously rather than in bursts
-    every *interval_seconds*.  Exceptions from *on_poll* are logged and
-    swallowed so they never interrupt the polling loop.
-
     Raises ``CliError`` on error or timeout.  Returns the final value on
     success.
     """
     for _attempt in range(max_attempts):
-        if on_poll is not None:
-            for _ in range(interval_seconds):
-                time.sleep(1)
-                try:
-                    on_poll()
-                except Exception:
-                    log.debug("on_poll callback failed", exc_info=True)
-        else:
-            time.sleep(interval_seconds)
-
+        time.sleep(interval_seconds)
         result = poll_fn()
         cli_console.step(f"Status: {format_status(result)}")
 
@@ -149,23 +129,26 @@ def _object_exists(object_type: str, name: str) -> bool:
 def _resolve_deploy_defaults(
     entity: "SnowflakeAppEntityModel",
     manager: "SnowflakeAppManager",
+    app_name: Optional[str] = None,
 ) -> Dict[str, Optional[str]]:
     """Resolve deploy defaults using a four-tier precedence:
 
     1. Values explicitly set in ``snowflake.yml`` (highest priority)
     2. SnowApps parameters (``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``)
-    3. Built-in defaults (personal DB for database, IMAGE_REPO for image repository)
+    3. Built-in defaults (personal DB for database, ``<app-id>_REPO`` for artifact repository)
     4. Current session values (lowest priority)
 
     Returns a dict with keys ``query_warehouse``, ``build_compute_pool``,
-    ``service_compute_pool``, ``build_eai``, ``image_repository``,
-    ``image_repo_database``, ``image_repo_schema``, ``database``, and
-    ``schema``.  Any of them may still be ``None`` if no source provides
-    a value.
+    ``service_compute_pool``, ``build_eai``, ``artifact_repository``,
+    ``artifact_repo_database``, ``artifact_repo_schema``, ``database``,
+    and ``schema``.  Any of them may still be ``None`` if no source
+    provides a value.
     """
 
     # ── 1. snowflake.yml values ───────────────────────────────────────
     fqn = entity.fqn
+    if app_name is None:
+        app_name = fqn.name
     yml_vals: Dict[str, Optional[str]] = {
         "query_warehouse": entity.query_warehouse,
         "build_compute_pool": (
@@ -175,14 +158,14 @@ def _resolve_deploy_defaults(
             entity.service_compute_pool.name if entity.service_compute_pool else None
         ),
         "build_eai": entity.build_eai.name if entity.build_eai else None,
-        "image_repository": (
-            entity.image_repository.name if entity.image_repository else None
+        "artifact_repository": (
+            entity.artifact_repository.name if entity.artifact_repository else None
         ),
-        "image_repo_database": (
-            entity.image_repository.database if entity.image_repository else None
+        "artifact_repo_database": (
+            entity.artifact_repository.database if entity.artifact_repository else None
         ),
-        "image_repo_schema": (
-            entity.image_repository.schema_ if entity.image_repository else None
+        "artifact_repo_schema": (
+            entity.artifact_repository.schema_ if entity.artifact_repository else None
         ),
         "database": fqn.database,
         "schema": fqn.schema,
@@ -202,7 +185,7 @@ def _resolve_deploy_defaults(
     from snowflake.cli.api.project.util import get_env_username
 
     default_vals: Dict[str, Optional[str]] = {
-        "image_repository": DEFAULT_IMAGE_REPOSITORY,
+        "artifact_repository": f"{app_name}_REPO",
     }
     if IS_PERSONAL_DB_SUPPORTED:
         default_vals["database"] = f"USER${get_env_username().upper()}"
@@ -235,11 +218,11 @@ def _resolve_deploy_defaults(
         else:
             resolved[key] = None
 
-    # Image repo db/schema default to the resolved database/schema.
-    if not resolved.get("image_repo_database"):
-        resolved["image_repo_database"] = resolved.get("database")
-    if not resolved.get("image_repo_schema"):
-        resolved["image_repo_schema"] = resolved.get("schema")
+    # Artifact repo db/schema default to the resolved database/schema.
+    if not resolved.get("artifact_repo_database"):
+        resolved["artifact_repo_database"] = resolved.get("database")
+    if not resolved.get("artifact_repo_schema"):
+        resolved["artifact_repo_schema"] = resolved.get("schema")
 
     return resolved
 
@@ -375,75 +358,16 @@ def _find_dockerfile_expose_port(bundle_root: Path) -> Optional[int]:
     return None
 
 
-def _build_job_spec(
-    image_repo_url: str,
-    app_id: str,
-    code_stage: FQN,
-    build_image: Optional[str] = None,
-) -> str:
-    """Return the SPCS YAML spec for the image-build job service."""
-    image = build_image or _BUILD_IMAGE
-    return f"""spec:
-  containers:
-  - name: main
-    image: "{image}"
-    env:
-      IMAGE_REGISTRY_URL: "{image_repo_url}"
-      IMAGE_NAME: "{app_id.lower()}"
-      IMAGE_TAG: "latest"
-      BUILD_CONTEXT: "/app"
-    volumeMounts:
-      - name: code-volume
-        mountPath: /app
-  volumes:
-  - name: code-volume
-    source: "@{code_stage.identifier}"
-    uid: 65532"""
-
-
-def _service_spec(
-    image_url: str,
-    app_port: int = DEFAULT_APP_PORT,
-    command: Optional[list] = None,
-    execute_as_caller: bool = False,
-) -> str:
-    """Return the SPCS YAML spec for the application service."""
-    command_block = ""
-    if command:
-        items = "\n".join(f"        - {c}" for c in command)
-        command_block = f"\n      command:\n{items}"
-
-    capabilities_block = ""
-    if execute_as_caller:
-        capabilities_block = """
-capabilities:
-  securityContext:
-    executeAsCaller: true"""
-
-    return f"""spec:
-  containers:
-    - name: main
-      image: "{image_url}"{command_block}
-  endpoints:
-    - name: app-endpoint
-      port: {app_port}
-      public: true{capabilities_block}
-serviceRoles:
-  - name: viewer
-    endpoints:
-      - app-endpoint"""
-
-
 class SnowflakeAppManager(SqlExecutionMixin):
     """Manager for Snowflake App operations.
 
-    NOTE: Many DDL-building methods (execute_build_job, create_service,
-    create_app_service, …) interpolate bare ``str`` arguments such as
-    *compute_pool*, *query_warehouse*, and EAI names directly into SQL
-    without identifier quoting.  This is safe as long as callers pass
-    simple unquoted identifiers, but it will break for names containing
-    spaces or special characters.  If that ever becomes a requirement,
-    wrap them with ``FQN.from_string(name).sql_identifier`` or
+    NOTE: DDL-building methods (create_app_service, build_app_artifact_repo, …)
+    interpolate bare ``str`` arguments such as *compute_pool*,
+    *query_warehouse*, and EAI names directly into SQL without identifier
+    quoting.  This is safe as long as callers pass simple unquoted
+    identifiers, but it will break for names containing spaces or special
+    characters.  If that ever becomes a requirement, wrap them with
+    ``FQN.from_string(name).sql_identifier`` or
     ``IDENTIFIER(to_string_literal(name))`` for consistency with the
     ``FQN``-based parameters that already use ``.sql_identifier``.
     """
@@ -505,127 +429,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
             f"CREATE STAGE IF NOT EXISTS {stage_fqn.sql_identifier} ENCRYPTION = (TYPE = '{encryption_type}')"
         )
 
-    def drop_service_if_exists(self, service_fqn: FQN) -> None:
-        """Drop a service if it exists."""
-        self.execute_query(f"DROP SERVICE IF EXISTS {service_fqn.sql_identifier}")
-
-    def drop_app_service_if_exists(self, service_fqn: FQN) -> None:
-        """Drop an application service if it exists."""
-        self.execute_query(
-            f"DROP APPLICATION SERVICE IF EXISTS {service_fqn.sql_identifier}"
-        )
-
-    def drop_stage_if_exists(self, stage_fqn: FQN) -> None:
-        """Drop a stage if it exists."""
-        self.execute_query(f"DROP STAGE IF EXISTS {stage_fqn.sql_identifier}")
-
-    def get_image_repo_url(
-        self,
-        repo_name: str,
-        database: Optional[str] = None,
-        schema: Optional[str] = None,
-    ) -> str:
-        """Get the image repository URL and convert to local registry."""
-        from snowflake.cli.api.project.util import (
-            identifier_to_show_like_pattern,
-            unquote_identifier,
-        )
-
-        show_obj_query = (
-            f"show image repositories like {identifier_to_show_like_pattern(repo_name)}"
-        )
-        if database and schema:
-            schema_fqn = FQN(database=None, schema=database, name=schema)
-            show_obj_query += f" in schema {schema_fqn.sql_identifier}"
-        elif database:
-            show_obj_query += f" in database IDENTIFIER('{database}')"
-        elif schema:
-            raise CliError(
-                "image_repository.schema requires image_repository.database to be set."
-            )
-        cursor = self.execute_query(show_obj_query, cursor_class=DictCursor)
-
-        if cursor.rowcount is None or cursor.rowcount == 0:
-            raise CliError(f"Image repository '{repo_name}' not found")
-
-        unqualified_name = unquote_identifier(repo_name)
-        rows = cursor.fetchall()
-        row = next(
-            (r for r in rows if r["name"].upper() == unqualified_name.upper()),
-            None,
-        )
-        if not row:
-            # Fall back to the first row if name matching fails
-            row = rows[0] if rows else None
-        if not row:
-            raise CliError(f"Image repository '{repo_name}' not found")
-
-        # Get repository_url from the result
-        repo_url = row["repository_url"]
-
-        # Convert to local registry URL (replace .registry-dev. or .registry. with .registry-local.)
-        local_url = repo_url.replace(".registry-dev.", ".registry-local.")
-        local_url = local_url.replace(".registry.", ".registry-local.")
-        local_url = local_url.replace(".awsuswest2qa6.", ".")
-        local_url = local_url.replace(".awsuswest2qa3.", ".")
-
-        return local_url
-
-    def execute_build_job(
-        self,
-        job_service_name: FQN,
-        compute_pool: str,
-        code_stage: FQN,
-        image_repo_url: str,
-        app_id: str,
-        external_access_integration: Optional[str] = None,
-        build_image: Optional[str] = None,
-    ) -> None:
-        """Execute a build job service."""
-        spec = _build_job_spec(image_repo_url, app_id, code_stage, build_image)
-
-        query_lines = [
-            f"EXECUTE JOB SERVICE IN COMPUTE POOL {compute_pool}",
-            f"NAME = {job_service_name.sql_identifier}",
-            "ASYNC = TRUE",
-            f"FROM SPECIFICATION $${spec}$$",
-        ]
-
-        if external_access_integration:
-            query_lines.insert(
-                3, f"EXTERNAL_ACCESS_INTEGRATIONS = ({external_access_integration})"
-            )
-
-        query = "\n".join(query_lines)
-        self.execute_query(query)
-
-    def artifact_repo_exists(self, database: str, schema: str, repo_name: str) -> bool:
-        """Return True if the artifact repository already exists."""
-        from snowflake.cli.api.project.util import (
-            identifier_to_show_like_pattern,
-            unquote_identifier,
-        )
-
-        schema_fqn = FQN(database=None, schema=database, name=schema)
-        cursor = self.execute_query(
-            f"SHOW ARTIFACT REPOSITORIES LIKE {identifier_to_show_like_pattern(repo_name)}"
-            f" IN SCHEMA {schema_fqn.sql_identifier}",
-            cursor_class=DictCursor,
-        )
-        unqualified = unquote_identifier(repo_name).upper()
-        return any(row["name"].upper() == unqualified for row in cursor)
-
-    def create_artifact_repo(self, database: str, schema: str, repo_name: str) -> None:
-        """Create an artifact repository.
-
-        Uses IF NOT EXISTS so concurrent invocations (e.g. parallel CI
-        jobs) don't race on the CREATE after both pass the existence check.
-        """
-        fqn = FQN(database=database, schema=schema, name=repo_name)
-        self.execute_query(
-            f"CREATE ARTIFACT REPOSITORY IF NOT EXISTS {fqn.sql_identifier} TYPE=APPLICATION"
-        )
-
     def get_build_status(self, job_fqn: FQN) -> str:
         """
         Get the status of the build job service.
@@ -643,60 +446,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
                 return row["status"]
 
         return "IDLE"
-
-    def create_service(
-        self,
-        service_name: FQN,
-        compute_pool: str,
-        query_warehouse: str,
-        app_port: int = DEFAULT_APP_PORT,
-        app_comment: Optional[str] = None,
-        execute_as_caller: bool = False,
-    ) -> None:
-        """Create a service with a placeholder spec (suspended by default)."""
-        spec = _service_spec(
-            _SERVICE_PLACEHOLDER_IMAGE,
-            app_port,
-            command=["sleep", "infinity"],
-            execute_as_caller=execute_as_caller,
-        )
-
-        query = (
-            f"CREATE SERVICE IF NOT EXISTS {service_name.sql_identifier}\n"
-            f"IN COMPUTE POOL {compute_pool}\n"
-            f"FROM SPECIFICATION $${spec}$$\n"
-            f"QUERY_WAREHOUSE = {query_warehouse}"
-        )
-        self.execute_query(query)
-
-        if app_comment:
-            escaped_comment = app_comment.replace("'", "''")
-            self.execute_query(
-                f"ALTER SERVICE {service_name.sql_identifier} SET COMMENT = '{escaped_comment}'"
-            )
-
-        # Suspend the service after creation (deploy will resume it)
-        self.execute_query(f"ALTER SERVICE {service_name.sql_identifier} SUSPEND")
-
-    def alter_service_spec(
-        self,
-        service_name: FQN,
-        image_url: str,
-        app_port: int = DEFAULT_APP_PORT,
-        execute_as_caller: bool = False,
-    ) -> None:
-        """Alter a service with the built image spec."""
-        spec = _service_spec(image_url, app_port, execute_as_caller=execute_as_caller)
-
-        query = (
-            f"ALTER SERVICE {service_name.sql_identifier}\n"
-            f"FROM SPECIFICATION $${spec}$$"
-        )
-        self.execute_query(query)
-
-    def resume_service(self, service_name: FQN) -> None:
-        """Resume a suspended service."""
-        self.execute_query(f"ALTER SERVICE {service_name.sql_identifier} RESUME")
 
     def get_service_status(self, service_fqn: FQN) -> str:
         """
@@ -801,6 +550,33 @@ class SnowflakeAppManager(SqlExecutionMixin):
         if build_eai:
             cfg["external_access_integrations"] = [build_eai]
         return json.dumps(cfg)
+
+    def artifact_repo_exists(self, database: str, schema: str, repo_name: str) -> bool:
+        """Return True if the artifact repository already exists."""
+        from snowflake.cli.api.project.util import (
+            identifier_to_show_like_pattern,
+            unquote_identifier,
+        )
+
+        schema_fqn = FQN(database=None, schema=database, name=schema)
+        cursor = self.execute_query(
+            f"SHOW ARTIFACT REPOSITORIES LIKE {identifier_to_show_like_pattern(repo_name)}"
+            f" IN SCHEMA {schema_fqn.sql_identifier}",
+            cursor_class=DictCursor,
+        )
+        unqualified = unquote_identifier(repo_name).upper()
+        return any(row["name"].upper() == unqualified for row in cursor)
+
+    def create_artifact_repo(self, database: str, schema: str, repo_name: str) -> None:
+        """Create an artifact repository.
+
+        Uses IF NOT EXISTS so concurrent invocations (e.g. parallel CI
+        jobs) don't race on the CREATE after both pass the existence check.
+        """
+        fqn = FQN(database=database, schema=schema, name=repo_name)
+        self.execute_query(
+            f"CREATE ARTIFACT REPOSITORY IF NOT EXISTS {fqn.sql_identifier} TYPE=APPLICATION"
+        )
 
     def build_app_artifact_repo(
         self,
@@ -907,10 +683,3 @@ class SnowflakeAppManager(SqlExecutionMixin):
         )
         row = cursor.fetchone()
         return row[0] if row else ""
-
-    def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
-        """Fetch build logs for a build job service."""
-        cursor = self.execute_query(
-            f"SELECT LOG FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
-        )
-        return [str(row[0]) for row in cursor if row[0]]

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -447,6 +447,20 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
         return "IDLE"
 
+    def drop_service_if_exists(self, service_fqn: FQN) -> None:
+        """Drop a service if it exists."""
+        self.execute_query(f"DROP SERVICE IF EXISTS {service_fqn.sql_identifier}")
+
+    def drop_app_service_if_exists(self, service_fqn: FQN) -> None:
+        """Drop an application service if it exists."""
+        self.execute_query(
+            f"DROP APPLICATION SERVICE IF EXISTS {service_fqn.sql_identifier}"
+        )
+
+    def drop_stage_if_exists(self, stage_fqn: FQN) -> None:
+        """Drop a stage if it exists."""
+        self.execute_query(f"DROP STAGE IF EXISTS {stage_fqn.sql_identifier}")
+
     def get_service_status(self, service_fqn: FQN) -> str:
         """
         Get the status of a service.

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
-from snowflake.cli._plugins.apps.commands import (
-    _make_build_log_streamer,
-    _make_deploy_log_streamer,
-)
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
 )
@@ -306,261 +302,6 @@ class TestPollUntilStateSetMode:
         assert mock_sleep.call_count == 2
 
 
-class TestPollUntilOnPoll:
-    """Tests for the on_poll callback that streams logs between status checks."""
-
-    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
-    def test_on_poll_called_every_second_between_status_checks(self, mock_sleep):
-        on_poll = Mock()
-        _poll_until(
-            poll_fn=lambda: "DONE",
-            done_states={"DONE"},
-            known_pending_states={"PENDING"},
-            timeout_message="timed out",
-            interval_seconds=3,
-            on_poll=on_poll,
-        )
-        assert on_poll.call_count == 3
-        assert mock_sleep.call_count == 3
-        assert all(c == call(1) for c in mock_sleep.call_args_list)
-
-    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
-    def test_on_poll_exception_does_not_interrupt_polling(self, mock_sleep):
-        on_poll = Mock(side_effect=RuntimeError("log fetch failed"))
-        result = _poll_until(
-            poll_fn=lambda: "DONE",
-            done_states={"DONE"},
-            known_pending_states={"PENDING"},
-            timeout_message="timed out",
-            interval_seconds=2,
-            on_poll=on_poll,
-        )
-        assert result == "DONE"
-        assert on_poll.call_count == 2
-
-    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
-    def test_on_poll_called_across_multiple_iterations(self, mock_sleep):
-        values = iter(["PENDING", "DONE"])
-        on_poll = Mock()
-        _poll_until(
-            poll_fn=lambda: next(values),
-            done_states={"DONE"},
-            known_pending_states={"PENDING"},
-            timeout_message="timed out",
-            interval_seconds=5,
-            on_poll=on_poll,
-        )
-        assert on_poll.call_count == 10
-
-    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
-    def test_no_on_poll_uses_single_sleep(self, mock_sleep):
-        _poll_until(
-            poll_fn=lambda: "DONE",
-            done_states={"DONE"},
-            timeout_message="timed out",
-            interval_seconds=5,
-        )
-        mock_sleep.assert_called_once_with(5)
-
-
-# ── Log streamer tests ────────────────────────────────────────────────
-
-
-class TestBuildLogStreamer:
-    """Tests for _make_build_log_streamer incremental log diffing."""
-
-    def test_first_call_prints_all_lines(self):
-        manager = Mock()
-        manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
-        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
-
-        streamer = _make_build_log_streamer(manager, fqn)
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            streamer()
-
-        assert mock_log.info.call_count == 3
-        mock_log.info.assert_any_call("line1")
-        mock_log.info.assert_any_call("line2")
-        mock_log.info.assert_any_call("line3")
-
-    def test_subsequent_call_prints_only_new_lines(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
-        streamer = _make_build_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_build_job_logs.return_value = ["line1", "line2"]
-            streamer()
-            assert mock_log.info.call_count == 2
-
-            mock_log.info.reset_mock()
-            manager.get_build_job_logs.return_value = [
-                "line1",
-                "line2",
-                "line3",
-                "line4",
-            ]
-            streamer()
-            assert mock_log.info.call_count == 2
-            mock_log.info.assert_any_call("line3")
-            mock_log.info.assert_any_call("line4")
-
-    def test_no_new_lines_prints_nothing(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
-        streamer = _make_build_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_build_job_logs.return_value = ["line1"]
-            streamer()
-            mock_log.info.reset_mock()
-
-            manager.get_build_job_logs.return_value = ["line1"]
-            streamer()
-            mock_log.info.assert_not_called()
-
-    def test_empty_logs_prints_nothing(self):
-        manager = Mock()
-        manager.get_build_job_logs.return_value = []
-        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
-        streamer = _make_build_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            streamer()
-            mock_log.info.assert_not_called()
-
-    def test_exception_is_swallowed(self):
-        manager = Mock()
-        manager.get_build_job_logs.side_effect = RuntimeError("connection lost")
-        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
-        streamer = _make_build_log_streamer(manager, fqn)
-
-        streamer()  # should not raise
-
-    def test_exception_does_not_reset_seen_count(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
-        streamer = _make_build_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_build_job_logs.return_value = ["line1", "line2"]
-            streamer()
-            assert mock_log.info.call_count == 2
-
-            mock_log.info.reset_mock()
-            manager.get_build_job_logs.side_effect = RuntimeError("transient")
-            streamer()
-            mock_log.info.assert_not_called()
-
-            manager.get_build_job_logs.side_effect = None
-            manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
-            streamer()
-            assert mock_log.info.call_count == 1
-            mock_log.info.assert_called_with("line3")
-
-
-class TestDeployLogStreamer:
-    """Tests for _make_deploy_log_streamer incremental log diffing."""
-
-    def test_first_call_prints_all_lines(self):
-        manager = Mock()
-        manager.get_app_service_logs.return_value = "line1\nline2\nline3"
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-
-        streamer = _make_deploy_log_streamer(manager, fqn)
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            streamer()
-
-        manager.get_app_service_logs.assert_called_with("DB.SCHEMA.MY_APP")
-        assert mock_log.info.call_count == 3
-        mock_log.info.assert_any_call("line1")
-        mock_log.info.assert_any_call("line2")
-        mock_log.info.assert_any_call("line3")
-
-    def test_subsequent_call_prints_only_new_lines(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_deploy_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_app_service_logs.return_value = "a\nb"
-            streamer()
-            assert mock_log.info.call_count == 2
-
-            mock_log.info.reset_mock()
-            manager.get_app_service_logs.return_value = "a\nb\nc\nd"
-            streamer()
-            assert mock_log.info.call_count == 2
-            mock_log.info.assert_any_call("c")
-            mock_log.info.assert_any_call("d")
-
-    def test_no_new_lines_prints_nothing(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_deploy_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_app_service_logs.return_value = "line1"
-            streamer()
-            mock_log.info.reset_mock()
-
-            manager.get_app_service_logs.return_value = "line1"
-            streamer()
-            mock_log.info.assert_not_called()
-
-    def test_empty_string_prints_nothing(self):
-        manager = Mock()
-        manager.get_app_service_logs.return_value = ""
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_deploy_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            streamer()
-            mock_log.info.assert_not_called()
-
-    def test_exception_is_swallowed(self):
-        manager = Mock()
-        manager.get_app_service_logs.side_effect = RuntimeError("connection lost")
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_deploy_log_streamer(manager, fqn)
-
-        streamer()  # should not raise
-
-    def test_exception_does_not_reset_seen_count(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_deploy_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_app_service_logs.return_value = "a\nb"
-            streamer()
-            assert mock_log.info.call_count == 2
-
-            mock_log.info.reset_mock()
-            manager.get_app_service_logs.side_effect = RuntimeError("transient")
-            streamer()
-            mock_log.info.assert_not_called()
-
-            manager.get_app_service_logs.side_effect = None
-            manager.get_app_service_logs.return_value = "a\nb\nc"
-            streamer()
-            assert mock_log.info.call_count == 1
-            mock_log.info.assert_called_with("c")
-
-    def test_multiline_with_various_line_endings(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_deploy_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_app_service_logs.return_value = "a\r\nb\nc"
-            streamer()
-            assert mock_log.info.call_count == 3
-            mock_log.info.assert_any_call("a")
-            mock_log.info.assert_any_call("b")
-            mock_log.info.assert_any_call("c")
-
-
 # ── _generate_snowflake_yml tests ─────────────────────────────────────
 
 
@@ -585,20 +326,11 @@ class TestGenerateSnowflakeYml:
         assert "name: MY_EAI" in result
         assert "name: MY_APP_CODE" in result
         assert "image_repository" not in result
+        assert "artifact_repository" not in result
 
     def test_no_null_values_in_output(self):
         result = _generate_snowflake_yml("my_app", self._BASE_RESOLVED)
         assert "null" not in result
-
-    def test_includes_image_repository_when_provided(self):
-        resolved = {**self._BASE_RESOLVED, "image_repository": "MY_IR"}
-        result = _generate_snowflake_yml("my_app", resolved)
-        assert "image_repository:" in result
-        assert "name: MY_IR" in result
-
-    def test_omits_image_repository_when_not_provided(self):
-        result = _generate_snowflake_yml("my_app", self._BASE_RESOLVED)
-        assert "image_repository" not in result
 
     def test_custom_schema(self):
         resolved = {**self._BASE_RESOLVED, "schema": "CFG_SCHEMA"}
@@ -717,198 +449,6 @@ class TestSnowflakeAppManager:
         mock_execute.assert_called_once_with(
             "CREATE STAGE IF NOT EXISTS IDENTIFIER('DB.SCHEMA.STAGE') ENCRYPTION = (TYPE = 'SNOWFLAKE_FULL')"
         )
-
-    @patch(EXECUTE_QUERY)
-    def test_drop_service_if_exists(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().drop_service_if_exists(fqn)
-        mock_execute.assert_called_once_with(
-            "DROP SERVICE IF EXISTS IDENTIFIER('DB.SCHEMA.SVC')"
-        )
-
-    @patch(EXECUTE_QUERY)
-    def test_drop_app_service_if_exists(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="MY_APP")
-        SnowflakeAppManager().drop_app_service_if_exists(fqn)
-        mock_execute.assert_called_once_with(
-            "DROP APPLICATION SERVICE IF EXISTS IDENTIFIER('DB.SCHEMA.MY_APP')"
-        )
-
-    @patch(EXECUTE_QUERY)
-    def test_drop_stage_if_exists(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="MY_STAGE")
-        SnowflakeAppManager().drop_stage_if_exists(fqn)
-        mock_execute.assert_called_once_with(
-            "DROP STAGE IF EXISTS IDENTIFIER('DB.SCHEMA.MY_STAGE')"
-        )
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 1
-        cursor.fetchall.return_value = [
-            {
-                "name": "MY_REPO",
-                "repository_url": "host.registry.snowflakecomputing.com/db/schema/my_repo",
-            }
-        ]
-        mock_execute.return_value = cursor
-
-        result = SnowflakeAppManager().get_image_repo_url("MY_REPO")
-        assert result == "host.registry-local.snowflakecomputing.com/db/schema/my_repo"
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_dev_registry(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 1
-        cursor.fetchall.return_value = [
-            {
-                "name": "MY_REPO",
-                "repository_url": "host.registry-dev.snowflakecomputing.com/db/schema/my_repo",
-            }
-        ]
-        mock_execute.return_value = cursor
-
-        result = SnowflakeAppManager().get_image_repo_url("MY_REPO")
-        assert result == "host.registry-local.snowflakecomputing.com/db/schema/my_repo"
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_qa_environment(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 1
-        cursor.fetchall.return_value = [
-            {
-                "name": "MY_REPO",
-                "repository_url": "host.awsuswest2qa6.registry.snowflakecomputing.com/db/schema/my_repo",
-            }
-        ]
-        mock_execute.return_value = cursor
-
-        result = SnowflakeAppManager().get_image_repo_url("MY_REPO")
-        assert result == "host.registry-local.snowflakecomputing.com/db/schema/my_repo"
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_not_found_empty(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 0
-        mock_execute.return_value = cursor
-
-        with pytest.raises(CliError, match="Image repository 'MY_REPO' not found"):
-            SnowflakeAppManager().get_image_repo_url("MY_REPO")
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_not_found_none_rowcount(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = None
-        mock_execute.return_value = cursor
-
-        with pytest.raises(CliError, match="Image repository 'MY_REPO' not found"):
-            SnowflakeAppManager().get_image_repo_url("MY_REPO")
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_with_database_and_schema(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 1
-        cursor.fetchall.return_value = [
-            {
-                "name": "MY_REPO",
-                "repository_url": "host.registry.snowflakecomputing.com/db/schema/my_repo",
-            }
-        ]
-        mock_execute.return_value = cursor
-
-        SnowflakeAppManager().get_image_repo_url(
-            "MY_REPO", database="CUSTOM_DB", schema="CUSTOM_SCHEMA"
-        )
-        query = mock_execute.call_args[0][0]
-        assert "in schema IDENTIFIER('CUSTOM_DB.CUSTOM_SCHEMA')" in query
-
-    @patch(EXECUTE_QUERY)
-    def test_get_image_repo_url_with_database_only(self, mock_execute):
-        cursor = Mock()
-        cursor.rowcount = 1
-        cursor.fetchall.return_value = [
-            {
-                "name": "MY_REPO",
-                "repository_url": "host.registry.snowflakecomputing.com/db/schema/my_repo",
-            }
-        ]
-        mock_execute.return_value = cursor
-
-        SnowflakeAppManager().get_image_repo_url("MY_REPO", database="CUSTOM_DB")
-        query = mock_execute.call_args[0][0]
-        assert "in database IDENTIFIER('CUSTOM_DB')" in query
-
-    def test_get_image_repo_url_schema_without_database_raises(self):
-        with pytest.raises(CliError, match="image_repository.schema requires"):
-            SnowflakeAppManager().get_image_repo_url("MY_REPO", schema="CUSTOM_SCHEMA")
-
-    @patch(EXECUTE_QUERY)
-    def test_execute_build_job_without_eai(self, mock_execute):
-        job_fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
-        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        SnowflakeAppManager().execute_build_job(
-            job_service_name=job_fqn,
-            compute_pool="BUILD_POOL",
-            code_stage=stage_fqn,
-            image_repo_url="host/db/schema/repo",
-            app_id="my_app",
-        )
-        mock_execute.assert_called_once()
-        query = mock_execute.call_args[0][0]
-        assert "EXECUTE JOB SERVICE IN COMPUTE POOL BUILD_POOL" in query
-        assert "NAME = IDENTIFIER('DB.SCHEMA.BUILD_JOB')" in query
-        assert "ASYNC = TRUE" in query
-        assert 'IMAGE_REGISTRY_URL: "host/db/schema/repo"' in query
-        assert 'IMAGE_NAME: "my_app"' in query
-        assert "@DB.SCHEMA.STAGE" in query
-        assert "EXTERNAL_ACCESS_INTEGRATIONS" not in query
-
-    @patch(EXECUTE_QUERY)
-    def test_execute_build_job_with_eai(self, mock_execute):
-        job_fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
-        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        SnowflakeAppManager().execute_build_job(
-            job_service_name=job_fqn,
-            compute_pool="BUILD_POOL",
-            code_stage=stage_fqn,
-            image_repo_url="host/db/schema/repo",
-            app_id="my_app",
-            external_access_integration="MY_EAI",
-        )
-        mock_execute.assert_called_once()
-        query = mock_execute.call_args[0][0]
-        assert "EXTERNAL_ACCESS_INTEGRATIONS = (MY_EAI)" in query
-
-    @patch(EXECUTE_QUERY)
-    def test_execute_build_job_uses_default_image(self, mock_execute):
-        job_fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
-        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        SnowflakeAppManager().execute_build_job(
-            job_service_name=job_fqn,
-            compute_pool="BUILD_POOL",
-            code_stage=stage_fqn,
-            image_repo_url="host/db/schema/repo",
-            app_id="my_app",
-        )
-        query = mock_execute.call_args[0][0]
-        assert "sf-image-build:0.0.1" in query
-
-    @patch(EXECUTE_QUERY)
-    def test_execute_build_job_with_custom_build_image(self, mock_execute):
-        job_fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
-        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        SnowflakeAppManager().execute_build_job(
-            job_service_name=job_fqn,
-            compute_pool="BUILD_POOL",
-            code_stage=stage_fqn,
-            image_repo_url="host/db/schema/repo",
-            app_id="my_app",
-            build_image="/my/custom/builder:2.0",
-        )
-        query = mock_execute.call_args[0][0]
-        assert '"/my/custom/builder:2.0"' in query
-        assert "sf-image-build:0.0.1" not in query
 
     @staticmethod
     def _find_query(call_args_list, substr):
@@ -1174,116 +714,6 @@ class TestSnowflakeAppManager:
         )
 
     @patch(EXECUTE_QUERY)
-    def test_create_service_basic(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().create_service(
-            service_name=fqn,
-            compute_pool="SVC_POOL",
-            query_warehouse="WH",
-        )
-        # Should call: CREATE SERVICE, ALTER SERVICE SUSPEND (no comment)
-        assert mock_execute.call_count == 2
-        create_query = mock_execute.call_args_list[0][0][0]
-        assert (
-            "CREATE SERVICE IF NOT EXISTS IDENTIFIER('DB.SCHEMA.SVC')" in create_query
-        )
-        assert "IN COMPUTE POOL SVC_POOL" in create_query
-        assert "QUERY_WAREHOUSE = WH" in create_query
-        suspend_query = mock_execute.call_args_list[1][0][0]
-        assert "ALTER SERVICE IDENTIFIER('DB.SCHEMA.SVC') SUSPEND" in suspend_query
-
-    @patch(EXECUTE_QUERY)
-    def test_create_service_default_no_execute_as_caller(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().create_service(
-            service_name=fqn,
-            compute_pool="SVC_POOL",
-            query_warehouse="WH",
-        )
-        create_query = mock_execute.call_args_list[0][0][0]
-        assert "executeAsCaller" not in create_query
-
-    @patch(EXECUTE_QUERY)
-    def test_create_service_with_execute_as_caller(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().create_service(
-            service_name=fqn,
-            compute_pool="SVC_POOL",
-            query_warehouse="WH",
-            execute_as_caller=True,
-        )
-        create_query = mock_execute.call_args_list[0][0][0]
-        assert "executeAsCaller: true" in create_query
-
-    @patch(EXECUTE_QUERY)
-    def test_create_service_with_comment(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().create_service(
-            service_name=fqn,
-            compute_pool="SVC_POOL",
-            query_warehouse="WH",
-            app_comment='{"appId": "MY_APP"}',
-        )
-        # Should call: CREATE SERVICE, ALTER SET COMMENT, ALTER SUSPEND
-        assert mock_execute.call_count == 3
-        comment_query = mock_execute.call_args_list[1][0][0]
-        assert "ALTER SERVICE IDENTIFIER('DB.SCHEMA.SVC') SET COMMENT" in comment_query
-        assert '{"appId": "MY_APP"}' in comment_query
-
-    @patch(EXECUTE_QUERY)
-    def test_create_service_escapes_comment_quotes(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().create_service(
-            service_name=fqn,
-            compute_pool="SVC_POOL",
-            query_warehouse="WH",
-            app_comment="it's a test",
-        )
-        comment_query = mock_execute.call_args_list[1][0][0]
-        assert "it''s a test" in comment_query
-
-    @patch(EXECUTE_QUERY)
-    def test_alter_service_spec(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().alter_service_spec(
-            service_name=fqn,
-            image_url="/db/schema/repo/my_app:latest",
-        )
-        mock_execute.assert_called_once()
-        query = mock_execute.call_args[0][0]
-        assert "ALTER SERVICE IDENTIFIER('DB.SCHEMA.SVC')" in query
-        assert "/db/schema/repo/my_app:latest" in query
-
-    @patch(EXECUTE_QUERY)
-    def test_alter_service_spec_default_no_execute_as_caller(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().alter_service_spec(
-            service_name=fqn,
-            image_url="/db/schema/repo/my_app:latest",
-        )
-        query = mock_execute.call_args[0][0]
-        assert "executeAsCaller" not in query
-
-    @patch(EXECUTE_QUERY)
-    def test_alter_service_spec_with_execute_as_caller(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().alter_service_spec(
-            service_name=fqn,
-            image_url="/db/schema/repo/my_app:latest",
-            execute_as_caller=True,
-        )
-        query = mock_execute.call_args[0][0]
-        assert "executeAsCaller: true" in query
-
-    @patch(EXECUTE_QUERY)
-    def test_resume_service(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
-        SnowflakeAppManager().resume_service(fqn)
-        mock_execute.assert_called_once_with(
-            "ALTER SERVICE IDENTIFIER('DB.SCHEMA.SVC') RESUME"
-        )
-
-    @patch(EXECUTE_QUERY)
     def test_get_service_status_running(self, mock_execute):
         cursor = Mock()
         cursor.__iter__ = Mock(
@@ -1537,12 +967,15 @@ class TestResolveDeployDefaults:
         build_compute_pool=None,
         service_compute_pool=None,
         build_eai=None,
+        artifact_repository=None,
         database="TEST_DB",
         schema="TEST_SCHEMA",
         app_name="MY_APP",
     ):
         entity = Mock()
-        entity.fqn = Mock(database=database, schema=schema, name=app_name)
+        fqn = Mock(database=database, schema=schema)
+        fqn.name = app_name
+        entity.fqn = fqn
         entity.query_warehouse = query_warehouse
         entity.build_compute_pool = (
             Mock(name_attr=build_compute_pool) if build_compute_pool else None
@@ -1557,6 +990,12 @@ class TestResolveDeployDefaults:
         entity.build_eai = Mock(name_attr=build_eai) if build_eai else None
         if build_eai:
             entity.build_eai.name = build_eai
+        entity.artifact_repository = None
+        if artifact_repository:
+            entity.artifact_repository = Mock()
+            entity.artifact_repository.name = artifact_repository
+            entity.artifact_repository.database = None
+            entity.artifact_repository.schema_ = None
         return entity
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
@@ -1667,6 +1106,47 @@ class TestResolveDeployDefaults:
         assert result["build_compute_pool"] is None
         assert result["service_compute_pool"] is None
         assert result["build_eai"] is None
+
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
+    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    def test_artifact_repository_defaults_to_app_name_repo(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(app_name="MY_APP")
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        assert result["artifact_repository"] == "MY_APP_REPO"
+
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
+    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    def test_explicit_artifact_repository_takes_precedence(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(artifact_repository="CUSTOM_REPO")
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        assert result["artifact_repository"] == "CUSTOM_REPO"
+
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
+    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    def test_explicit_app_name_overrides_fqn_for_default_repo(
+        self, mock_ctx, mock_role, mock_fetch, mock_params
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(app_name="ENTITY_NAME")
+        result = _resolve_deploy_defaults(
+            entity, SnowflakeAppManager(), app_name="OVERRIDE_NAME"
+        )
+        assert result["artifact_repository"] == "OVERRIDE_NAME_REPO"
 
 
 # ── CLI command tests ─────────────────────────────────────────────────
@@ -2993,9 +2473,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch(
@@ -3014,8 +2494,6 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock()
-        entity.image_repository.name = "MY_REPO"
         mock_get_entity.return_value = entity
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
@@ -3036,9 +2514,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3066,30 +2544,22 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock()
-        entity.image_repository.name = "MY_REPO"
-        entity.image_repository.database = None
-        entity.image_repository.schema_ = None
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.get_image_repo_url.return_value = (
-            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
-        )
-        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
 
             with change_directory(tmp_path):
                 result = runner.invoke(["__app", "deploy", "--deploy-only"])
                 assert result.exit_code == 0, result.output
-                mock_mgr.get_image_repo_url.assert_called_once_with(
-                    "IMAGE_REPO", database="TEST_DB", schema="TEST_SCHEMA"
-                )
-                mock_mgr.execute_build_job.assert_not_called()
-                mock_mgr.create_service.assert_called_once()
-                mock_mgr.alter_service_spec.assert_called_once()
-                mock_mgr.resume_service.assert_called_once()
+                mock_mgr.build_app_artifact_repo.assert_not_called()
+                mock_mgr.artifact_repo_exists.assert_not_called()
+                mock_mgr.create_app_service.assert_called_once()
 
     @patch(
         RESOLVE_DEPLOY_DEFAULTS,
@@ -3100,9 +2570,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch(
@@ -3122,7 +2592,6 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = None
         mock_get_entity.return_value = entity
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
@@ -3142,9 +2611,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch(
@@ -3163,8 +2632,6 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock()
-        entity.image_repository.name = "MY_REPO"
         mock_get_entity.return_value = entity
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
@@ -3173,47 +2640,6 @@ class TestDeployCommand:
                 result = runner.invoke(["__app", "deploy"])
                 assert result.exit_code == 1
                 assert "service_compute_pool is required" in result.output
-
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": None,
-            "build_compute_pool": "BUILD_POOL",
-            "service_compute_pool": "SVC_POOL",
-            "build_eai": None,
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._get_entity",
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_deploy_fails_missing_query_warehouse(
-        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
-    ):
-        entity = Mock()
-        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
-        entity.code_stage = None
-        entity.artifacts = []
-        entity.meta = None
-        entity.artifact_repository = None
-        entity.image_repository = Mock()
-        entity.image_repository.name = "MY_REPO"
-        mock_get_entity.return_value = entity
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy"])
-                assert result.exit_code == 1
-                assert "query_warehouse is required" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
@@ -3228,9 +2654,9 @@ class TestDeployCommand:
             "build_eai": "MY_EAI",
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3250,7 +2676,7 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
-        """Deploy with artifact_repository set uses build/run artifact repo APIs."""
+        """Deploy uses build/run artifact repo APIs."""
         from snowflake.cli.api.project.project_paths import ProjectPaths
 
         entity = Mock()
@@ -3266,10 +2692,7 @@ class TestDeployCommand:
         entity.query_warehouse = "WH"
         entity.build_image = None
         entity.execute_as_caller = False
-        ar_mock = Mock(database="AR_DB", schema_="AR_SCHEMA")
-        ar_mock.name = "AR_REPO"
-        entity.artifact_repository = ar_mock
-        entity.image_repository = None
+        entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
         entity.build_eai = None
@@ -3300,17 +2723,13 @@ class TestDeployCommand:
                 assert result.exit_code == 0, result.output
                 assert "my-app.snowflakecomputing.app" in result.output
 
-        mock_mgr.artifact_repo_exists.assert_called_once_with(
-            database="AR_DB", schema="AR_SCHEMA", repo_name="AR_REPO"
-        )
-        mock_mgr.create_artifact_repo.assert_called_once_with(
-            database="AR_DB", schema="AR_SCHEMA", repo_name="AR_REPO"
-        )
+        mock_mgr.artifact_repo_exists.assert_called_once()
+        mock_mgr.create_artifact_repo.assert_called_once()
         mock_mgr.build_app_artifact_repo.assert_called_once_with(
             stage_fqn=FQN(
                 database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP_CODE_STAGE"
             ),
-            artifact_repo_fqn="AR_DB.AR_SCHEMA.AR_REPO",
+            artifact_repo_fqn="TEST_DB.TEST_SCHEMA.MY_APP_REPO",
             app_id="MY_APP",
             compute_pool="BUILD_POOL",
             database="TEST_DB",
@@ -3321,7 +2740,7 @@ class TestDeployCommand:
         )
         mock_mgr.create_app_service.assert_called_once_with(
             service_fqn=FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP"),
-            artifact_repo_fqn="AR_DB.AR_SCHEMA.AR_REPO",
+            artifact_repo_fqn="TEST_DB.TEST_SCHEMA.MY_APP_REPO",
             package_name="MY_APP",
             compute_pool="SVC_POOL",
             version="LATEST",
@@ -3329,11 +2748,6 @@ class TestDeployCommand:
             external_access_integrations=["MY_EAI"],
             comment='{"appId": "MY_APP"}',
         )
-        mock_mgr.get_image_repo_url.assert_not_called()
-        mock_mgr.create_service.assert_not_called()
-        mock_mgr.alter_service_spec.assert_not_called()
-        mock_mgr.execute_build_job.assert_not_called()
-        # 2 polls: build status + describe for endpoint URL
         assert mock_poll.call_count == 2
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
@@ -3349,9 +2763,9 @@ class TestDeployCommand:
             "build_eai": "MY_EAI",
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3371,7 +2785,7 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
-        """When the artifact repo already exists, skip CREATE."""
+        """Deploy skips CREATE ARTIFACT REPOSITORY when repo already exists."""
         from snowflake.cli.api.project.project_paths import ProjectPaths
 
         entity = Mock()
@@ -3387,10 +2801,7 @@ class TestDeployCommand:
         entity.query_warehouse = "WH"
         entity.build_image = None
         entity.execute_as_caller = False
-        ar_mock = Mock(database="AR_DB", schema_="AR_SCHEMA")
-        ar_mock.name = "AR_REPO"
-        entity.artifact_repository = ar_mock
-        entity.image_repository = None
+        entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
         entity.build_eai = None
@@ -3408,18 +2819,21 @@ class TestDeployCommand:
         )
         mock_poll.side_effect = [
             "DONE",
-            {"url": "my-app.snowflakecomputing.app", "is_upgrading": "false"},
+            {
+                "url": "my-app.snowflakecomputing.app",
+                "is_upgrading": "false",
+            },
         ]
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+
             with change_directory(tmp_path):
                 result = runner.invoke(["__app", "deploy"])
                 assert result.exit_code == 0, result.output
 
-        mock_mgr.artifact_repo_exists.assert_called_once_with(
-            database="AR_DB", schema="AR_SCHEMA", repo_name="AR_REPO"
-        )
+        mock_mgr.artifact_repo_exists.assert_called_once()
         mock_mgr.create_artifact_repo.assert_not_called()
+        mock_mgr.build_app_artifact_repo.assert_called_once()
 
     # ── Phase flag tests ──────────────────────────────────────────────
 
@@ -3459,9 +2873,9 @@ class TestDeployCommand:
             "build_eai": "MY_EAI",
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3494,9 +2908,7 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
-        entity.build_image = None
-        entity.execute_as_caller = False
+        entity.runtime_image = ""
         mock_get_entity.return_value = entity
 
         bundle_dir = tmp_path / "output" / "bundle"
@@ -3506,10 +2918,17 @@ class TestDeployCommand:
 
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.stage_exists.return_value = False
-        mock_mgr.get_image_repo_url.return_value = (
-            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
+        mock_mgr.artifact_repo_exists.return_value = False
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
         )
-        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
+        mock_poll.side_effect = [
+            "DONE",  # build status poll
+            {
+                "url": "my-app.snowflakecomputing.app",
+                "is_upgrading": "false",
+            },  # describe poll
+        ]
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
             from tests_common import change_directory
@@ -3521,10 +2940,10 @@ class TestDeployCommand:
 
         mock_mgr.create_stage.assert_called_once()
         mock_perform_bundle.assert_called_once()
-        mock_mgr.execute_build_job.assert_called_once()
-        mock_mgr.create_service.assert_called_once()
-        mock_mgr.alter_service_spec.assert_called_once()
-        mock_mgr.resume_service.assert_called_once()
+        mock_mgr.artifact_repo_exists.assert_called_once()
+        mock_mgr.create_artifact_repo.assert_called_once()
+        mock_mgr.build_app_artifact_repo.assert_called_once()
+        mock_mgr.create_app_service.assert_called_once()
 
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
     @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
@@ -3538,9 +2957,9 @@ class TestDeployCommand:
             "build_eai": "MY_EAI",
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3567,7 +2986,6 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
         mock_get_entity.return_value = entity
 
         bundle_dir = tmp_path / "output" / "bundle"
@@ -3588,9 +3006,8 @@ class TestDeployCommand:
 
         mock_mgr.create_stage.assert_called_once()
         mock_perform_bundle.assert_called_once()
-        mock_mgr.execute_build_job.assert_not_called()
-        mock_mgr.create_service.assert_not_called()
-        mock_mgr.get_image_repo_url.assert_not_called()
+        mock_mgr.build_app_artifact_repo.assert_not_called()
+        mock_mgr.create_app_service.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3603,9 +3020,9 @@ class TestDeployCommand:
             "build_eai": "MY_EAI",
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3633,13 +3050,13 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
-        entity.build_image = None
+        entity.runtime_image = ""
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.get_image_repo_url.return_value = (
-            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
+        mock_mgr.artifact_repo_exists.return_value = False
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
         )
         mock_poll.return_value = "DONE"
 
@@ -3651,10 +3068,10 @@ class TestDeployCommand:
                 assert result.exit_code == 0, result.output
                 assert "Build completed successfully" in result.output
 
-        mock_mgr.execute_build_job.assert_called_once()
-        mock_mgr.create_service.assert_not_called()
-        mock_mgr.alter_service_spec.assert_not_called()
-        mock_mgr.resume_service.assert_not_called()
+        mock_mgr.artifact_repo_exists.assert_called_once()
+        mock_mgr.create_artifact_repo.assert_called_once()
+        mock_mgr.build_app_artifact_repo.assert_called_once()
+        mock_mgr.create_app_service.assert_not_called()
         mock_mgr.stage_exists.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
@@ -3668,9 +3085,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3698,14 +3115,13 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.get_image_repo_url.return_value = (
-            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
-        )
-        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
             from tests_common import change_directory
@@ -3715,10 +3131,8 @@ class TestDeployCommand:
                 assert result.exit_code == 0, result.output
                 assert "App ready at" in result.output
 
-        mock_mgr.create_service.assert_called_once()
-        mock_mgr.alter_service_spec.assert_called_once()
-        mock_mgr.resume_service.assert_called_once()
-        mock_mgr.execute_build_job.assert_not_called()
+        mock_mgr.create_app_service.assert_called_once()
+        mock_mgr.build_app_artifact_repo.assert_not_called()
         mock_mgr.stage_exists.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
@@ -3733,9 +3147,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3763,7 +3177,6 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = None
         mock_get_entity.return_value = entity
 
         bundle_dir = tmp_path / "output" / "bundle"
@@ -3790,9 +3203,9 @@ class TestDeployCommand:
             "build_eai": None,
             "database": "TEST_DB",
             "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
         },
     )
     @patch("snowflake.cli._plugins.apps.commands._get_entity")
@@ -3810,7 +3223,6 @@ class TestDeployCommand:
         entity.artifacts = []
         entity.meta = None
         entity.artifact_repository = None
-        entity.image_repository = None
         mock_get_entity.return_value = entity
 
         with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
@@ -3820,527 +3232,3 @@ class TestDeployCommand:
                 result = runner.invoke(["__app", "deploy", "--build-only"])
                 assert "service_compute_pool is required" not in result.output
                 assert "query_warehouse is required" not in result.output
-
-    # ── Telemetry span tests ─────────────────────────────────────────
-
-    @staticmethod
-    def _make_deploy_mocks(
-        tmp_path,
-        mock_get_ctx,
-        mock_get_entity,
-        mock_manager_cls,
-        mock_perform_bundle,
-        *,
-        use_artifact_repo=False,
-    ):
-        """Wire up the common mocks for a deploy invocation and return (metrics, mock_mgr)."""
-        from snowflake.cli.api.metrics import CLIMetrics
-        from snowflake.cli.api.project.project_paths import ProjectPaths
-
-        metrics = CLIMetrics()
-        mock_ctx = Mock()
-        mock_ctx.metrics = metrics
-        mock_ctx.connection_context.database = "TEST_DB"
-        mock_ctx.connection_context.schema = "TEST_SCHEMA"
-        mock_ctx.connection_context.warehouse = "WH"
-        mock_get_ctx.return_value = mock_ctx
-
-        entity = Mock()
-        fqn = Mock()
-        fqn.name = "MY_APP"
-        fqn.database = "TEST_DB"
-        fqn.schema = "TEST_SCHEMA"
-        entity.fqn = fqn
-        entity.code_stage = None
-        entity.artifacts = []
-        entity.meta = None
-        entity.build_image = None
-        entity.execute_as_caller = False
-        entity.runtime_image = "runtime:latest"
-
-        if use_artifact_repo:
-            ar_mock = Mock(database="AR_DB", schema_="AR_SCHEMA")
-            ar_mock.name = "AR_REPO"
-            entity.artifact_repository = ar_mock
-            entity.image_repository = None
-            entity.build_compute_pool = None
-            entity.service_compute_pool = None
-            entity.build_eai = None
-            entity.query_warehouse = "WH"
-        else:
-            entity.artifact_repository = None
-            entity.image_repository = Mock(name="MY_REPO", database=None, schema_=None)
-
-        mock_get_entity.return_value = entity
-
-        bundle_dir = tmp_path / "output" / "bundle"
-        bundle_dir.mkdir(parents=True, exist_ok=True)
-        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
-
-        mock_mgr = mock_manager_cls.return_value
-        mock_mgr.stage_exists.return_value = False
-        mock_mgr.get_image_repo_url.return_value = (
-            "host.registry-local.snowflakecomputing.com/TEST_DB/TEST_SCHEMA/IMAGE_REPO"
-        )
-        mock_mgr.build_app_artifact_repo.return_value = (
-            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
-        )
-
-        return metrics, mock_mgr
-
-    @patch("snowflake.cli._plugins.apps.commands._poll_until")
-    @patch("snowflake.cli._plugins.apps.commands.StageManager")
-    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": "BUILD_POOL",
-            "service_compute_pool": "SVC_POOL",
-            "build_eai": "MY_EAI",
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
-    def test_deploy_image_repo_records_telemetry_spans(
-        self,
-        mock_get_ctx,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        mock_perform_bundle,
-        mock_stage_manager_cls,
-        mock_poll,
-        runner,
-        tmp_path,
-    ):
-        """Non-artifact-repo deploy records exactly the expected spans in order."""
-        from snowflake.cli.api.metrics import CLIMetricsSpan
-
-        mock_poll.return_value = "https://my-app.snowflakecomputing.app"
-        metrics, _ = self._make_deploy_mocks(
-            tmp_path,
-            mock_get_ctx,
-            mock_get_entity,
-            mock_manager_cls,
-            mock_perform_bundle,
-        )
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy"])
-                assert result.exit_code == 0, result.output
-
-        span_names = [s[CLIMetricsSpan.NAME_KEY] for s in metrics.completed_spans]
-        assert span_names == [
-            "snowflake_app.bundle",
-            "snowflake_app.upload",
-            "snowflake_app.build",
-            "snowflake_app.deploy_service",
-            "snowflake_app.endpoint_provision",
-        ]
-        for span in metrics.completed_spans:
-            assert span[CLIMetricsSpan.ERROR_KEY] is None
-            assert span[CLIMetricsSpan.EXECUTION_TIME_KEY] > 0
-
-    @patch("snowflake.cli._plugins.apps.commands._poll_until")
-    @patch("snowflake.cli._plugins.apps.commands.StageManager")
-    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": "BUILD_POOL",
-            "service_compute_pool": "SVC_POOL",
-            "build_eai": "MY_EAI",
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
-    def test_deploy_artifact_repo_records_telemetry_spans(
-        self,
-        mock_get_ctx,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        mock_perform_bundle,
-        mock_stage_manager_cls,
-        mock_poll,
-        runner,
-        tmp_path,
-    ):
-        """Artifact-repo deploy records exactly the expected spans in order."""
-        from snowflake.cli.api.metrics import CLIMetricsSpan
-
-        mock_poll.side_effect = [
-            "DONE",
-            {
-                "url": "https://my-app.snowflakecomputing.app",
-                "is_upgrading": "false",
-                "status": "READY",
-            },
-        ]
-        metrics, _ = self._make_deploy_mocks(
-            tmp_path,
-            mock_get_ctx,
-            mock_get_entity,
-            mock_manager_cls,
-            mock_perform_bundle,
-            use_artifact_repo=True,
-        )
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy"])
-                assert result.exit_code == 0, result.output
-
-        span_names = [s[CLIMetricsSpan.NAME_KEY] for s in metrics.completed_spans]
-        assert span_names == [
-            "snowflake_app.bundle",
-            "snowflake_app.upload",
-            "snowflake_app.build",
-            "snowflake_app.deploy_service",
-            "snowflake_app.endpoint_provision",
-        ]
-        for span in metrics.completed_spans:
-            assert span[CLIMetricsSpan.ERROR_KEY] is None
-
-    @patch("snowflake.cli._plugins.apps.commands._poll_until")
-    @patch("snowflake.cli._plugins.apps.commands.StageManager")
-    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": "BUILD_POOL",
-            "service_compute_pool": "SVC_POOL",
-            "build_eai": "MY_EAI",
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "image_repository": "IMAGE_REPO",
-            "image_repo_database": "TEST_DB",
-            "image_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
-    def test_deploy_build_failure_records_error_in_span(
-        self,
-        mock_get_ctx,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        mock_perform_bundle,
-        mock_stage_manager_cls,
-        mock_poll,
-        runner,
-        tmp_path,
-    ):
-        """When build polling raises CliError, the build span records the error."""
-        from snowflake.cli.api.metrics import CLIMetricsSpan
-
-        def _poll_side_effect(**kwargs):
-            if kwargs.get("done_states") == {"DONE"}:
-                raise CliError("Build timed out.")
-            return "https://my-app.snowflakecomputing.app"
-
-        mock_poll.side_effect = _poll_side_effect
-        metrics, _ = self._make_deploy_mocks(
-            tmp_path,
-            mock_get_ctx,
-            mock_get_entity,
-            mock_manager_cls,
-            mock_perform_bundle,
-        )
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy"])
-                assert result.exit_code == 1
-
-        span_map = {s[CLIMetricsSpan.NAME_KEY]: s for s in metrics.completed_spans}
-        assert "snowflake_app.build" in span_map
-        assert span_map["snowflake_app.build"][CLIMetricsSpan.ERROR_KEY] == "CliError"
-        assert "snowflake_app.bundle" in span_map
-        assert span_map["snowflake_app.bundle"][CLIMetricsSpan.ERROR_KEY] is None
-
-
-TEARDOWN_DEFAULTS = {
-    "database": "TEST_DB",
-    "schema": "TEST_SCHEMA",
-}
-
-
-class TestTeardownCommand:
-    @staticmethod
-    def _make_entity(
-        name="MY_APP",
-        artifact_repository=None,
-        code_stage=None,
-    ):
-        entity = Mock()
-        fqn = Mock()
-        fqn.name = name
-        entity.fqn = fqn
-        entity.artifact_repository = artifact_repository
-        entity.code_stage = code_stage
-        return entity
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_drops_service_stage_and_build_job(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity()
-        mock_mgr = mock_manager_cls.return_value
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown", "--force"])
-                assert result.exit_code == 0, result.output
-                assert "Successfully dropped service" in result.output
-
-        assert mock_mgr.drop_service_if_exists.call_count == 2
-        dropped_fqns = [
-            c.args[0].identifier for c in mock_mgr.drop_service_if_exists.call_args_list
-        ]
-        assert "TEST_DB.TEST_SCHEMA.MY_APP" in dropped_fqns
-        assert "TEST_DB.TEST_SCHEMA.MY_APP_BUILD_JOB" in dropped_fqns
-        mock_mgr.drop_stage_if_exists.assert_called_once()
-        mock_mgr.drop_app_service_if_exists.assert_not_called()
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_drops_app_service_and_stage_for_artifact_repo(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity(
-            artifact_repository=Mock(name="MY_REPO"),
-        )
-        mock_mgr = mock_manager_cls.return_value
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown", "--force"])
-                assert result.exit_code == 0, result.output
-                assert "Successfully dropped application service" in result.output
-
-        mock_mgr.drop_app_service_if_exists.assert_called_once()
-        mock_mgr.drop_stage_if_exists.assert_called_once()
-        mock_mgr.drop_service_if_exists.assert_not_called()
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_uses_custom_stage_name(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        code_stage = Mock()
-        code_stage.name = "CUSTOM_STAGE"
-        mock_get_entity.return_value = self._make_entity(code_stage=code_stage)
-        mock_mgr = mock_manager_cls.return_value
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown", "--force"])
-                assert result.exit_code == 0, result.output
-
-        stage_fqn = mock_mgr.drop_stage_if_exists.call_args.args[0]
-        assert stage_fqn.identifier == "TEST_DB.TEST_SCHEMA.CUSTOM_STAGE"
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_passes_entity_id(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity()
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(
-                    ["__app", "teardown", "--entity-id", "custom_app", "--force"]
-                )
-                assert result.exit_code == 0, result.output
-                mock_resolve.assert_called_once_with("custom_app")
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_cancelled_without_force(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity()
-        mock_mgr = mock_manager_cls.return_value
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown"], input="n\n")
-                assert result.exit_code == 0, result.output
-                assert "Teardown cancelled" in result.output
-
-        mock_mgr.drop_service_if_exists.assert_not_called()
-        mock_mgr.drop_app_service_if_exists.assert_not_called()
-        mock_mgr.drop_stage_if_exists.assert_not_called()
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_confirmed_without_force(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity()
-        mock_mgr = mock_manager_cls.return_value
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown"], input="y\n")
-                assert result.exit_code == 0, result.output
-                assert "Successfully dropped service" in result.output
-
-        assert mock_mgr.drop_service_if_exists.call_count == 2
-        mock_mgr.drop_stage_if_exists.assert_called_once()
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
-    )
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_uses_resolved_defaults_for_db_schema(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity()
-        mock_mgr = mock_manager_cls.return_value
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown", "--force"])
-                assert result.exit_code == 0, result.output
-                assert "PARAM_DB.PARAM_SCHEMA.MY_APP" in result.output
-
-        mock_defaults.assert_called_once()
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value={})
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_teardown_errors_when_database_missing(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        runner,
-        tmp_path,
-    ):
-        mock_get_entity.return_value = self._make_entity()
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "teardown", "--force"])
-                assert result.exit_code == 1
-                assert "Cannot resolve" in result.output

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1108,12 +1108,8 @@ class TestResolveDeployDefaults:
         assert result["build_eai"] is None
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
-    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
-    @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    def test_artifact_repository_defaults_to_app_name_repo(
-        self, mock_ctx, mock_role, mock_fetch, mock_params
-    ):
+    def test_artifact_repository_defaults_to_app_name_repo(self, mock_ctx, mock_params):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(app_name="MY_APP")
@@ -1121,12 +1117,8 @@ class TestResolveDeployDefaults:
         assert result["artifact_repository"] == "MY_APP_REPO"
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
-    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
-    @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    def test_explicit_artifact_repository_takes_precedence(
-        self, mock_ctx, mock_role, mock_fetch, mock_params
-    ):
+    def test_explicit_artifact_repository_takes_precedence(self, mock_ctx, mock_params):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(artifact_repository="CUSTOM_REPO")
@@ -1134,11 +1126,9 @@ class TestResolveDeployDefaults:
         assert result["artifact_repository"] == "CUSTOM_REPO"
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
-    @patch(FETCH_CONFIG_DEFAULTS, return_value={})
-    @patch(CURRENT_ROLE, return_value="ENGINEER")
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
     def test_explicit_app_name_overrides_fqn_for_default_repo(
-        self, mock_ctx, mock_role, mock_fetch, mock_params
+        self, mock_ctx, mock_params
     ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

For `snow __app deploy`, use only artifact-repository (drop support for image repository). If a specific `artifact_repository` was not specified in `snowflake.yml` or config table, a new artifact repository named `<APP_ID>_REPO` will be created.
