### PR TITLE
Fix token keep-alive when session/master tokens come from env or connection config

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,6 +35,7 @@
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.
 * Updated `snowflake-connector-python` to version 4.4.0. Connector python 4.x series introduced stricter permission checks. In future versions of Snowflake CLI strict configuration file permissions will become mandatory. To test if your files have correct permissions set SNOWFLAKE_CLI_FEATURES_ENFORCE_STRICT_CONFIG_PERMISSIONS=1 before running CLI commands.
 * Fixed error message when `PRIVATE_KEY_PASSPHRASE` environment variable is set to an empty string.
+* Fixed session/master token connections created from environment variables or named connection config not enabling token keep-alive settings. This could cause follow-up commands (including `snow app setup` after a successful `--dry-run`) to fail with `251007: Session and master tokens invalid`.
 
 # v3.16.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@
 * Fixed `snow streamlit deploy` failing with a collision error when `pages/*.py` glob in `additional_source_files` overlaps with the automatically-included `pages/` directory. Overlapping glob patterns are now deduplicated during v1-to-v2 definition conversion.
 * Updated `snowflake-connector-python` to version 4.4.0. Connector python 4.x series introduced stricter permission checks. In future versions of Snowflake CLI strict configuration file permissions will become mandatory. To test if your files have correct permissions set SNOWFLAKE_CLI_FEATURES_ENFORCE_STRICT_CONFIG_PERMISSIONS=1 before running CLI commands.
 * Fixed error message when `PRIVATE_KEY_PASSPHRASE` environment variable is set to an empty string.
-* Fixed session/master token connections created from environment variables or named connection config not enabling token keep-alive settings. This could cause follow-up commands (including `snow app setup` after a successful `--dry-run`) to fail with `251007: Session and master tokens invalid`.
+* Fixed session/master token connections created from environment variables or named connection config not enabling token keep-alive settings. This could cause follow-up commands to fail with `251007: Session and master tokens invalid`.
 
 # v3.16.0
 

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -226,6 +226,12 @@ def connect_to_snowflake(
                 "connection_diag_allowlist_path"
             ] = diag_allowlist_path
 
+    # Determine token-based auth from the final merged parameters (flags/config/env).
+    # Keep the existing guard behavior above unchanged for now, but ensure keep-alive
+    # protections are applied whenever session/master tokens are actually used.
+    using_session_token = "session_token" in connection_parameters
+    using_master_token = "master_token" in connection_parameters
+
     # Make sure the connection is not closed if it was shared to the SnowCLI, instead of being created in the SnowCLI
     _avoid_closing_the_connection_if_it_was_shared(
         using_session_token, using_master_token, connection_parameters

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -260,6 +260,66 @@ def test_returns_nice_error_in_case_of_missing_master_token(runner):
     )
 
 
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+@mock.patch("snowflake.connector.connect")
+@mock.patch.dict(
+    os.environ,
+    {
+        "SNOWFLAKE_SESSION_TOKEN": "env-session-token",
+        "SNOWFLAKE_MASTER_TOKEN": "env-master-token",
+    },
+    clear=True,
+)
+def test_env_session_master_tokens_enable_keep_alive(
+    mock_connect, mock_command_info, test_snowcli_config
+):
+    """Session/master tokens from generic env vars should enable keep-alive."""
+    from snowflake.cli._app.snow_connector import connect_to_snowflake
+    from snowflake.cli.api.config import config_init
+
+    config_init(test_snowcli_config)
+    mock_command_info.return_value = "SNOWCLI.TEST"
+
+    connect_to_snowflake(connection_name="default")
+
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args[1]
+    assert call_kwargs["session_token"] == "env-session-token"
+    assert call_kwargs["master_token"] == "env-master-token"
+    assert call_kwargs["server_session_keep_alive"] is True
+    assert call_kwargs["client_session_keep_alive"] is True
+    assert call_kwargs["client_session_keep_alive_heartbeat_frequency"] == 3600
+
+
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+@mock.patch("snowflake.cli._app.snow_connector.get_connection_dict")
+@mock.patch("snowflake.connector.connect")
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_config_session_master_tokens_enable_keep_alive(
+    mock_connect, mock_get_connection_dict, mock_command_info
+):
+    """Session/master tokens from connection config should enable keep-alive."""
+    from snowflake.cli._app.snow_connector import connect_to_snowflake
+
+    mock_command_info.return_value = "SNOWCLI.TEST"
+    mock_get_connection_dict.return_value = {
+        "account": "test_account",
+        "user": "test_user",
+        "session_token": "cfg-session-token",
+        "master_token": "cfg-master-token",
+    }
+
+    connect_to_snowflake(connection_name="qa6bug")
+
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args[1]
+    assert call_kwargs["session_token"] == "cfg-session-token"
+    assert call_kwargs["master_token"] == "cfg-master-token"
+    assert call_kwargs["server_session_keep_alive"] is True
+    assert call_kwargs["client_session_keep_alive"] is True
+    assert call_kwargs["client_session_keep_alive_heartbeat_frequency"] == 3600
+
+
 @mock.patch("snowflake.connector.connect")
 @pytest.mark.parametrize("feature_flag", [None, True, False])
 def test_internal_application_data_is_sent_if_feature_flag_is_set(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

We found a gap in `connect_to_snowflake` token handling:
- `using_session_token` / `using_master_token` were inferred only from CLI overrides.
- Session/master tokens sourced from environment variables (`SNOWFLAKE_SESSION_TOKEN` / `SNOWFLAKE_MASTER_TOKEN`) or named connection config were not recognized as token-auth mode for keep-alive behavior.

#### User-visible scenarios affected
1. Tokens provided via env vars + named connection
   - First command invocation can succeed (for example: `snow app setup --dry-run ...`).
   - Follow-up invocation can fail with `251007: Session and master tokens invalid` because the token-auth keep-alive settings were not applied.

2. Tokens provided in named connection config
   - Same issue as above: connection is token-auth, but keep-alive protection was skipped.

#### Fix
Recompute token-auth mode from final merged `connection_parameters` (flags + connection config + env vars) immediately before applying keep-alive behavior.
