### PR TITLE
Snowflake Apps: Add teardown command

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -898,3 +898,79 @@ def deploy(
             ),
         )
     return MessageResult(f"App ready at {endpoint_url}")
+
+
+@app.command(requires_connection=True)
+def teardown(
+    entity_id: Optional[str] = typer.Option(
+        None,
+        "--entity-id",
+        help="ID of the snowflake-app entity to tear down. Required if multiple snowflake-app entities exist.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Drop without confirmation prompt.",
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Drops a deployed Snowflake App and its associated objects.
+
+    Reads the entity from snowflake.yml and drops the application service
+    (or SPCS service), the code stage, and the build job service.
+    Unless --force is provided, prompts for confirmation before dropping.
+    """
+    resolved_entity_id = _resolve_entity_id(entity_id)
+    entity = _get_entity(resolved_entity_id)
+
+    fqn = entity.fqn
+    manager = SnowflakeAppManager()
+    defaults = _resolve_deploy_defaults(entity, manager)
+
+    db = defaults.get("database")
+    schema = defaults.get("schema")
+
+    if not db or not schema:
+        missing = [k for k, v in {"database": db, "schema": schema}.items() if not v]
+        raise CliError(
+            f"Cannot resolve {' or '.join(missing)} for the app. "
+            "Set them in snowflake.yml or in your connection configuration."
+        )
+
+    app_name = fqn.name
+    service_fqn = FQN(database=db, schema=schema, name=app_name)
+    use_artifact_repo = entity.artifact_repository is not None
+
+    stage_name = (
+        entity.code_stage.name if entity.code_stage else f"{app_name}_CODE_STAGE"
+    )
+    stage_fqn = FQN(database=db, schema=schema, name=stage_name)
+    build_job_fqn = FQN(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
+
+    object_kind = "application service" if use_artifact_repo else "service"
+
+    if not force:
+        should_continue = typer.confirm(
+            f"Are you sure you want to drop {object_kind} {service_fqn.identifier}"
+            f" and its associated objects?"
+        )
+        if not should_continue:
+            return MessageResult("Teardown cancelled.")
+
+    cli_console.step(f"Dropping {object_kind} {service_fqn.identifier}")
+    if use_artifact_repo:
+        manager.drop_app_service_if_exists(service_fqn)
+    else:
+        manager.drop_service_if_exists(service_fqn)
+
+    cli_console.step(f"Dropping stage {stage_fqn.identifier}")
+    manager.drop_stage_if_exists(stage_fqn)
+
+    if not use_artifact_repo:
+        cli_console.step(f"Dropping build job service {build_job_fqn.identifier}")
+        manager.drop_service_if_exists(build_job_fqn)
+
+    return MessageResult(
+        f"Successfully dropped {object_kind} {service_fqn.identifier}."
+    )

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -542,6 +542,16 @@ class SnowflakeAppManager(SqlExecutionMixin):
         """Drop a service if it exists."""
         self.execute_query(f"DROP SERVICE IF EXISTS {service_fqn.sql_identifier}")
 
+    def drop_app_service_if_exists(self, service_fqn: FQN) -> None:
+        """Drop an application service if it exists."""
+        self.execute_query(
+            f"DROP APPLICATION SERVICE IF EXISTS {service_fqn.sql_identifier}"
+        )
+
+    def drop_stage_if_exists(self, stage_fqn: FQN) -> None:
+        """Drop a stage if it exists."""
+        self.execute_query(f"DROP STAGE IF EXISTS {stage_fqn.sql_identifier}")
+
     def get_image_repo_url(
         self,
         repo_name: str,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -674,6 +674,149 @@
   
   '''
 # ---
+# name: test_help_messages[__app.teardown]
+  '''
+                                                                                  
+   Usage: root __app teardown [OPTIONS]                                           
+                                                                                  
+   Drops a deployed Snowflake App and its associated objects.                     
+                                                                                  
+   Reads the entity from snowflake.yml and drops the application service (or SPCS 
+   service), the code stage, and the build job service. Unless --force is         
+   provided, prompts for confirmation before dropping.                            
+                                                                                  
+  +- Options --------------------------------------------------------------------+
+  | --entity-id          TEXT  ID of the snowflake-app entity to tear down.      |
+  |                            Required if multiple snowflake-app entities       |
+  |                            exist.                                            |
+  | --force                    Drop without confirmation prompt.                 |
+  | --help       -h            Show this message and exit.                       |
+  +------------------------------------------------------------------------------+
+  +- Connection configuration ---------------------------------------------------+
+  | --connection,--environment    -c      TEXT     Name of the connection, as    |
+  |                                                defined in your config.toml   |
+  |                                                file. Default: default.       |
+  | --host                                TEXT     Host address for the          |
+  |                                                connection. Overrides the     |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --account,--accountname               TEXT     Name assigned to your         |
+  |                                                Snowflake account. Overrides  |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --user,--username                     TEXT     Username to connect to        |
+  |                                                Snowflake. Overrides the      |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --password                            TEXT     Snowflake password. Overrides |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --authenticator                       TEXT     Snowflake authenticator.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --workload-identity-provider          TEXT     Workload identity provider    |
+  |                                                (AWS, AZURE, GCP, OIDC).      |
+  |                                                Overrides the value specified |
+  |                                                for the connection            |
+  | --private-key-file,--privat…          TEXT     Snowflake private key file    |
+  |                                                path. Overrides the value     |
+  |                                                specified for the connection. |
+  | --token                               TEXT     OAuth token to use when       |
+  |                                                connecting to Snowflake.      |
+  | --token-file-path                     TEXT     Path to file with an OAuth    |
+  |                                                token to use when connecting  |
+  |                                                to Snowflake.                 |
+  | --database,--dbname                   TEXT     Database to use. Overrides    |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --schema,--schemaname                 TEXT     Database schema to use.       |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --role,--rolename                     TEXT     Role to use. Overrides the    |
+  |                                                value specified for the       |
+  |                                                connection.                   |
+  | --warehouse                           TEXT     Warehouse to use. Overrides   |
+  |                                                the value specified for the   |
+  |                                                connection.                   |
+  | --temporary-connection        -x               Uses a connection defined     |
+  |                                                with command-line parameters, |
+  |                                                instead of one defined in     |
+  |                                                config                        |
+  | --mfa-passcode                        TEXT     Token to use for multi-factor |
+  |                                                authentication (MFA)          |
+  | --enable-diag                                  Whether to generate a         |
+  |                                                connection diagnostic report. |
+  | --diag-log-path                       TEXT     Path for the generated        |
+  |                                                report. Defaults to system    |
+  |                                                temporary directory.          |
+  | --diag-allowlist-path                 TEXT     Path to a JSON file that      |
+  |                                                contains allowlist            |
+  |                                                parameters.                   |
+  | --oauth-client-id                     TEXT     Value of client id provided   |
+  |                                                by the Identity Provider for  |
+  |                                                Snowflake integration.        |
+  | --oauth-client-secret                 TEXT     Value of the client secret    |
+  |                                                provided by the Identity      |
+  |                                                Provider for Snowflake        |
+  |                                                integration.                  |
+  | --oauth-authorization-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the authorization   |
+  |                                                code to the driver.           |
+  | --oauth-token-request-url             TEXT     Identity Provider endpoint    |
+  |                                                supplying the access tokens   |
+  |                                                to the driver.                |
+  | --oauth-redirect-uri                  TEXT     URI to use for authorization  |
+  |                                                code redirection.             |
+  | --oauth-scope                         TEXT     Scope requested in the        |
+  |                                                Identity Provider             |
+  |                                                authorization request.        |
+  | --oauth-disable-pkce                           Disables Proof Key for Code   |
+  |                                                Exchange (PKCE). Default:     |
+  |                                                False.                        |
+  | --oauth-enable-refresh-toke…                   Enables a silent              |
+  |                                                re-authentication when the    |
+  |                                                actual access token becomes   |
+  |                                                outdated. Default: False.     |
+  | --oauth-enable-single-use-r…                   Whether to opt-in to          |
+  |                                                single-use refresh token      |
+  |                                                semantics. Default: False.    |
+  | --client-store-temporary-cr…                   Store the temporary           |
+  |                                                credential.                   |
+  +------------------------------------------------------------------------------+
+  +- Global configuration -------------------------------------------------------+
+  | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
+  |                                CSV]                   format.                |
+  |                                                       [default: TABLE]       |
+  | --verbose              -v                             Displays log entries   |
+  |                                                       for log levels info    |
+  |                                                       and higher.            |
+  | --debug                                               Displays log entries   |
+  |                                                       for log levels debug   |
+  |                                                       and higher; debug logs |
+  |                                                       contain additional     |
+  |                                                       information.           |
+  | --silent                                              Turns off intermediate |
+  |                                                       output to console.     |
+  | --enhanced-exit-codes                                 Differentiate exit     |
+  |                                                       error codes based on   |
+  |                                                       failure type.          |
+  |                                                       [env var:              |
+  |                                                       SNOWFLAKE_ENHANCED_EX… |
+  | --decimal-precision            INTEGER                Number of decimal      |
+  |                                                       places to display for  |
+  |                                                       decimal values. Uses   |
+  |                                                       Python's default       |
+  |                                                       precision if not       |
+  |                                                       specified. [env var:   |
+  |                                                       SNOWFLAKE_DECIMAL_PRE… |
+  +------------------------------------------------------------------------------+
+  
+  
+  '''
+# ---
 # name: test_help_messages[__app.validate]
   '''
                                                                                   
@@ -835,6 +978,7 @@
   |            requested.                                                        |
   | open       Opens a deployed Snowflake App in the browser.                    |
   | setup      Initializes a snowflake.yml file for a Snowflake App project.     |
+  | teardown   Drops a deployed Snowflake App and its associated objects.        |
   | validate   Validates a local Snowflake App project.                          |
   +------------------------------------------------------------------------------+
   
@@ -23690,6 +23834,7 @@
   |            requested.                                                        |
   | open       Opens a deployed Snowflake App in the browser.                    |
   | setup      Initializes a snowflake.yml file for a Snowflake App project.     |
+  | teardown   Drops a deployed Snowflake App and its associated objects.        |
   | validate   Validates a local Snowflake App project.                          |
   +------------------------------------------------------------------------------+
   

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -727,6 +727,22 @@ class TestSnowflakeAppManager:
         )
 
     @patch(EXECUTE_QUERY)
+    def test_drop_app_service_if_exists(self, mock_execute):
+        fqn = FQN(database="DB", schema="SCHEMA", name="MY_APP")
+        SnowflakeAppManager().drop_app_service_if_exists(fqn)
+        mock_execute.assert_called_once_with(
+            "DROP APPLICATION SERVICE IF EXISTS IDENTIFIER('DB.SCHEMA.MY_APP')"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_drop_stage_if_exists(self, mock_execute):
+        fqn = FQN(database="DB", schema="SCHEMA", name="MY_STAGE")
+        SnowflakeAppManager().drop_stage_if_exists(fqn)
+        mock_execute.assert_called_once_with(
+            "DROP STAGE IF EXISTS IDENTIFIER('DB.SCHEMA.MY_STAGE')"
+        )
+
+    @patch(EXECUTE_QUERY)
     def test_get_image_repo_url(self, mock_execute):
         cursor = Mock()
         cursor.rowcount = 1
@@ -4264,3 +4280,256 @@ class TestDeployCommand:
         assert span_map["snowflake_app.build"][CLIMetricsSpan.ERROR_KEY] == "CliError"
         assert "snowflake_app.bundle" in span_map
         assert span_map["snowflake_app.bundle"][CLIMetricsSpan.ERROR_KEY] is None
+
+
+TEARDOWN_DEFAULTS = {
+    "database": "TEST_DB",
+    "schema": "TEST_SCHEMA",
+}
+
+
+class TestTeardownCommand:
+    @staticmethod
+    def _make_entity(
+        name="MY_APP",
+        artifact_repository=None,
+        code_stage=None,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = name
+        entity.fqn = fqn
+        entity.artifact_repository = artifact_repository
+        entity.code_stage = code_stage
+        return entity
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_drops_service_stage_and_build_job(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity()
+        mock_mgr = mock_manager_cls.return_value
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown", "--force"])
+                assert result.exit_code == 0, result.output
+                assert "Successfully dropped service" in result.output
+
+        assert mock_mgr.drop_service_if_exists.call_count == 2
+        dropped_fqns = [
+            c.args[0].identifier for c in mock_mgr.drop_service_if_exists.call_args_list
+        ]
+        assert "TEST_DB.TEST_SCHEMA.MY_APP" in dropped_fqns
+        assert "TEST_DB.TEST_SCHEMA.MY_APP_BUILD_JOB" in dropped_fqns
+        mock_mgr.drop_stage_if_exists.assert_called_once()
+        mock_mgr.drop_app_service_if_exists.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_drops_app_service_and_stage_for_artifact_repo(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity(
+            artifact_repository=Mock(name="MY_REPO"),
+        )
+        mock_mgr = mock_manager_cls.return_value
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown", "--force"])
+                assert result.exit_code == 0, result.output
+                assert "Successfully dropped application service" in result.output
+
+        mock_mgr.drop_app_service_if_exists.assert_called_once()
+        mock_mgr.drop_stage_if_exists.assert_called_once()
+        mock_mgr.drop_service_if_exists.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_uses_custom_stage_name(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        code_stage = Mock()
+        code_stage.name = "CUSTOM_STAGE"
+        mock_get_entity.return_value = self._make_entity(code_stage=code_stage)
+        mock_mgr = mock_manager_cls.return_value
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown", "--force"])
+                assert result.exit_code == 0, result.output
+
+        stage_fqn = mock_mgr.drop_stage_if_exists.call_args.args[0]
+        assert stage_fqn.identifier == "TEST_DB.TEST_SCHEMA.CUSTOM_STAGE"
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_passes_entity_id(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity()
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(
+                    ["__app", "teardown", "--entity-id", "custom_app", "--force"]
+                )
+                assert result.exit_code == 0, result.output
+                mock_resolve.assert_called_once_with("custom_app")
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_cancelled_without_force(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity()
+        mock_mgr = mock_manager_cls.return_value
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown"], input="n\n")
+                assert result.exit_code == 0, result.output
+                assert "Teardown cancelled" in result.output
+
+        mock_mgr.drop_service_if_exists.assert_not_called()
+        mock_mgr.drop_app_service_if_exists.assert_not_called()
+        mock_mgr.drop_stage_if_exists.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value=TEARDOWN_DEFAULTS)
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_confirmed_without_force(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity()
+        mock_mgr = mock_manager_cls.return_value
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown"], input="y\n")
+                assert result.exit_code == 0, result.output
+                assert "Successfully dropped service" in result.output
+
+        assert mock_mgr.drop_service_if_exists.call_count == 2
+        mock_mgr.drop_stage_if_exists.assert_called_once()
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_uses_resolved_defaults_for_db_schema(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity()
+        mock_mgr = mock_manager_cls.return_value
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown", "--force"])
+                assert result.exit_code == 0, result.output
+                assert "PARAM_DB.PARAM_SCHEMA.MY_APP" in result.output
+
+        mock_defaults.assert_called_once()
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(RESOLVE_DEPLOY_DEFAULTS, return_value={})
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_errors_when_database_missing(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        mock_get_entity.return_value = self._make_entity()
+
+        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
+            with change_directory(tmp_path):
+                result = runner.invoke(["__app", "teardown", "--force"])
+                assert result.exit_code == 1
+                assert "Cannot resolve" in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- Adds a new `snow __app teardown` command that drops a deployed Snowflake App and its associated schema-level objects
- Drops the application service or SPCS service depending on deploy path (artifact-repo vs image-repo)
- Also drops the code stage and build job service (image-repo path only) created during deploy
- Resolves database/schema in the same order as deploy
- Includes `--force` flag to skip interactive confirmation