### PR TITLE
Add snowcli team as codeowner alongside native-apps on all app paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,3 @@
 /src/snowflake/cli/_plugins/apps/ @snowflakedb/native-apps
 /tests/apps/ @snowflakedb/native-apps
 /tests_integration/apps/ @snowflakedb/native-apps
-/tests/__snapshots__/ @snowflakedb/native-apps
-/tests_integration/__snapshots__/ @snowflakedb/native-apps

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 * @snowflakedb/snowcli
 
 # Apps plugin
-/src/snowflake/cli/_plugins/apps/ @snowflakedb/native-apps
-/tests/apps/ @snowflakedb/native-apps
-/tests_integration/apps/ @snowflakedb/native-apps
+/src/snowflake/cli/_plugins/apps/ @snowflakedb/snowcli @snowflakedb/native-apps
+/tests/apps/ @snowflakedb/snowcli @snowflakedb/native-apps
+/tests_integration/apps/ @snowflakedb/snowcli @snowflakedb/native-apps
+/tests/__snapshots__/ @snowflakedb/snowcli @snowflakedb/native-apps
+/tests_integration/__snapshots__/ @snowflakedb/snowcli @snowflakedb/native-apps


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [N/A] I've added or updated automated unit tests to verify correctness of my new code.
   * [N/A] I've added or updated integration tests to verify correctness of my new code.
   * [N/A] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [N/A] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [N/A] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [N/A] I've described my changes in the documentation.

### Changes description
Adds `@snowflakedb/snowcli` as a codeowner alongside `@snowflakedb/native-apps` on all app plugin paths in CODEOWNERS. This way either team can approve changes to these paths, rather than PRs being blocked waiting solely on native-apps review.

Previously, the last-match-wins behavior in CODEOWNERS meant that files like `tests/__snapshots__/test_help_messages.ambr` required native-apps review even for unrelated changes (e.g. #2868).

**Note:** CODEOWNERS has no "master codeowner" concept — it uses last-match-wins with no inheritance, so the `* @snowflakedb/snowcli` catch-all is overridden by any more specific rule below it. The only way to ensure `@snowflakedb/snowcli` can always approve is to explicitly list them on every rule.