### PR TITLE
Add CI/CD integration version tracking for Nucleus

### DIFF
--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -59,6 +59,7 @@ class CLITelemetryField(Enum):
     COMMAND_OUTPUT_TYPE = "command_output_type"
     COMMAND_EXECUTION_TIME = "command_execution_time"
     COMMAND_CI_ENVIRONMENT = "command_ci_environment"
+    COMMAND_CI_INTEGRATION_VERSION = "command_ci_integration_version"
     COMMAND_AGENT_ENVIRONMENT = "command_agent_environment"
     # Configuration
     CONFIG_FEATURE_FLAGS = "config_feature_flags"
@@ -215,6 +216,10 @@ def _get_ci_environment_type() -> str:
     """Detect CI/CD environment type based on environment variables."""
     if "SF_GITHUB_ACTION" in os.environ:
         return "SF_GITHUB_ACTION"
+    if "SF_GITLAB_COMPONENT" in os.environ:
+        return "SF_GITLAB_COMPONENT"
+    if "SF_ADO_EXTENSION" in os.environ:
+        return "SF_ADO_EXTENSION"
     if "GITHUB_ACTIONS" in os.environ:
         return "GITHUB_ACTIONS"
     if "GITLAB_CI" in os.environ:
@@ -242,6 +247,11 @@ def _get_ci_environment_type() -> str:
     if _is_interactive_terminal():
         return "LOCAL"
     return "UNKNOWN"
+
+
+def _get_ci_integration_version() -> str:
+    """Get the version of the official Snowflake CI/CD integration, if any."""
+    return os.environ.get("SF_CICD_INTEGRATION_VERSION", "")
 
 
 def _detect_agent_environment() -> str:
@@ -333,6 +343,7 @@ class CLITelemetryClient:
             CLITelemetryField.VERSION_OS: platform.platform(),
             CLITelemetryField.VERSION_PYTHON: python_version(),
             CLITelemetryField.COMMAND_CI_ENVIRONMENT: _get_ci_environment_type(),
+            CLITelemetryField.COMMAND_CI_INTEGRATION_VERSION: _get_ci_integration_version(),
             CLITelemetryField.COMMAND_AGENT_ENVIRONMENT: _detect_agent_environment(),
             CLITelemetryField.CONFIG_FEATURE_FLAGS: {
                 k: str(v) for k, v in get_feature_flags_section().items()

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -74,6 +74,9 @@ def test_executing_command_sends_telemetry_usage_data_legacy_config(
             "command_ci_environment"
         ]  # to avoid side effect from CI
         del usage_command_event["message"][
+            "command_ci_integration_version"
+        ]  # to avoid side effect from CI
+        del usage_command_event["message"][
             "command_agent_environment"
         ]  # to avoid side effect from agent environment
         assert usage_command_event == {
@@ -141,6 +144,9 @@ def test_executing_command_sends_telemetry_usage_data_ng_config(
             "command_ci_environment"
         ]  # to avoid side effect from CI
         del usage_command_event["message"][
+            "command_ci_integration_version"
+        ]  # to avoid side effect from CI
+        del usage_command_event["message"][
             "command_agent_environment"
         ]  # to avoid side effect from agent environment
 
@@ -173,6 +179,8 @@ def test_executing_command_sends_telemetry_usage_data_ng_config(
     "ci_type, env_var",
     [
         ("SF_GITHUB_ACTION", "SF_GITHUB_ACTION"),
+        ("SF_GITLAB_COMPONENT", "SF_GITLAB_COMPONENT"),
+        ("SF_ADO_EXTENSION", "SF_ADO_EXTENSION"),
         ("GITHUB_ACTIONS", "GITHUB_ACTIONS"),
         ("GITLAB_CI", "GITLAB_CI"),
         ("CIRCLECI", "CIRCLECI"),
@@ -431,6 +439,74 @@ def test_cli_exception_classification(error: Exception, is_cli: bool):
     from snowflake.cli._app.telemetry import _is_cli_exception
 
     assert _is_cli_exception(error) == is_cli
+
+
+def test_get_ci_integration_version_returns_value_when_set():
+    """Test that integration version is returned when env var is set."""
+    from snowflake.cli._app.telemetry import _get_ci_integration_version
+
+    with mock.patch.dict(
+        os.environ, {"SF_CICD_INTEGRATION_VERSION": "v2.0.2"}, clear=True
+    ):
+        assert _get_ci_integration_version() == "v2.0.2"
+
+
+def test_get_ci_integration_version_returns_empty_when_unset():
+    """Test that empty string is returned when env var is not set."""
+    from snowflake.cli._app.telemetry import _get_ci_integration_version
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert _get_ci_integration_version() == ""
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.connection.commands.ObjectManager")
+def test_ci_integration_version_appears_in_telemetry(_, mock_conn, runner):
+    """Test that integration version is included in telemetry payload."""
+    with mock.patch.dict(
+        os.environ,
+        {"SF_GITHUB_ACTION": "true", "SF_CICD_INTEGRATION_VERSION": "v2.0.2"},
+        clear=True,
+    ):
+        result = runner.invoke(["connection", "test"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    usage_command_event = (
+        mock_conn.return_value._telemetry.try_add_log_to_batch.call_args_list[  # noqa: SLF001
+            0
+        ]
+        .args[0]
+        .to_dict()
+    )
+
+    assert (
+        usage_command_event["message"]["command_ci_environment"] == "SF_GITHUB_ACTION"
+    )
+    assert usage_command_event["message"]["command_ci_integration_version"] == "v2.0.2"
+
+
+def test_sf_gitlab_component_takes_priority_over_gitlab_ci():
+    """Test that SF_GITLAB_COMPONENT is detected before generic GITLAB_CI."""
+    from snowflake.cli._app.telemetry import _get_ci_environment_type
+
+    with mock.patch.dict(
+        os.environ,
+        {"SF_GITLAB_COMPONENT": "true", "GITLAB_CI": "true"},
+        clear=True,
+    ):
+        assert _get_ci_environment_type() == "SF_GITLAB_COMPONENT"
+
+
+def test_sf_ado_extension_takes_priority_over_azure_devops():
+    """Test that SF_ADO_EXTENSION is detected before generic AZURE_DEVOPS."""
+    from snowflake.cli._app.telemetry import _get_ci_environment_type
+
+    with mock.patch.dict(
+        os.environ,
+        {"SF_ADO_EXTENSION": "true", "TF_BUILD": "true"},
+        clear=True,
+    ):
+        assert _get_ci_environment_type() == "SF_ADO_EXTENSION"
 
 
 @mock.patch("uuid.uuid4")


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Adds telemetry support for tracking which official Snowflake CI/CD integration and version is being used. This enables adoption dashboards for the Nucleus project (per Q1 Plan Section "Telemetry & adoption tracking").

**Changes in `telemetry.py`:**
- Add `SF_GITLAB_COMPONENT` and `SF_ADO_EXTENSION` detection in `_get_ci_environment_type()`, with priority over generic platform checks (`GITLAB_CI`, `TF_BUILD`) so we can distinguish official Snowflake integrations from bare CI/CD usage
- Add `_get_ci_integration_version()` reading `SF_CICD_INTEGRATION_VERSION` env var set by each official integration
- Wire new `COMMAND_CI_INTEGRATION_VERSION` field into telemetry payload

**Changes in `test_telemetry.py`:**
- Add `SF_GITLAB_COMPONENT` and `SF_ADO_EXTENSION` to parametrized CI environment test
- Add tests for version reading (set/unset)
- Add integration test verifying version appears in telemetry payload
- Add priority tests (official integration marker detected before generic platform)

**Companion PRs** (set the env vars that this PR reads):
- snowflakedb/snowflake-cli-action - adds `SF_CICD_INTEGRATION_VERSION`
- snowflakedb/snowflake-ado-extension - adds `SF_ADO_EXTENSION` + `SF_CICD_INTEGRATION_VERSION`
- snowflakedbutils/snowflake-cicd-component (GitLab) - adds `SF_CICD_INTEGRATION_VERSION`