### PR TITLE
Fix SNOWFLAKE_HOST/PORT env overrides on temporary connections

### DIFF
--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -62,6 +62,8 @@ SUPPORTED_ENV_OVERRIDES = [
     "account",
     "user",
     "password",
+    "host",
+    "port",
     "authenticator",
     "workload_identity_provider",
     "private_key_file",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -802,6 +802,42 @@ def test_session_and_master_tokens(mock_connector, mock_ctx, runner):
     )
 
 
+@mock.patch.dict(
+    os.environ,
+    {
+        "SNOWFLAKE_HOST": "env-host.snowflakecomputing.com",
+        "SNOWFLAKE_PORT": "4242",
+    },
+    clear=True,
+)
+@mock.patch("snowflake.connector.connect")
+def test_host_and_port_are_read_from_env_for_temporary_connection(
+    mock_connector, mock_ctx, runner
+):
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    result = runner.invoke(
+        [
+            "object",
+            "list",
+            "warehouse",
+            "--temporary-connection",
+            "--account",
+            "test_account",
+            "--user",
+            "snowcli_test",
+            "--password",
+            "top_secret",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_connector.call_args.kwargs
+    assert kwargs["host"] == "env-host.snowflakecomputing.com"
+    assert kwargs["port"] == "4242"
+
+
 @mock.patch("snowflake.connector.connect")
 def test_token_file_path_tokens(mock_connector, mock_ctx, runner, temporary_directory):
     ctx = mock_ctx()


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

The `SUPPORTED_ENV_OVERRIDES` list in `snow_connector.py` — the allowlist of connection parameters that can be supplied via `SNOWFLAKE_*` environment variables — was missing `host` and `port`. As a result, when a caller opened a temporary connection without passing `--host` / `--port` on the CLI, the `SNOWFLAKE_HOST` / `SNOWFLAKE_PORT` env vars were silently dropped during the env-override pass (`connect_to_snowflake`, lines ~189–195), and the connector fell back to `<account>.snowflakecomputing.com`.

This was breaking the daily `RT-Snowflake-CLI-preprod` Jenkins run (build #338): `tests_integration/test_session_token.py::test_use_session_token` passes `-x --account --session-token --master-token` expecting the preprod host to come from env, but the host was being dropped and the resulting request hit prod and 404'd on `/session/heartbeat`.

**Fix:** added `"host"` and `"port"` to `SUPPORTED_ENV_OVERRIDES` right after `"password"`, matching the behavior of `SNOWFLAKE_ACCOUNT` and other supported env vars.

**Tests:** added `test_host_and_port_are_read_from_env_for_temporary_connection` in `tests/test_connection.py` as a regression guard — sets `SNOWFLAKE_HOST` / `SNOWFLAKE_PORT`, invokes a `--temporary-connection` command, asserts they reach the connector. Full local unit-test suite (7142 tests) passes.