### PR TITLE
Add native-apps team as codeowners for nativeapp test snapshots

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 /src/snowflake/cli/_plugins/apps/ @snowflakedb/native-apps
 /tests/apps/ @snowflakedb/native-apps
 /tests_integration/apps/ @snowflakedb/native-apps
-/tests/nativeapp/__snapshots__/ @snowflakedb/native-apps
-/tests_integration/nativeapp/__snapshots__/ @snowflakedb/native-apps
+/tests/__snapshots__/ @snowflakedb/native-apps
+/tests_integration/__snapshots__/ @snowflakedb/native-apps

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 /src/snowflake/cli/_plugins/apps/ @snowflakedb/native-apps
 /tests/apps/ @snowflakedb/native-apps
 /tests_integration/apps/ @snowflakedb/native-apps
+/tests/nativeapp/__snapshots__/ @snowflakedb/native-apps
+/tests/nativeapp/codegen/snowpark/__snapshots__/ @snowflakedb/native-apps
+/tests_integration/nativeapp/__snapshots__/ @snowflakedb/native-apps

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,4 @@
 /tests/apps/ @snowflakedb/native-apps
 /tests_integration/apps/ @snowflakedb/native-apps
 /tests/nativeapp/__snapshots__/ @snowflakedb/native-apps
-/tests/nativeapp/codegen/snowpark/__snapshots__/ @snowflakedb/native-apps
 /tests_integration/nativeapp/__snapshots__/ @snowflakedb/native-apps


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Follow-up to #2874. Adds `@snowflakedb/native-apps` as codeowners for the top-level `__snapshots__` directories that were missed in the original PR:

- `/tests/__snapshots__/`
- `/tests_integration/__snapshots__/`