### PR TITLE
Fixed dcm commands crashing when `sources/` contains hidden files

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,6 +27,7 @@
 * Added `snow dcm purge` command to drop all the objects managed by the specified DCM Project
 
 ## Fixes and improvements
+* Significantly improved DCM files upload performance
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.
 * Updated `snowflake-connector-python` to version 4.4.0. Connector python 4.x series introduced stricter permission checks. In future versions of Snowflake CLI strict configuration file permissions will become mandatory. To test if your files have correct permissions set SNOWFLAKE_CLI_FEATURES_ENFORCE_STRICT_CONFIG_PERMISSIONS=1 before running CLI commands.
 

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List
 
 from snowflake.cli._plugins.dcm.models import MANIFEST_FILE_NAME, SOURCES_FOLDER
 from snowflake.cli._plugins.dcm.utils import collect_output
+from snowflake.cli._plugins.stage.diff import _to_diff_line
 from snowflake.cli._plugins.stage.manager import StageManager
 from snowflake.cli.api.artifacts.utils import bundle_artifacts
 from snowflake.cli.api.commands.utils import parse_key_value_variables
@@ -34,6 +36,19 @@ from snowflake.cli.api.stage_path import StagePath
 from snowflake.connector.cursor import SnowflakeCursor
 
 log = logging.getLogger(__name__)
+
+
+@dataclass
+class FileUpload:
+    file: Path
+    dest: str
+
+
+@dataclass
+class UploadPlan:
+    artifacts: List[PathMapping] = field(default_factory=list)
+    individual_files: List[FileUpload] = field(default_factory=list)
+    relative_paths_to_upload: List[str] = field(default_factory=list)
 
 
 class DCMProjectManager(SqlExecutionMixin):
@@ -247,29 +262,35 @@ class DCMProjectManager(SqlExecutionMixin):
             source_path,
         )
 
-        artifacts = DCMProjectManager._collect_artifacts(source_path.path)
-        log.info(
-            "Collected DCM artifacts for sync (project_identifier=%s, artifacts_count=%d).",
-            project_identifier,
-            len(artifacts),
-        )
-
         with cli_console.phase("Uploading definition files"):
             stage_fqn = FQN.from_resource(
                 ObjectType.DCM_PROJECT, project_identifier, "TMP_STAGE"
             )
+            plan = DCMProjectManager._build_upload_plan(
+                source_path.path, stage_fqn.identifier
+            )
+
             project_paths = ProjectPaths(project_root=source_path.path)
             project_paths.remove_up_bundle_root()
             SecurePath(project_paths.bundle_root).mkdir(parents=True, exist_ok=True)
 
             try:
                 bundle_artifacts(
-                    project_paths, artifacts, pattern_type=PatternMatchingType.GLOB
+                    project_paths,
+                    plan.artifacts,
+                    pattern_type=PatternMatchingType.GLOB,
                 )
 
                 stage_manager = StageManager()
+                cli_console.step(f"Creating temporary stage {stage_fqn.identifier}.")
                 stage_manager.create(
                     fqn=FQN.from_stage(stage_fqn.identifier), temporary=True
+                )
+
+                DCMProjectManager._report_files_to_be_deployed(plan)
+
+                cli_console.step(
+                    f"Uploading files from local {project_paths.bundle_root} directory to temporary stage."
                 )
                 for result in stage_manager.put_recursive(
                     local_path=project_paths.bundle_root,
@@ -280,6 +301,14 @@ class DCMProjectManager(SqlExecutionMixin):
                         "Uploaded %s to %s",
                         result["source"],
                         result["target"],
+                    )
+
+                for entry in plan.individual_files:
+                    stage_manager.put(local_path=entry.file, stage_path=entry.dest)
+                    log.info(
+                        "Uploaded %s to %s",
+                        entry.file.relative_to(source_path.path),
+                        entry.dest,
                     )
             finally:
                 project_paths.clean_up_output()
@@ -292,14 +321,52 @@ class DCMProjectManager(SqlExecutionMixin):
         return stage_fqn.identifier
 
     @staticmethod
-    def _collect_artifacts(source_path: Path) -> List[PathMapping]:
-        """Collect all artifacts from sources/ folder and manifest.yml."""
-        artifacts: List[PathMapping] = []
+    def _build_upload_plan(source_path: Path, stage_root: str) -> UploadPlan:
+        plan = UploadPlan()
+        DCMProjectManager._add_manifest(plan, source_path)
+        DCMProjectManager._add_sources(plan, source_path, stage_root)
+        return plan
 
-        artifacts.append(PathMapping(src=MANIFEST_FILE_NAME))
+    @staticmethod
+    def _add_manifest(plan: UploadPlan, source_path: Path) -> None:
+        if (source_path / MANIFEST_FILE_NAME).exists():
+            plan.artifacts.append(PathMapping(src=MANIFEST_FILE_NAME))
+            plan.relative_paths_to_upload.append(MANIFEST_FILE_NAME)
 
+    @staticmethod
+    def _add_sources(plan: UploadPlan, source_path: Path, stage_root: str) -> None:
         sources_path = source_path / SOURCES_FOLDER
-        if sources_path.exists() and sources_path.is_dir():
-            artifacts.append(PathMapping(src=SOURCES_FOLDER))
+        if not (sources_path.exists() and sources_path.is_dir()):
+            return
+        plan.artifacts.append(PathMapping(src=SOURCES_FOLDER, ignore=[".*"]))
+        for file in sorted(sources_path.rglob("*")):
+            if not file.is_file():
+                continue
+            relative = file.relative_to(sources_path)
+            plan.relative_paths_to_upload.append(f"{SOURCES_FOLDER}/{relative}")
+            if DCMProjectManager._is_in_hidden_path(relative):
+                dest_dir = DCMProjectManager._sources_stage_destination(
+                    relative, stage_root
+                )
+                plan.individual_files.append(FileUpload(file=file, dest=dest_dir))
 
-        return artifacts
+    @staticmethod
+    def _is_in_hidden_path(relative: Path) -> bool:
+        return any(part.startswith(".") for part in relative.parts)
+
+    @staticmethod
+    def _sources_stage_destination(relative: Path, stage_root: str) -> str:
+        dest_dir = f"{stage_root}/{SOURCES_FOLDER}"
+        if relative.parent != Path("."):
+            dest_dir = f"{dest_dir}/{relative.parent}"
+        return dest_dir
+
+    @staticmethod
+    def _report_files_to_be_deployed(plan: UploadPlan) -> None:
+        if not plan.relative_paths_to_upload:
+            return
+
+        cli_console.message("Local changes to be deployed:")
+        with cli_console.indented():
+            for rel in plan.relative_paths_to_upload:
+                cli_console.message(_to_diff_line("added", rel, rel))

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -358,7 +358,7 @@ class DCMProjectManager(SqlExecutionMixin):
     def _sources_stage_destination(relative: Path, stage_root: str) -> str:
         dest_dir = f"{stage_root}/{SOURCES_FOLDER}"
         if relative.parent != Path("."):
-            dest_dir = f"{dest_dir}/{relative.parent}"
+            dest_dir = f"{dest_dir}/{relative.parent.as_posix()}"
         return dest_dir
 
     @staticmethod

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -323,15 +323,14 @@ class DCMProjectManager(SqlExecutionMixin):
     @staticmethod
     def _build_upload_plan(source_path: Path, stage_root: str) -> UploadPlan:
         plan = UploadPlan()
-        DCMProjectManager._add_manifest(plan, source_path)
+        DCMProjectManager._add_manifest(plan)
         DCMProjectManager._add_sources(plan, source_path, stage_root)
         return plan
 
     @staticmethod
-    def _add_manifest(plan: UploadPlan, source_path: Path) -> None:
-        if (source_path / MANIFEST_FILE_NAME).exists():
-            plan.artifacts.append(PathMapping(src=MANIFEST_FILE_NAME))
-            plan.relative_paths_to_upload.append(MANIFEST_FILE_NAME)
+    def _add_manifest(plan: UploadPlan) -> None:
+        plan.artifacts.append(PathMapping(src=MANIFEST_FILE_NAME))
+        plan.relative_paths_to_upload.append(MANIFEST_FILE_NAME)
 
     @staticmethod
     def _add_sources(plan: UploadPlan, source_path: Path, stage_root: str) -> None:

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -736,11 +736,11 @@ class TestSyncLocalFiles:
             assert (
                 "/.hidden_dir/*" not in q
             ), f"hidden dir must not be uploaded via dir/* glob: {q}"
-        for name in (
-            "/dbt/.gitignore",
-            "/.hidden_dir/visible.sql",
-            "/.hidden_dir/sub/deep.sql",
+        for filename, stage_dest in (
+            (".gitignore", f"/{SOURCES_FOLDER}/dbt"),
+            ("visible.sql", f"/{SOURCES_FOLDER}/.hidden_dir"),
+            ("deep.sql", f"/{SOURCES_FOLDER}/.hidden_dir/sub"),
         ):
             assert any(
-                name in q for q in put_queries
-            ), f"expected a PUT for {name}; got: {put_queries}"
+                filename in q and stage_dest in q for q in put_queries
+            ), f"expected a PUT for {filename} to {stage_dest}; got: {put_queries}"

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -529,12 +529,14 @@ def test_purge_project_with_alias(mock_execute_query):
 
 class TestSyncLocalFiles:
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put")
     @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
     def test_uploads_to_temporary_stage(
         self,
         mock_create_stage,
         mock_bundle_artifacts,
+        mock_put,
         mock_put_recursive,
         project_directory,
         mock_connect,
@@ -543,26 +545,32 @@ class TestSyncLocalFiles:
     ):
         mock_put_recursive.return_value = iter([])
 
-        with project_directory("dcm_project") as project_dir:
+        with project_directory("dcm_project"):
             result = DCMProjectManager.sync_local_files(project_identifier=TEST_PROJECT)
 
             mock_create_stage.assert_called_once()
-            create_call = mock_create_stage.call_args
-            assert create_call.kwargs["temporary"] is True
+            assert mock_create_stage.call_args.kwargs["temporary"] is True
+
+            mock_bundle_artifacts.assert_called_once()
 
             mock_put_recursive.assert_called_once()
-            put_call = mock_put_recursive.call_args
-            assert put_call.kwargs["stage_path"] == str(mock_from_resource())
+            assert mock_put_recursive.call_args.kwargs["stage_path"] == str(
+                mock_from_resource()
+            )
+
+            mock_put.assert_not_called()
 
             assert result == str(mock_from_resource())
 
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put")
     @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
     def test_sync_local_files_with_source_directory(
         self,
         _mock_create_stage,
         mock_bundle_artifacts,
+        mock_put,
         mock_put_recursive,
         tmp_path,
         mock_connect,
@@ -590,17 +598,18 @@ class TestSyncLocalFiles:
         )
 
         mock_bundle_artifacts.assert_called_once()
-        call_args = mock_bundle_artifacts.call_args
-        actual_project_root = call_args.args[0].project_root
+        actual_project_root = mock_bundle_artifacts.call_args.args[0].project_root
         assert actual_project_root.resolve() == source_dir.resolve()
 
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put")
     @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
     def test_sync_local_files_with_relative_source_directory(
         self,
         _mock_create_stage,
         mock_bundle_artifacts,
+        mock_put,
         mock_put_recursive,
         tmp_path,
         mock_connect,
@@ -615,6 +624,10 @@ class TestSyncLocalFiles:
         with open(manifest_file, "w") as f:
             yaml.dump({"manifest_version": 2, "type": "dcm_project"}, f)
 
+        sources_dir = source_dir / SOURCES_FOLDER
+        sources_dir.mkdir()
+        (sources_dir / "file.sql").touch()
+
         original_cwd = os.getcwd()
         try:
             os.chdir(tmp_path)
@@ -625,20 +638,21 @@ class TestSyncLocalFiles:
             )
 
             mock_bundle_artifacts.assert_called_once()
-            call_args = mock_bundle_artifacts.call_args
-            actual_project_root = call_args.args[0].project_root
+            actual_project_root = mock_bundle_artifacts.call_args.args[0].project_root
             assert actual_project_root.is_absolute()
             assert actual_project_root.resolve() == source_dir.resolve()
         finally:
             os.chdir(original_cwd)
 
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put_recursive")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.put")
     @mock.patch("snowflake.cli._plugins.dcm.manager.bundle_artifacts")
     @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
-    def test_sync_local_files_includes_all_files_in_sources(
+    def test_sync_local_files_collects_manifest_and_sources(
         self,
         _mock_create_stage,
         mock_bundle_artifacts,
+        mock_put,
         mock_put_recursive,
         tmp_path,
         mock_connect,
@@ -672,9 +686,61 @@ class TestSyncLocalFiles:
         )
 
         mock_bundle_artifacts.assert_called_once()
-        call_args = mock_bundle_artifacts.call_args
-        artifacts = call_args.args[1]
+        artifacts = mock_bundle_artifacts.call_args.args[1]
         artifact_srcs = [a.src for a in artifacts]
 
         assert MANIFEST_FILE_NAME in artifact_srcs
         assert SOURCES_FOLDER in artifact_srcs
+
+    @mock.patch("snowflake.cli._plugins.stage.manager.StageManager.execute_query")
+    @mock.patch("snowflake.cli._plugins.dcm.manager.StageManager.create")
+    def test_sync_local_files_uploads_hidden_files(
+        self,
+        _mock_create_stage,
+        mock_execute_query,
+        tmp_path,
+        mock_connect,
+        mock_cursor,
+        mock_from_resource,
+    ):
+        mock_execute_query.return_value = mock_cursor(rows=[], columns=[])
+
+        source_dir = tmp_path / "project_with_dotfiles"
+        source_dir.mkdir()
+        with open(source_dir / MANIFEST_FILE_NAME, "w") as f:
+            yaml.dump({"manifest_version": 2, "type": "dcm_project"}, f)
+
+        dbt = source_dir / SOURCES_FOLDER / "dbt"
+        (dbt / "models").mkdir(parents=True)
+        (dbt / ".gitignore").touch()
+        (dbt / "models" / "model.sql").touch()
+
+        hidden_dir = source_dir / SOURCES_FOLDER / ".hidden_dir"
+        (hidden_dir / "sub").mkdir(parents=True)
+        (hidden_dir / "visible.sql").touch()
+        (hidden_dir / "sub" / "deep.sql").touch()
+
+        DCMProjectManager.sync_local_files(
+            project_identifier=TEST_PROJECT, source_directory=str(source_dir)
+        )
+
+        put_queries = [
+            call.args[0]
+            for call in mock_execute_query.call_args_list
+            if call.args and call.args[0].lstrip().lower().startswith("put ")
+        ]
+        for q in put_queries:
+            assert (
+                "/dbt/*" not in q
+            ), f"PUT for dotfile-only dbt/ dir would crash the connector: {q}"
+            assert (
+                "/.hidden_dir/*" not in q
+            ), f"hidden dir must not be uploaded via dir/* glob: {q}"
+        for name in (
+            "/dbt/.gitignore",
+            "/.hidden_dir/visible.sql",
+            "/.hidden_dir/sub/deep.sql",
+        ):
+            assert any(
+                name in q for q in put_queries
+            ), f"expected a PUT for {name}; got: {put_queries}"

--- a/tests_integration/test_dcm_project.py
+++ b/tests_integration/test_dcm_project.py
@@ -112,9 +112,24 @@ def test_dcm_deploy(
     runner,
     test_database,
     project_directory,
+    sql_test_helper,
 ):
     project_name = "project_descriptive_name"
-    with project_directory("dcm_project"):
+    standard_table_fqn = f"{test_database}.PUBLIC.MYTABLE"
+    hidden_file_table_fqn = f"{test_database}.PUBLIC.HIDDEN_FILE_TABLE"
+    hidden_folder_table_fqn = f"{test_database}.PUBLIC.HIDDEN_FOLDER_TABLE"
+
+    with project_directory("dcm_project") as project_root:
+        definitions = project_root / "sources" / "definitions"
+        (definitions / ".hidden_def.sql").write_text(
+            f"define table identifier('{hidden_file_table_fqn}') (fooBar string);\n"
+        )
+        hidden_folder = definitions / ".hidden"
+        hidden_folder.mkdir()
+        (hidden_folder / "in_hidden.sql").write_text(
+            f"define table identifier('{hidden_folder_table_fqn}') (fooBar string);\n"
+        )
+
         result = runner.invoke_with_connection(["dcm", "create", project_name])
         assert result.exit_code == 0, result.output
         assert f"DCM Project '{project_name}' successfully created." in result.output
@@ -135,7 +150,7 @@ def test_dcm_deploy(
                 "deploy",
                 project_name,
                 "-D",
-                f"table_name='{test_database}.PUBLIC.MyTable'",
+                f"table_name='{standard_table_fqn}'",
             ]
         )
         assert result.exit_code == 0, result.output
@@ -144,6 +159,21 @@ def test_dcm_deploy(
             project_name,
             {("DEPLOYMENT$1", None)},
         )
+
+        rows = sql_test_helper.execute_single_sql(
+            f"SHOW TABLES IN SCHEMA {test_database}.PUBLIC"
+        )
+        deployed_table_names = {row["name"] for row in rows}
+        for fqn in (
+            standard_table_fqn,
+            hidden_file_table_fqn,
+            hidden_folder_table_fqn,
+        ):
+            expected_name = fqn.rsplit(".", 1)[-1]
+            assert expected_name in deployed_table_names, (
+                f"{fqn} was not created by deploy; "
+                f"got {sorted(deployed_table_names)}"
+            )
 
         # remove project
         result = runner.invoke_with_connection(["dcm", "drop", project_name])


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
Fixes every `snow dcm ...` command that syncs the project (`plan`, `deploy`, `analyze`, `preview`, `purge`, `test`) crashing when `sources/` contains, or any subdirectory contain, a hidden file (`.gitignore`, `.DS_Store`, etc.): 

> 253006: File doesn't exist: ['/Users/.../output/bundle/sources/dbt/*']

 #### Root cause
Commit 22eb51ab switched DCM to `bundle_artifacts` +  `StageManager.put_recursive(temp_directory=bundle_root)`. `put_recursive` walks the bundle bottom-up and issues `PUT file://.../dir/*` per directory. The Snowflake Python connector expands that glob via `glob.glob(...)`, which does not match files starting with `.`. When a directory ends up containing only a dotfile (after its subdirs have been processed and `rmtree`'d), the glob returns an empty list and the connector raises 253006.

v3.16 did not have this problem because it enumerated source files individually and uploaded each by exact path — no wildcard expansion, dotfiles included.


#### Fix
A small, targeted change to `DCMProjectManager.sync_local_files` that preserves the `bundle_artifacts` + `put_recursive(temp_directory=bundle_root)` path introduced by 22eb51ab.

  `_build_upload_plan` returns an `UploadPlan` that is the single source of truth for what gets uploaded. One walk of the source tree populates three fields:

  - **`artifacts`** — `PathMapping`s for `bundle_artifacts`. `SOURCES_FOLDER` is added with `ignore=[".*"]` so dotfiles never reach the bundle and can't trigger the 253006 crash.
  - **`individual_files`** — list of `FileUpload(file, dest)` entries for dotfiles, uploaded per-file with exact paths (which bypass `glob.glob`'s wildcard expansion entirely).
  - **`relative_paths_to_upload`** — every file the user will see on the stage, used by the "Local changes to be deployed" banner.

  `sync_local_files` consumes the plan: `bundle_artifacts(plan.artifacts)` → `put_recursive(bundle_root, temp_directory=bundle_root)` for the batched upload of visible files → per-file `stage_manager.put(...)` for each `FileUpload` in `plan.individual_files`. `_report_files_to_be_deployed` reads directly from `plan.relative_paths_to_upload` — no filtering, no walking, no risk of drift between what's reported and what's uploaded.

#### Behavior changes visible to users
- **CLI output restored to pre-[22eb51ab](https://github.com/snowflakedb/snowflake-cli/commit/22eb51ab47c53c4afb43f7cc1d30d73e95e5d9ca) format.** `Creating temporary stage <FQN>.` step, `Local changes to be deployed:` banner with `added: <rel> -> <rel>` lines for every file (including dotfiles), and `Uploading files from local <bundle_root> directory to temporary stage.` step. The banner is driven by `plan.relative_paths_to_upload`, so it always matches what actually uploads.
