### PR TITLE
Support non-interactive shells in the `dcm purge` command

### DIFF
--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -33,6 +33,7 @@ from snowflake.cli.api.commands.execution_metadata import ExecutionMetadata
 from snowflake.cli.api.config import get_feature_flags_section
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.utils.error_handling import ignore_exceptions
+from snowflake.cli.api.utils.tty import is_tty_interactive
 from snowflake.connector import ProgrammingError
 from snowflake.connector.telemetry import (
     TelemetryData,
@@ -199,14 +200,6 @@ def _get_definition_version() -> str | None:
     return None
 
 
-def _is_interactive_terminal() -> bool:
-    """Check if stdin and stdout are connected to a TTY."""
-    try:
-        return sys.stdin.isatty() and sys.stdout.isatty()
-    except Exception:
-        return False
-
-
 def _is_env_truthy(name: str) -> bool:
     """Check if an environment variable has a truthy value."""
     return os.environ.get(name, "").lower() in ("yes", "true", "1", "on")
@@ -244,7 +237,7 @@ def _get_ci_environment_type() -> str:
         return "TRAVIS_CI"
     if _is_env_truthy("CI"):
         return "UNKNOWN_CI"
-    if _is_interactive_terminal():
+    if is_tty_interactive():
         return "LOCAL"
     return "UNKNOWN"
 

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -39,9 +39,11 @@ from snowflake.cli._plugins.object.command_aliases import add_object_command_ali
 from snowflake.cli._plugins.object.commands import scope_option
 from snowflake.cli._plugins.object.manager import ObjectManager
 from snowflake.cli.api.commands.flags import (
+    ForceOption,
     IdentifierType,
     IfExistsOption,
     IfNotExistsOption,
+    InteractiveOption,
     LocalDirectoryType,
     identifier_argument,
     like_option,
@@ -352,6 +354,8 @@ def purge(
     from_location: SecurePath = from_option,
     target: Optional[str] = target_option,
     save_output: bool = save_output_option,
+    interactive: bool = InteractiveOption,
+    force: Optional[bool] = ForceOption,
     skip_plan: bool = typer.Option(
         False,
         "--skip-plan",
@@ -368,7 +372,12 @@ def purge(
     context = _resolve_context_with_optional_manifest(from_location, identifier, target)
     project_id = context.project_identifier
 
-    _confirm_purge(project_id)
+    if not force and not interactive:
+        raise CliError(
+            "Cannot purge the DCM project non-interactively without --force."
+        )
+    if not force:
+        _confirm_purge(project_id)
 
     with cli_console.spinner() as spinner:
         spinner.add_task(description=f"Purging dcm project {project_id}", total=None)

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -33,11 +33,7 @@ from snowflake.cli._plugins.apps.commands import (
     snowflake_app_validate,
 )
 from snowflake.cli._plugins.nativeapp.artifacts import VersionInfo
-from snowflake.cli._plugins.nativeapp.common_flags import (
-    ForceOption,
-    InteractiveOption,
-    ValidateOption,
-)
+from snowflake.cli._plugins.nativeapp.common_flags import ValidateOption
 from snowflake.cli._plugins.nativeapp.entities.application import ApplicationEntityModel
 from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntityModel,
@@ -61,6 +57,10 @@ from snowflake.cli._plugins.workspace.manager import WorkspaceManager
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.decorators import (
     with_project_definition,
+)
+from snowflake.cli.api.commands.flags import (
+    ForceOption,
+    InteractiveOption,
 )
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.entities.utils import EntityActions

--- a/src/snowflake/cli/_plugins/nativeapp/entities/application.py
+++ b/src/snowflake/cli/_plugins/nativeapp/entities/application.py
@@ -18,11 +18,7 @@ from snowflake.cli._plugins.connection.util import (
 from snowflake.cli._plugins.nativeapp.artifacts import (
     find_events_definitions_in_manifest_file,
 )
-from snowflake.cli._plugins.nativeapp.common_flags import (
-    ForceOption,
-    InteractiveOption,
-    ValidateOption,
-)
+from snowflake.cli._plugins.nativeapp.common_flags import ValidateOption
 from snowflake.cli._plugins.nativeapp.constants import (
     ALLOWED_SPECIAL_COMMENTS,
     COMMENT_COL,
@@ -56,6 +52,10 @@ from snowflake.cli._plugins.nativeapp.utils import needs_confirmation
 from snowflake.cli._plugins.stage.manager import DefaultStagePathParts
 from snowflake.cli._plugins.workspace.context import ActionContext
 from snowflake.cli.api.cli_global_context import get_cli_context, span
+from snowflake.cli.api.commands.flags import (
+    ForceOption,
+    InteractiveOption,
+)
 from snowflake.cli.api.console.abc import AbstractConsole
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.entities.common import (

--- a/src/snowflake/cli/_plugins/nativeapp/utils.py
+++ b/src/snowflake/cli/_plugins/nativeapp/utils.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from sys import stdin, stdout
 from typing import Iterable, Optional, Union
 
 from click import ClickException
@@ -24,10 +23,6 @@ from click import ClickException
 
 def needs_confirmation(needs_confirm: bool, auto_yes: bool) -> bool:
     return needs_confirm and not auto_yes
-
-
-def is_tty_interactive():
-    return stdin.isatty() and stdout.isatty()
 
 
 def get_first_paragraph_from_markdown_file(file_path: Path) -> Optional[str]:

--- a/src/snowflake/cli/_plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/commands.py
@@ -19,7 +19,6 @@ from typing import Optional
 
 import typer
 from snowflake.cli._plugins.nativeapp.artifacts import VersionInfo
-from snowflake.cli._plugins.nativeapp.common_flags import ForceOption, InteractiveOption
 from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
     force_project_definition_v2,
 )
@@ -28,6 +27,7 @@ from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.decorators import (
     with_project_definition,
 )
+from snowflake.cli.api.commands.flags import ForceOption, InteractiveOption
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.entities.utils import EntityActions
 from snowflake.cli.api.output.types import (

--- a/src/snowflake/cli/_plugins/workspace/commands.py
+++ b/src/snowflake/cli/_plugins/workspace/commands.py
@@ -22,15 +22,15 @@ from typing import List, Optional
 
 import typer
 import yaml
-from snowflake.cli._plugins.nativeapp.common_flags import (
-    ForceOption,
-    InteractiveOption,
-    ValidateOption,
-)
+from snowflake.cli._plugins.nativeapp.common_flags import ValidateOption
 from snowflake.cli._plugins.workspace.manager import WorkspaceManager
 from snowflake.cli.api.artifacts.bundle_map import BundleMap
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.decorators import with_project_definition
+from snowflake.cli.api.commands.flags import (
+    ForceOption,
+    InteractiveOption,
+)
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.entities.utils import EntityActions
 from snowflake.cli.api.exceptions import IncompatibleParametersError

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -42,6 +42,7 @@ from snowflake.cli.api.secret import SecretType
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.stage_path import StagePath
 from snowflake.cli.api.utils.path_utils import is_stage_path
+from snowflake.cli.api.utils.tty import is_tty_interactive
 from snowflake.cli.api.utils.types import try_cast_to_int
 from snowflake.connector.auth.workload_identity import ApiFederatedAuthenticationType
 
@@ -823,3 +824,24 @@ def deprecated_flag_callback_enum(msg: str):
         return value.value
 
     return _warning_callback
+
+
+def _interactive_callback(val):
+    if val is None:
+        return is_tty_interactive()
+    return val
+
+
+InteractiveOption = typer.Option(
+    None,
+    help="When enabled, this option displays prompts even if the standard input and output are not terminal devices. Defaults to True in an interactive shell environment, and False otherwise.",
+    callback=_interactive_callback,
+    show_default=False,
+)
+
+ForceOption = typer.Option(
+    False,
+    "--force",
+    help="When enabled, this option causes the command to implicitly approve any prompts that arise. You should enable this option if interactive mode is not specified and if you want perform potentially destructive actions. Defaults to unset.",
+    is_flag=True,
+)

--- a/src/snowflake/cli/api/utils/tty.py
+++ b/src/snowflake/cli/api/utils/tty.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typer
+import sys
 
-ValidateOption = typer.Option(
-    True,
-    "--validate/--no-validate",
-    help="When enabled, this option triggers validation of a deployed Snowflake Native App's setup script SQL",
-    is_flag=True,
-)
+
+def is_tty_interactive() -> bool:
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except Exception:
+        return False

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -9336,14 +9336,34 @@
   |                                 default_target is defined in the manifest.   |
   +------------------------------------------------------------------------------+
   +- Options --------------------------------------------------------------------+
-  | --alias                TEXT  Alias for the deployment.                       |
-  | --from                 PATH  Local directory path containing DCM project     |
-  |                              files. Omit to use current directory.           |
-  | --target               TEXT  Target profile from manifest.yml to use. Uses   |
-  |                              default_target if not specified.                |
-  | --save-output                Save command response and artifacts to local    |
-  |                              'out/' directory.                               |
-  | --help         -h            Show this message and exit.                     |
+  | --alias                                TEXT  Alias for the deployment.       |
+  | --from                                 PATH  Local directory path containing |
+  |                                              DCM project files. Omit to use  |
+  |                                              current directory.              |
+  | --target                               TEXT  Target profile from             |
+  |                                              manifest.yml to use. Uses       |
+  |                                              default_target if not           |
+  |                                              specified.                      |
+  | --save-output                                Save command response and       |
+  |                                              artifacts to local 'out/'       |
+  |                                              directory.                      |
+  | --interactive      --no-interactive          When enabled, this option       |
+  |                                              displays prompts even if the    |
+  |                                              standard input and output are   |
+  |                                              not terminal devices. Defaults  |
+  |                                              to True in an interactive shell |
+  |                                              environment, and False          |
+  |                                              otherwise.                      |
+  | --force                                      When enabled, this option       |
+  |                                              causes the command to           |
+  |                                              implicitly approve any prompts  |
+  |                                              that arise. You should enable   |
+  |                                              this option if interactive mode |
+  |                                              is not specified and if you     |
+  |                                              want perform potentially        |
+  |                                              destructive actions. Defaults   |
+  |                                              to unset.                       |
+  | --help         -h                            Show this message and exit.     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/api/utils/test_tty.py
+++ b/tests/api/utils/test_tty.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from snowflake.cli.api.utils.tty import is_tty_interactive
+
+
+def test_is_tty_interactive_returns_true_when_tty():
+    with mock.patch("sys.stdin") as mock_stdin, mock.patch("sys.stdout") as mock_stdout:
+        mock_stdin.isatty.return_value = True
+        mock_stdout.isatty.return_value = True
+        assert is_tty_interactive() is True
+
+
+def test_is_tty_interactive_returns_false_when_not_tty():
+    with mock.patch("sys.stdin") as mock_stdin, mock.patch("sys.stdout") as mock_stdout:
+        mock_stdin.isatty.return_value = False
+        mock_stdout.isatty.return_value = True
+        assert is_tty_interactive() is False
+
+    with mock.patch("sys.stdin") as mock_stdin, mock.patch("sys.stdout") as mock_stdout:
+        mock_stdin.isatty.return_value = True
+        mock_stdout.isatty.return_value = False
+        assert is_tty_interactive() is False
+
+
+def test_is_tty_interactive_returns_false_on_exception():
+    with mock.patch("sys.stdin") as mock_stdin:
+        mock_stdin.isatty.side_effect = Exception("No TTY available")
+        assert is_tty_interactive() is False

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -237,49 +237,13 @@ def test_generic_ci_env_variable_returns_unknown_ci(_, mock_conn, runner, ci_val
     assert usage_command_event["message"]["command_ci_environment"] == "UNKNOWN_CI"
 
 
-def test_is_interactive_terminal_returns_true_when_tty():
-    """Test _is_interactive_terminal returns True when both stdin and stdout are TTYs."""
-    from snowflake.cli._app.telemetry import _is_interactive_terminal
-
-    with mock.patch("sys.stdin") as mock_stdin, mock.patch("sys.stdout") as mock_stdout:
-        mock_stdin.isatty.return_value = True
-        mock_stdout.isatty.return_value = True
-        assert _is_interactive_terminal() is True
-
-
-def test_is_interactive_terminal_returns_false_when_not_tty():
-    """Test _is_interactive_terminal returns False when stdin or stdout is not a TTY."""
-    from snowflake.cli._app.telemetry import _is_interactive_terminal
-
-    # stdin is not a TTY
-    with mock.patch("sys.stdin") as mock_stdin, mock.patch("sys.stdout") as mock_stdout:
-        mock_stdin.isatty.return_value = False
-        mock_stdout.isatty.return_value = True
-        assert _is_interactive_terminal() is False
-
-    # stdout is not a TTY
-    with mock.patch("sys.stdin") as mock_stdin, mock.patch("sys.stdout") as mock_stdout:
-        mock_stdin.isatty.return_value = True
-        mock_stdout.isatty.return_value = False
-        assert _is_interactive_terminal() is False
-
-
-def test_is_interactive_terminal_returns_false_on_exception():
-    """Test _is_interactive_terminal returns False when isatty() raises an exception."""
-    from snowflake.cli._app.telemetry import _is_interactive_terminal
-
-    with mock.patch("sys.stdin") as mock_stdin:
-        mock_stdin.isatty.side_effect = Exception("No TTY available")
-        assert _is_interactive_terminal() is False
-
-
 def test_get_ci_environment_type_returns_local_for_interactive_terminal():
     """Test that LOCAL is returned when running in an interactive terminal."""
     from snowflake.cli._app.telemetry import _get_ci_environment_type
 
     with mock.patch.dict(os.environ, {}, clear=True):
         with mock.patch(
-            "snowflake.cli._app.telemetry._is_interactive_terminal", return_value=True
+            "snowflake.cli._app.telemetry.is_tty_interactive", return_value=True
         ):
             assert _get_ci_environment_type() == "LOCAL"
 
@@ -290,7 +254,7 @@ def test_get_ci_environment_type_returns_unknown_for_non_interactive_non_ci():
 
     with mock.patch.dict(os.environ, {}, clear=True):
         with mock.patch(
-            "snowflake.cli._app.telemetry._is_interactive_terminal", return_value=False
+            "snowflake.cli._app.telemetry.is_tty_interactive", return_value=False
         ):
             assert _get_ci_environment_type() == "UNKNOWN"
 
@@ -337,7 +301,7 @@ def test_agent_context_non_tty_with_agent_detected():
 
     with mock.patch.dict(os.environ, {"CURSOR_AGENT": "1"}, clear=True):
         with mock.patch(
-            "snowflake.cli._app.telemetry._is_interactive_terminal", return_value=False
+            "snowflake.cli._app.telemetry.is_tty_interactive", return_value=False
         ):
             assert _get_ci_environment_type() == "UNKNOWN"
             assert _detect_agent_environment() == "CURSOR"

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -547,7 +547,9 @@ class TestDCMPurge:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "purge", project_identifier])
+            result = runner.invoke(
+                ["dcm", "purge", project_identifier, "--interactive"]
+            )
 
         assert result.exit_code == 0, result.output
         assert mock_prompt.call_count == expected_prompt_count
@@ -576,7 +578,9 @@ class TestDCMPurge:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "purge", "fooBar", "--alias", "my_alias"])
+            result = runner.invoke(
+                ["dcm", "purge", "fooBar", "--alias", "my_alias", "--interactive"]
+            )
 
         assert result.exit_code == 0, result.output
 
@@ -602,7 +606,7 @@ class TestDCMPurge:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "purge", "fooBar"])
+            result = runner.invoke(["dcm", "purge", "fooBar", "--interactive"])
 
         assert result.exit_code != 0
         mock_dcm_manager().purge.assert_not_called()
@@ -634,7 +638,7 @@ class TestDCMPurge:
         )
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "purge", "--target", "dev"])
+            result = runner.invoke(["dcm", "purge", "--target", "dev", "--interactive"])
 
         assert result.exit_code == 0, result.output
         mock_dcm_manager().purge.assert_called_once_with(
@@ -663,7 +667,7 @@ class TestDCMPurge:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "purge", "fooBar"])
+            result = runner.invoke(["dcm", "purge", "fooBar", "--interactive"])
 
         assert result.exit_code == 0, result.output
         assert "  Project identifier mismatch" in result.output
@@ -691,10 +695,116 @@ class TestDCMPurge:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with change_directory(tmp_path):
-            result = runner.invoke(["dcm", "purge", "fooBar", "--save-output"])
+            result = runner.invoke(
+                ["dcm", "purge", "fooBar", "--save-output", "--interactive"]
+            )
 
             assert result.exit_code == 0, result.output
             _assert_json_dumped("purge", plan_response, tmp_path)
+
+    @pytest.mark.parametrize("extra_args", [[], ["--no-interactive"]])
+    @mock.patch("snowflake.cli._plugins.dcm.commands._confirm_purge")
+    def test_purge_with_force_skips_prompt(
+        self,
+        mock_confirm_purge,
+        extra_args,
+        mock_dcm_manager,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_dcm_manager().purge.return_value = mock_cursor(
+            rows=[("[]",)], columns=("operations",)
+        )
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "purge", "fooBar", "--force", *extra_args])
+
+        assert result.exit_code == 0, result.output
+        mock_confirm_purge.assert_not_called()
+        mock_dcm_manager().purge.assert_called_once_with(
+            project_identifier=FQN.from_string("fooBar"),
+            alias=None,
+            skip_plan=False,
+        )
+
+    def test_purge_no_interactive_without_force_fails(
+        self,
+        mock_dcm_manager,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "purge", "fooBar", "--no-interactive"])
+
+        assert result.exit_code != 0
+        assert (
+            "Cannot purge the DCM project non-interactively without --force"
+            in result.output
+        )
+        mock_dcm_manager().purge.assert_not_called()
+
+    @mock.patch(
+        "snowflake.cli.api.commands.flags.is_tty_interactive", return_value=False
+    )
+    def test_purge_default_non_tty_without_force_fails(
+        self,
+        mock_is_tty,
+        mock_dcm_manager,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "purge", "fooBar"])
+
+        assert result.exit_code != 0
+        assert (
+            "Cannot purge the DCM project non-interactively without --force"
+            in result.output
+        )
+        mock_dcm_manager().purge.assert_not_called()
+
+    @mock.patch(
+        "snowflake.cli.api.commands.flags.is_tty_interactive", return_value=True
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.dcm.commands.typer.prompt", return_value="purge fooBar"
+    )
+    def test_purge_default_tty_shows_prompt(
+        self,
+        mock_prompt,
+        mock_is_tty,
+        mock_dcm_manager,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_dcm_manager().purge.return_value = mock_cursor(
+            rows=[("[]",)], columns=("operations",)
+        )
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "purge", "fooBar"])
+
+        assert result.exit_code == 0, result.output
+        mock_prompt.assert_called()
+        mock_dcm_manager().purge.assert_called_once()
 
 
 class TestDCMPlan:

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -877,8 +877,7 @@ def test_dcm_purge(
 
         # WHEN: purge the project
         result = runner.invoke_with_connection(
-            ["dcm", "purge", project_name],
-            input="purge project_descriptive_name\n",
+            ["dcm", "purge", project_name, "--force"],
         )
         assert result.exit_code == 0, result.output
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
SNOW-3382389
Support non-interactive shells in the `dcm purge` command.

Adds `--force`, `--interactive`, and `--no-interactive` to `snow dcm purge` so the command can run non-interactively, like in CI/CD pipelines. Previously, it always prompted the user to type `purge <identifier>`, blocking automation.

Behavior matches the nativeapp convention:

  | `--force` | `--interactive` | Result |
  |---|---|---|
  | false | true (default in TTY) | Show the existing typed-identifier confirmation prompt |
  | false | false (default in non-TTY, or via `--no-interactive`) | Fail with `Cannot purge the DCM project non-interactively without --force.` |
  | true | (any) | Skip the prompt and proceed |

  The existing `_confirm_purge` (which asks for the full project identifier) is preserved in interactive mode — it's a safety check for a highly destructive operation and doesn't fit the simple yes/no model used by nativeapp's `Policy` classes.

#### Shared-code refactor
DCM cannot import from other plugins, so the primitives that DCM needs were extracted to `src/snowflake/cli/api/`:
  - `ForceOption`, `InteractiveOption` → `src/snowflake/cli/api/commands/flags.py`
  - `is_tty_interactive()` → `src/snowflake/cli/api/utils/tty.py` (also consolidates a duplicate copy that lived in `_app/telemetry.py`)
