### PR TITLE
Snowflake Apps: make build_eai optional and allow code_stage FQN identifier

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,8 @@
 * Added `snow custom-image validate` command to validate custom Docker images against configured rules (entrypoint, environment variables, Python packages, dependency health). Supports an optional `--scan-vulnerabilities` flag to run Grype vulnerability scanning.
 
 ## Fixes and improvements
+* `snow app setup` / `snow app deploy` (Snowflake Apps Deploy flow): `--build-eai` is now fully optional. When no value is provided and no account parameter is set, the generated `snowflake.yml` omits the `build_eai` block, `--dry-run` no longer prints a `build_eai: None (missing)` line, and the deploy pipeline runs the artifact-repo build without an external access integration.
+* `code_stage` in `snowflake.yml` (Snowflake Apps Deploy flow) now accepts a fully-qualified identifier (`DB.SCHEMA.STAGE`) in addition to the existing dict form. A bare string (`code_stage: MY_STAGE`) is still accepted for backwards compatibility and resolves to the app's database/schema at deploy time. Generated `snowflake.yml` files now emit the identifier form.
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.
 * Updated `snowflake-connector-python` to version 4.4.0. Connector python 4.x series introduced stricter permission checks. In future versions of Snowflake CLI strict configuration file permissions will become mandatory. To test if your files have correct permissions set SNOWFLAKE_CLI_FEATURES_ENFORCE_STRICT_CONFIG_PERMISSIONS=1 before running CLI commands.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,8 +27,6 @@
 * Added `snow dcm purge` command to drop all the objects managed by the specified DCM Project
 
 ## Fixes and improvements
-* `snow app setup` / `snow app deploy` (Snowflake Apps Deploy flow): `--build-eai` is now fully optional. When no value is provided and no account parameter is set, the generated `snowflake.yml` omits the `build_eai` block, `--dry-run` no longer prints a `build_eai: None (missing)` line, and the deploy pipeline runs the artifact-repo build without an external access integration.
-* `code_stage` in `snowflake.yml` (Snowflake Apps Deploy flow) now accepts a fully-qualified identifier (`DB.SCHEMA.STAGE`) in addition to the existing dict form. A bare string (`code_stage: MY_STAGE`) is still accepted for backwards compatibility and resolves to the app's database/schema at deploy time. Generated `snowflake.yml` files now emit the identifier form.
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.
 * Updated `snowflake-connector-python` to version 4.4.0. Connector python 4.x series introduced stricter permission checks. In future versions of Snowflake CLI strict configuration file permissions will become mandatory. To test if your files have correct permissions set SNOWFLAKE_CLI_FEATURES_ENFORCE_STRICT_CONFIG_PERMISSIONS=1 before running CLI commands.
 

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -207,6 +207,12 @@ def snowflake_app_setup(
             f"Initialized Snowflake Apps Deploy project in {DEFINITION_FILENAME}."
         )
     for key, (value, source) in resolved.items():
+        # Skip optional fields that could not be resolved (e.g. ``build_eai``
+        # when no value was provided and no account parameter is set).
+        # Emitting ``build_eai: None  (missing)`` is noisy and implies the
+        # field is required when it is not.
+        if value is None and source == SOURCE_MISSING:
+            continue
         cli_console.step(f"  {key}: {value}  ({source})")
     return EmptyResult()
 
@@ -395,9 +401,13 @@ def snowflake_app_deploy(
 
     if entity.code_stage:
         stage_name = entity.code_stage.name
+        stage_database = entity.code_stage.database
+        stage_schema = entity.code_stage.schema_
         encryption_type = entity.code_stage.encryption_type or "SNOWFLAKE_SSE"
     else:
         stage_name = f"{app_name}_CODE_STAGE"
+        stage_database = None
+        stage_schema = None
         encryption_type = "SNOWFLAKE_SSE"
 
     build_compute_pool = (
@@ -430,7 +440,15 @@ def snowflake_app_deploy(
     artifact_repo_fqn_str = f"{ar_database}.{ar_schema}.{ar_name}"
 
     # ── Derived names ─────────────────────────────────────────────────
-    stage_fqn = FQN(database=database, schema=schema, name=stage_name)
+    # If the code_stage was defined as a fully-qualified identifier
+    # (e.g. ``DB.SCHEMA.STAGE``) use its components; otherwise fall back
+    # to the app's resolved database/schema for backwards-compatibility
+    # with existing apps that configure ``code_stage`` as a bare name.
+    stage_fqn = FQN(
+        database=stage_database or database,
+        schema=stage_schema or schema,
+        name=stage_name,
+    )
     service_fqn = FQN(database=database, schema=schema, name=app_name)
 
     stage_manager = StageManager()
@@ -618,10 +636,15 @@ def snowflake_app_teardown(
     service_fqn = FQN(database=db, schema=schema, name=app_name)
     use_artifact_repo = entity.artifact_repository is not None
 
-    stage_name = (
-        entity.code_stage.name if entity.code_stage else f"{app_name}_CODE_STAGE"
-    )
-    stage_fqn = FQN(database=db, schema=schema, name=stage_name)
+    if entity.code_stage:
+        stage_name = entity.code_stage.name
+        stage_database = entity.code_stage.database or db
+        stage_schema = entity.code_stage.schema_ or schema
+    else:
+        stage_name = f"{app_name}_CODE_STAGE"
+        stage_database = db
+        stage_schema = schema
+    stage_fqn = FQN(database=stage_database, schema=stage_schema, name=stage_name)
     build_job_fqn = FQN(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
 
     object_kind = "application service" if use_artifact_repo else "service"

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -14,7 +14,7 @@
 
 import logging
 from textwrap import dedent
-from typing import Dict
+from typing import Dict, Optional
 
 log = logging.getLogger(__name__)
 
@@ -24,15 +24,19 @@ IS_PERSONAL_DB_SUPPORTED = False  # Will be enabled in the future
 
 def _generate_snowflake_yml(
     app_id: str,
-    resolved: Dict[str, str],
+    resolved: Dict[str, Optional[str]],
 ) -> str:
     """Generate snowflake.yml content from pre-resolved configuration values.
 
-    All required keys (``database``, ``schema``, ``warehouse``,
-    ``build_compute_pool``, ``service_compute_pool``, ``build_eai``) must
-    be present and non-empty in *resolved*.  The artifact repository is
-    omitted from the generated YAML; the CLI will default to
-    ``<app-id>_REPO`` at deploy time.
+    Required keys: ``database``, ``schema``, ``warehouse``,
+    ``build_compute_pool``, ``service_compute_pool``.
+
+    Optional keys: ``build_eai``.  When not provided (``None``) the
+    ``build_eai`` block is omitted from the generated YAML — the builder
+    service will run without an external access integration.
+
+    The artifact repository is omitted from the generated YAML; the CLI
+    will default to ``<app-id>_REPO`` at deploy time.
     """
 
     if resolved.get("image_repository"):
@@ -47,11 +51,21 @@ def _generate_snowflake_yml(
     warehouse = resolved["warehouse"]
     build_compute_pool = resolved["build_compute_pool"]
     service_compute_pool = resolved["service_compute_pool"]
-    build_eai = resolved["build_eai"]
+    build_eai = resolved.get("build_eai")
 
-    code_stage = f"{app_id.upper()}_CODE"
+    # code_stage is emitted as an identifier (``DB.SCHEMA.STAGE``) so it is
+    # self-contained and does not implicitly depend on the app's database
+    # and schema at deploy time.
+    code_stage_name = f"{app_id.upper()}_CODE"
+    code_stage_identifier = f"{database}.{schema}.{code_stage_name}"
 
-    return dedent(
+    build_eai_block = (
+        f"\n            build_eai:\n              name: {build_eai}"
+        if build_eai
+        else ""
+    )
+
+    raw = (
         f"""\
         definition_version: "2"
 
@@ -80,10 +94,8 @@ def _generate_snowflake_yml(
             build_compute_pool:
               name: {build_compute_pool}
             service_compute_pool:
-              name: {service_compute_pool}
-            build_eai:
-              name: {build_eai}
-            code_stage:
-              name: {code_stage}
-        """
+              name: {service_compute_pool}"""
+        + build_eai_block
+        + f"\n            code_stage: {code_stage_identifier}\n"
     )
+    return dedent(raw)

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -84,9 +84,20 @@ class ImageRepositoryReference(UpdatableModel):
 
 
 class CodeStageReference(UpdatableModel):
-    """Reference to a code stage."""
+    """Reference to a code stage.
+
+    Supports both a fully-qualified identifier form (``DB.SCHEMA.STAGE``)
+    and a bare-name form (``STAGE``).  When only a name is provided the
+    app's database and schema are used implicitly at deploy time.
+    """
 
     name: str = IdentifierField(title="Name of the code stage")
+    schema_: Optional[str] = IdentifierField(
+        title="Schema of the code stage", alias="schema", default=None
+    )
+    database: Optional[str] = IdentifierField(
+        title="Database of the code stage", default=None
+    )
     encryption_type: Optional[str] = Field(
         title="Encryption type for the stage", default="SNOWFLAKE_SSE"
     )
@@ -160,6 +171,31 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
     code_stage: Optional[CodeStageReference] = Field(
         title="Stage for storing code artifacts", default=None
     )
+
+    @field_validator("code_stage", mode="before")
+    @classmethod
+    def _validate_code_stage(cls, value):
+        """Accept either a dict, a plain stage name, or a ``DB.SCHEMA.STAGE`` identifier.
+
+        When a string is provided it is parsed as an FQN.  Any missing
+        database/schema components are left as ``None`` and resolved to the
+        app's database/schema at deploy time — this preserves
+        backwards-compatibility with existing apps that configure
+        ``code_stage`` as a bare name.
+        """
+        if value is None or value == "null":
+            return None
+        if isinstance(value, str):
+            from snowflake.cli.api.identifiers import FQN
+
+            fqn = FQN.from_string(value)
+            parsed: dict = {"name": fqn.name}
+            if fqn.database:
+                parsed["database"] = fqn.database
+            if fqn.schema:
+                parsed["schema"] = fqn.schema
+            return parsed
+        return value
 
     app_port: int = Field(title="Port the app listens on", default=DEFAULT_APP_PORT)
 

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -328,13 +328,29 @@ class TestGenerateSnowflakeYml:
         assert "query_warehouse: TEST_WH" in result
         assert "name: MY_POOL" in result
         assert "name: MY_EAI" in result
-        assert "name: MY_APP_CODE" in result
+        # code_stage is written as a fully-qualified identifier.
+        assert "code_stage: TEST_DB.SNOW_APPS.MY_APP_CODE" in result
         assert "image_repository" not in result
         assert "artifact_repository" not in result
 
     def test_no_null_values_in_output(self):
         result = _generate_snowflake_yml("my_app", self._BASE_RESOLVED)
         assert "null" not in result
+
+    def test_build_eai_omitted_when_missing(self):
+        """When ``build_eai`` is missing, the generated YAML has no
+        ``build_eai`` block — the field is optional."""
+        resolved = {**self._BASE_RESOLVED, "build_eai": None}
+        result = _generate_snowflake_yml("my_app", resolved)
+        assert "build_eai" not in result
+        assert "None" not in result
+
+    def test_build_eai_omitted_when_missing_key(self):
+        """When ``build_eai`` is not in the resolved dict at all, the
+        generated YAML still works and omits the block."""
+        resolved = {k: v for k, v in self._BASE_RESOLVED.items() if k != "build_eai"}
+        result = _generate_snowflake_yml("my_app", resolved)
+        assert "build_eai" not in result
 
     def test_custom_schema(self):
         resolved = {**self._BASE_RESOLVED, "schema": "CFG_SCHEMA"}
@@ -357,7 +373,11 @@ class TestGenerateSnowflakeYml:
 
         assert entity.type == "snowflake-app"
         assert entity.query_warehouse == "TEST_WH"
+        # code_stage is emitted as ``DB.SCHEMA.STAGE`` and the validator
+        # parses it back into a ``CodeStageReference`` with db/schema set.
         assert entity.code_stage.name == "MY_APP_CODE"
+        assert entity.code_stage.database == "TEST_DB"
+        assert entity.code_stage.schema_ == "SNOW_APPS"
         assert entity.artifacts is not None
 
 
@@ -1204,6 +1224,31 @@ class TestSetupCommand:
             assert not (tmp_path / "snowflake.yml").exists()
             assert "PARAM_DB" in result.output
             assert "PARAM_WH" in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_dry_run_omits_missing_build_eai(self, mock_mgr_cls, runner, tmp_path):
+        """``--build-eai`` is optional: when no value is resolved the dry-run
+        output should not emit the ``build_eai`` line (which would otherwise
+        display ``build_eai: None  (missing)`` and imply it is required)."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            # no build_eai
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                ["app", "setup", "--app-name", "my_app", "--dry-run"]
+            )
+            assert result.exit_code == 0, result.output
+            assert "build_eai" not in result.output
+            assert "missing" not in result.output
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_dry_run_json_output(self, mock_mgr_cls, runner, tmp_path):

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -164,6 +164,60 @@ class TestSnowflakeAppEntityModel:
         )
         assert model.code_stage.encryption_type == "SNOWFLAKE_SSE"
 
+    def test_code_stage_as_bare_name_string(self):
+        """``code_stage: MY_STAGE`` (bare string) is accepted for
+        backwards-compatibility — db/schema are resolved to the app's
+        db/schema at deploy time."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            code_stage="MY_STAGE",
+        )
+        assert model.code_stage.name == "MY_STAGE"
+        assert model.code_stage.database is None
+        assert model.code_stage.schema_ is None
+
+    def test_code_stage_as_fully_qualified_identifier(self):
+        """``code_stage: DB.SCHEMA.STAGE`` is parsed into its components."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            code_stage="MY_DB.MY_SCHEMA.MY_STAGE",
+        )
+        assert model.code_stage.name == "MY_STAGE"
+        assert model.code_stage.schema_ == "MY_SCHEMA"
+        assert model.code_stage.database == "MY_DB"
+
+    def test_code_stage_as_schema_qualified_identifier(self):
+        """``code_stage: SCHEMA.STAGE`` fills schema_ only."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            code_stage="MY_SCHEMA.MY_STAGE",
+        )
+        assert model.code_stage.name == "MY_STAGE"
+        assert model.code_stage.schema_ == "MY_SCHEMA"
+        assert model.code_stage.database is None
+
+    def test_code_stage_dict_with_db_and_schema(self):
+        """Dict form with explicit database/schema is supported."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            code_stage={
+                "name": "MY_STAGE",
+                "database": "MY_DB",
+                "schema": "MY_SCHEMA",
+            },
+        )
+        assert model.code_stage.name == "MY_STAGE"
+        assert model.code_stage.database == "MY_DB"
+        assert model.code_stage.schema_ == "MY_SCHEMA"
+
     def test_meta_field_defaults(self):
         """Meta field sub-fields default to None."""
         model = SnowflakeAppEntityModel(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Three small fixes to the `snow app` (Snowflake Apps Deploy) flow stacked on top of the unified `snow app` branch.

1. **`--build-eai` is fully optional for `snow app setup` / `snow app deploy`.** When no value is resolved (no `--build-eai` flag, no `DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION` account parameter), the generated `snowflake.yml` omits the `build_eai` block entirely instead of writing `name: None`. The deploy pipeline already handled `None` correctly downstream; this fixes the yml-generation side so the validator does not reject the generated file.
2. **`snow app setup --dry-run` no longer emits `build_eai` when it is missing.** Previously the dry-run output contained a noisy `build_eai: None  (missing)` line that implied the field was required.
3. **`code_stage` accepts a fully-qualified identifier (`DB.SCHEMA.STAGE`).** The canonical form is now an identifier; existing apps using a bare string (`code_stage: MY_STAGE`) continue to work and implicitly use the app's database/schema at deploy time. The existing dict form (`code_stage: { name: ..., encryption_type: ... }`) is also preserved. `snow app setup` now emits the identifier form in generated `snowflake.yml` files.