### PR TITLE
Snowflake Apps: Make compute pools, EAIs, and build warehouse optional

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -200,18 +200,6 @@ def setup(
         raise ClickException(
             "Missing warehouse. Set the DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE account parameter or check your connection."
         )
-    if not resolved["build_compute_pool"][0]:
-        raise ClickException(
-            "Missing build compute pool. Pass --compute-pool or set the DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL account parameter."
-        )
-    if not resolved["service_compute_pool"][0]:
-        raise ClickException(
-            "Missing service compute pool. Pass --compute-pool or set the DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL account parameter."
-        )
-    if not resolved["build_eai"][0]:
-        raise ClickException(
-            "Missing build EAI. Pass --build-eai or set the DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION account parameter."
-        )
 
     resolved_values = {k: v[0] for k, v in resolved.items()}
 
@@ -538,19 +526,6 @@ def deploy(
     ar_schema = defaults["artifact_repo_schema"]
     artifact_repo_fqn_str = f"{ar_database}.{ar_schema}.{ar_name}"
 
-    # ── Validate required configuration ───────────────────────────────
-    if run_build and not build_compute_pool:
-        raise CliError(
-            "build_compute_pool is required for the build phase. "
-            "Please configure it in snowflake.yml."
-        )
-
-    if run_deploy and not service_compute_pool:
-        raise CliError(
-            "service_compute_pool is required for the deploy phase. "
-            "Please configure it in snowflake.yml."
-        )
-
     # ── Derived names ─────────────────────────────────────────────────
     stage_fqn = FQN(database=database, schema=schema, name=stage_name)
     service_fqn = FQN(database=database, schema=schema, name=app_name)
@@ -605,7 +580,6 @@ def deploy(
             database=database,
             schema=schema,
             runtime_image=entity.runtime_image,
-            query_warehouse=query_warehouse,
             build_eai=build_eai,
         )
         cli_console.step(f"SPCS_TEST_BUILD_APP_ARTIFACT_REPO output:\n{build_result}")

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -554,13 +554,10 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
     @staticmethod
     def _build_artifact_repo_config(
-        query_warehouse: Optional[str] = None,
         build_eai: Optional[str] = None,
     ) -> str:
         """Build the JSON config blob accepted by the artifact-repo system functions."""
         cfg: Dict[str, Any] = {}
-        if query_warehouse:
-            cfg["query_warehouse"] = query_warehouse
         if build_eai:
             cfg["external_access_integrations"] = [build_eai]
         return json.dumps(cfg)
@@ -597,11 +594,10 @@ class SnowflakeAppManager(SqlExecutionMixin):
         stage_fqn: FQN,
         artifact_repo_fqn: str,
         app_id: str,
-        compute_pool: str,
+        compute_pool: Optional[str],
         database: str,
         schema: str,
         runtime_image: str = "",
-        query_warehouse: Optional[str] = None,
         build_eai: Optional[str] = None,
         project_type: str = "nodejs",
     ) -> str:
@@ -609,13 +605,13 @@ class SnowflakeAppManager(SqlExecutionMixin):
         from snowflake.cli.api.project.util import to_string_literal
 
         with self._use_database_and_schema(database, schema):
-            config = self._build_artifact_repo_config(query_warehouse, build_eai)
+            config = self._build_artifact_repo_config(build_eai)
             query = (
                 f"SELECT SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO("
                 f"'@{stage_fqn.identifier}', "
                 f"{to_string_literal(artifact_repo_fqn)}, "
                 f"{to_string_literal(app_id)}, "
-                f"{to_string_literal(compute_pool)}, "
+                f"{to_string_literal(compute_pool or '')}, "
                 f"{to_string_literal(runtime_image)}, "
                 f"{to_string_literal(project_type)}, "
                 f"{to_string_literal(config)}"
@@ -630,7 +626,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         service_fqn: FQN,
         artifact_repo_fqn: str,
         package_name: str,
-        compute_pool: str,
+        compute_pool: Optional[str] = None,
         version: Optional[str] = None,
         query_warehouse: Optional[str] = None,
         external_access_integrations: Optional[list[str]] = None,
@@ -643,7 +639,8 @@ class SnowflakeAppManager(SqlExecutionMixin):
         ]
         if version:
             parts.append(f"VERSION {version}")
-        parts.append(f"IN COMPUTE POOL {compute_pool}")
+        if compute_pool:
+            parts.append(f"IN COMPUTE POOL {compute_pool}")
         if external_access_integrations:
             eai_list = ", ".join(external_access_integrations)
             parts.append(f"EXTERNAL_ACCESS_INTEGRATIONS = ({eai_list})")

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1183,45 +1183,6 @@ class TestSetupCommand:
                 assert "already exists" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_fails_on_missing_compute_pool(self, mock_mgr_cls, runner, tmp_path):
-        """Setup should fail when compute pool cannot be resolved."""
-        mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.fetch_snow_apps_parameters.return_value = {
-            "database": "PARAM_DB",
-            "schema": "PARAM_SCHEMA",
-            "query_warehouse": "PARAM_WH",
-            "build_eai": "PARAM_EAI",
-        }
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            from tests_common import change_directory
-
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "setup", "--app-name", "my_app"])
-                assert result.exit_code == 1
-                assert "--compute-pool" in result.output
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_fails_on_missing_build_eai(self, mock_mgr_cls, runner, tmp_path):
-        """Setup should fail when build EAI cannot be resolved."""
-        mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.fetch_snow_apps_parameters.return_value = {
-            "database": "PARAM_DB",
-            "schema": "PARAM_SCHEMA",
-            "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_POOL",
-        }
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-            from tests_common import change_directory
-
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "setup", "--app-name", "my_app"])
-                assert result.exit_code == 1
-                assert "--build-eai" in result.output
-
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_dry_run_does_not_create_file(self, mock_mgr_cls, runner, tmp_path):
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
@@ -2454,45 +2415,6 @@ RESOLVE_DEPLOY_DEFAULTS = (
 
 
 class TestDeployCommand:
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": None,
-            "service_compute_pool": "SVC_POOL",
-            "build_eai": None,
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "artifact_repository": "MY_APP_REPO",
-            "artifact_repo_database": "TEST_DB",
-            "artifact_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._get_entity",
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_deploy_fails_missing_build_compute_pool(
-        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
-    ):
-        entity = Mock()
-        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
-        entity.code_stage = None
-        entity.artifacts = []
-        entity.meta = None
-        entity.artifact_repository = None
-        mock_get_entity.return_value = entity
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy"])
-                assert result.exit_code == 1
-                assert "build_compute_pool is required" in result.output
-
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     @patch(
@@ -2550,86 +2472,6 @@ class TestDeployCommand:
                 mock_mgr.build_app_artifact_repo.assert_not_called()
                 mock_mgr.artifact_repo_exists.assert_not_called()
                 mock_mgr.create_app_service.assert_called_once()
-
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": None,
-            "service_compute_pool": None,
-            "build_eai": None,
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "artifact_repository": "MY_APP_REPO",
-            "artifact_repo_database": "TEST_DB",
-            "artifact_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._get_entity",
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_deploy_only_allows_missing_build_compute_pool(
-        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
-    ):
-        """--deploy-only should not require build_compute_pool."""
-        entity = Mock()
-        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
-        entity.code_stage = None
-        entity.artifacts = []
-        entity.meta = None
-        entity.artifact_repository = None
-        mock_get_entity.return_value = entity
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy", "--deploy-only"])
-                assert result.exit_code == 1
-                assert "build_compute_pool is required" not in result.output
-                assert "service_compute_pool is required" in result.output
-
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": "BUILD_POOL",
-            "service_compute_pool": None,
-            "build_eai": None,
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "artifact_repository": "MY_APP_REPO",
-            "artifact_repo_database": "TEST_DB",
-            "artifact_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._get_entity",
-    )
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_deploy_fails_missing_service_compute_pool(
-        self, mock_resolve, mock_get_entity, mock_defaults, runner, tmp_path
-    ):
-        entity = Mock()
-        entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
-        entity.code_stage = None
-        entity.artifacts = []
-        entity.meta = None
-        entity.artifact_repository = None
-        mock_get_entity.return_value = entity
-
-        with with_feature_flags({FeatureFlag.ENABLE_SNOWFLAKE_APPS: True}):
-
-            with change_directory(tmp_path):
-                result = runner.invoke(["__app", "deploy"])
-                assert result.exit_code == 1
-                assert "service_compute_pool is required" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
@@ -2725,7 +2567,6 @@ class TestDeployCommand:
             database="TEST_DB",
             schema="TEST_SCHEMA",
             runtime_image="runtime:latest",
-            query_warehouse="WH",
             build_eai="MY_EAI",
         )
         mock_mgr.create_app_service.assert_called_once_with(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Compute pools and EAIs are no longer required for the build or app service phases — the server will use defaults when they are not provided.

The `query_warehouse` parameter is also removed from the build system command `SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`.
