### PR TITLE
Tag native app version SQL with query_tag for observability

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,7 @@
 ## Fixes and improvements
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.
 * Updated `snowflake-connector-python` to version 4.4.0. Connector python 4.x series introduced stricter permission checks. In future versions of Snowflake CLI strict configuration file permissions will become mandatory. To test if your files have correct permissions set SNOWFLAKE_CLI_FEATURES_ENFORCE_STRICT_CONFIG_PERMISSIONS=1 before running CLI commands.
+* Native App version operations (`snow app version create` and its `add patch` path) now set a session `query_tag` around the underlying `ALTER APPLICATION PACKAGE` call. These statements run setup scripts server-side and are expected to be slower than regular `ALTER APPLICATION PACKAGE` operations; the tag makes them easy to identify in query history and observability tools. No behavior change.
 
 # v3.16.0
 

--- a/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
+++ b/src/snowflake/cli/_plugins/nativeapp/sf_sql_facade.py
@@ -341,7 +341,10 @@ class SnowflakeSQLFacade:
 
         with self._use_role_optional(role):
             try:
-                self._sql_executor.execute_query(query)
+                with self._sql_executor.query_tag(
+                    "snowflake-cli:nativeapp:version_create"
+                ):
+                    self._sql_executor.execute_query(query)
             except Exception as err:
                 if isinstance(err, ProgrammingError):
                     if err.errno == MAX_UNBOUND_VERSIONS_REACHED:
@@ -444,9 +447,12 @@ class SnowflakeSQLFacade:
         )
         with self._use_role_optional(role):
             try:
-                result_cursor = self._sql_executor.execute_query(
-                    add_patch_query, cursor_class=DictCursor
-                ).fetchall()
+                with self._sql_executor.query_tag(
+                    "snowflake-cli:nativeapp:version_add_patch"
+                ):
+                    result_cursor = self._sql_executor.execute_query(
+                        add_patch_query, cursor_class=DictCursor
+                    ).fetchall()
             except Exception as err:
                 if isinstance(err, ProgrammingError):
                     if err.errno == APPLICATION_PACKAGE_PATCH_ALREADY_EXISTS:

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -35,6 +35,7 @@ from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.util import (
     identifier_to_show_like_pattern,
     to_identifier,
+    to_string_literal,
     unquote_identifier,
 )
 from snowflake.cli.api.utils.cursor import find_first_row
@@ -105,6 +106,23 @@ class BaseSqlExecutor:
 
         # Without remove_comments=True, connectors might throw an error if there is a comment at the end of the file
         return list(self.execute_string(queries, remove_comments=True, **kwargs))
+
+    @contextmanager
+    def query_tag(self, tag: str):
+        """Sets a session query_tag for the duration of the context, then unsets it.
+
+        Useful for marking queries that are expected to be slow (e.g. because they
+        trigger server-side setup-script execution) so downstream observability
+        tooling can identify them without relying on account-specific filters.
+        """
+        self.execute_query(f"alter session set query_tag = {to_string_literal(tag)}")
+        try:
+            yield
+        finally:
+            try:
+                self.execute_query("alter session unset query_tag")
+            except Exception:  # noqa: BLE001
+                self._log.debug("Failed to unset query_tag", exc_info=True)
 
 
 class SqlExecutor(BaseSqlExecutor):

--- a/tests/nativeapp/test_sf_sql_facade.py
+++ b/tests/nativeapp/test_sf_sql_facade.py
@@ -4082,6 +4082,12 @@ def test_create_version_in_package(
         (
             mock_execute_query,
             mock.call(
+                "alter session set query_tag = 'snowflake-cli:nativeapp:version_create'"
+            ),
+        ),
+        (
+            mock_execute_query,
+            mock.call(
                 dedent(
                     f"""\
                         alter application package {package_name}
@@ -4090,6 +4096,10 @@ def test_create_version_in_package(
                     """
                 )
             ),
+        ),
+        (
+            mock_execute_query,
+            mock.call("alter session unset query_tag"),
         ),
     ]
 
@@ -4121,6 +4131,12 @@ def test_create_version_in_package_with_label(
         (
             mock_execute_query,
             mock.call(
+                "alter session set query_tag = 'snowflake-cli:nativeapp:version_create'"
+            ),
+        ),
+        (
+            mock_execute_query,
+            mock.call(
                 dedent(
                     f"""\
                         alter application package {package_name}
@@ -4130,6 +4146,10 @@ def test_create_version_in_package_with_label(
                     """
                 )
             ),
+        ),
+        (
+            mock_execute_query,
+            mock.call("alter session unset query_tag"),
         ),
     ]
 
@@ -4161,6 +4181,12 @@ def test_create_version_with_special_characters(
         (
             mock_execute_query,
             mock.call(
+                "alter session set query_tag = 'snowflake-cli:nativeapp:version_create'"
+            ),
+        ),
+        (
+            mock_execute_query,
+            mock.call(
                 dedent(
                     f"""\
                         alter application package "{package_name}"
@@ -4169,6 +4195,10 @@ def test_create_version_with_special_characters(
                     """
                 )
             ),
+        ),
+        (
+            mock_execute_query,
+            mock.call("alter session unset query_tag"),
         ),
     ]
 
@@ -4232,7 +4262,8 @@ def test_create_version_in_package_with_error(
     action_placeholder = "register" if release_channels_enabled else "add"
     error_message = error_message.replace("ACTION_PLACEHOLDER", action_placeholder)
 
-    mock_execute_query.side_effect = error_raised
+    # query_tag set succeeds, the ALTER PACKAGE call raises, query_tag unset succeeds
+    mock_execute_query.side_effect = [None, error_raised, None]
 
     with mock_release_channels(sql_facade, release_channels_enabled):
         with pytest.raises(error_caught) as err:
@@ -4372,7 +4403,7 @@ def test_add_patch_to_package_version_valid_input_then_success(
         """
     )
 
-    mock_execute_query.side_effect = [mock_cursor([{"patch": 1}], [])]
+    mock_execute_query.side_effect = [None, mock_cursor([{"patch": 1}], []), None]
     result = sql_facade.add_patch_to_package_version(
         package_name=package_name,
         path_to_version_directory=stage_fqn,
@@ -4381,7 +4412,15 @@ def test_add_patch_to_package_version_valid_input_then_success(
     )
 
     assert result == patch
-    mock_execute_query.assert_called_once_with(expected_query, cursor_class=DictCursor)
+    mock_execute_query.assert_has_calls(
+        [
+            mock.call(
+                "alter session set query_tag = 'snowflake-cli:nativeapp:version_add_patch'"
+            ),
+            mock.call(expected_query, cursor_class=DictCursor),
+            mock.call("alter session unset query_tag"),
+        ]
+    )
 
 
 # patch 0 shouldn't be treated in a special way (rely on backend saying 0 already exists)
@@ -4401,7 +4440,7 @@ def test_add_patch_to_package_version_valid_input_then_success_patch_0(
         """
     )
 
-    mock_execute_query.side_effect = [mock_cursor([{"patch": 0}], [])]
+    mock_execute_query.side_effect = [None, mock_cursor([{"patch": 0}], []), None]
     result = sql_facade.add_patch_to_package_version(
         package_name=package_name,
         path_to_version_directory=stage_fqn,
@@ -4410,7 +4449,15 @@ def test_add_patch_to_package_version_valid_input_then_success_patch_0(
     )
 
     assert result == patch
-    mock_execute_query.assert_called_once_with(expected_query, cursor_class=DictCursor)
+    mock_execute_query.assert_has_calls(
+        [
+            mock.call(
+                "alter session set query_tag = 'snowflake-cli:nativeapp:version_add_patch'"
+            ),
+            mock.call(expected_query, cursor_class=DictCursor),
+            mock.call("alter session unset query_tag"),
+        ]
+    )
 
 
 def test_add_patch_to_package_version_valid_input_then_success_no_patch_in_input(
@@ -4428,7 +4475,7 @@ def test_add_patch_to_package_version_valid_input_then_success_no_patch_in_input
         """
     )
 
-    mock_execute_query.side_effect = [mock_cursor([{"patch": 5}], [])]
+    mock_execute_query.side_effect = [None, mock_cursor([{"patch": 5}], []), None]
     result = sql_facade.add_patch_to_package_version(
         package_name=package_name,
         path_to_version_directory=stage_fqn,
@@ -4437,7 +4484,15 @@ def test_add_patch_to_package_version_valid_input_then_success_no_patch_in_input
     )
 
     assert result == 5
-    mock_execute_query.assert_called_once_with(expected_query, cursor_class=DictCursor)
+    mock_execute_query.assert_has_calls(
+        [
+            mock.call(
+                "alter session set query_tag = 'snowflake-cli:nativeapp:version_add_patch'"
+            ),
+            mock.call(expected_query, cursor_class=DictCursor),
+            mock.call("alter session unset query_tag"),
+        ]
+    )
 
 
 @pytest.mark.parametrize(
@@ -4473,7 +4528,8 @@ def test_add_patch_to_package_version_with_error(
     patch = 1
     stage_fqn = "src.stage"
 
-    mock_execute_query.side_effect = error_raised
+    # query_tag set succeeds, the ALTER PACKAGE call raises, query_tag unset succeeds
+    mock_execute_query.side_effect = [None, error_raised, None]
 
     with pytest.raises(error_caught) as err:
         sql_facade.add_patch_to_package_version(
@@ -4495,9 +4551,11 @@ def test_add_patch_to_package_with_patch_already_exist_error_and_null_patch(
     patch = None
     stage_fqn = "src.stage"
 
-    mock_execute_query.side_effect = ProgrammingError(
-        errno=APPLICATION_PACKAGE_PATCH_ALREADY_EXISTS
-    )
+    mock_execute_query.side_effect = [
+        None,
+        ProgrammingError(errno=APPLICATION_PACKAGE_PATCH_ALREADY_EXISTS),
+        None,
+    ]
 
     with pytest.raises(UserInputError) as err:
         sql_facade.add_patch_to_package_version(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

`ALTER APPLICATION PACKAGE ... {register|add} VERSION` and `ADD PATCH` statements run setup scripts server-side, so they have materially higher latency than other `ALTER APPLICATION PACKAGE` operations. Issuing them untagged makes it hard for query-history and observability tooling to tell "known-slow version operation" apart from "something wrong with `ALTER APPLICATION PACKAGE`".

This PR sets a session `query_tag` around those two calls so they are easy to identify in query history without relying on account-specific filters.

#### Core changes

- **New `BaseSqlExecutor.query_tag(tag)` context manager** in `src/snowflake/cli/api/sql_execution.py` — sets `query_tag` on enter, unsets on exit. The unset in `finally` swallows-and-logs so teardown can't mask the original exception.
- **`SnowflakeSQLFacade.create_version_in_package`** wraps its `ALTER APPLICATION PACKAGE ... {register|add} VERSION` call with `query_tag("snowflake-cli:nativeapp:version_create")`.
- **`SnowflakeSQLFacade.add_patch_to_package_version`** wraps its `ALTER APPLICATION PACKAGE ... ADD PATCH` call with `query_tag("snowflake-cli:nativeapp:version_add_patch")`.

No behavior change — the CLI sends two extra session statements per version/patch call, but the result and error paths are unchanged.

#### Tests

Updated the six affected unit tests in `tests/nativeapp/test_sf_sql_facade.py` to assert the tag set/unset calls bracket the main query. All 281 tests in that file pass locally; the 13 `tests/api/test_sql_execution.py` tests also pass.

#### Why not a generic "tag every CLI query" mechanism

Kept the scope tight on purpose: only these two operations have the known structural slowness that motivated the change. A broader tagging scheme can come later if other SLOs need it.