### PR TITLE
fix: [SNOW-3441124] fix integration test

### DIFF
--- a/tests_integration/test_session_token.py
+++ b/tests_integration/test_session_token.py
@@ -33,6 +33,8 @@ def test_use_session_token(runner, snowflake_session):
             session_token,
             "--master-token",
             master_token,
+            "--host",
+            snowflake_session.host,
         ]
     )
     assert result_of_setting_variable.exit_code == 0
@@ -48,6 +50,8 @@ def test_use_session_token(runner, snowflake_session):
             session_token,
             "--master-token",
             master_token,
+            "--host",
+            snowflake_session.host,
             "--format",
             "json",
         ]


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
https://snowflakecomputing.atlassian.net/browse/SNOW-3441124

The fixture that sets up connection to Snowflake might be using non-default host (which is the case for this test):
```python
@pytest.fixture(scope="session")
def snowflake_session() -> SnowflakeConnection:
    config = {
        "application": "INTEGRATION_TEST",
        "authenticator": "SNOWFLAKE_JWT",
        "account": _get_from_env("ACCOUNT"),
        "user": _get_from_env("USER"),
        "private_key_file": _get_private_key_file(),
        "private_key_raw": _get_from_env("PRIVATE_KEY_RAW", allow_none=True),
        "host": _get_from_env("HOST", allow_none=True),
        "warehouse": _get_from_env("WAREHOUSE", allow_none=True),
        "role": _get_from_env("ROLE", allow_none=True),
    }
    config = {k: v for k, v in config.items() if v is not None}
    update_connection_details_with_private_key(config)
    connection = connector.connect(**config)
    yield connection
    connection.close()
```
So the fix is about using the same host when later running the actual test