### PR TITLE
Snowflake Apps: default --app-name to current directory in setup

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -73,7 +73,7 @@ SOURCE_MISSING = "missing"
 
 
 def snowflake_app_setup(
-    app_name: str,
+    app_name: Optional[str],
     dry_run: bool,
     compute_pool: Optional[str],
     build_eai: Optional[str],
@@ -83,9 +83,16 @@ def snowflake_app_setup(
     See the ``snow app setup`` command in
     :mod:`snowflake.cli._plugins.nativeapp.commands` for the CLI surface.
     """
-    if not re.fullmatch(r"[a-zA-Z0-9_]+", app_name):
+    resolved_app_name = app_name or Path.cwd().name
+    if not resolved_app_name:
         raise ClickException(
-            f"Invalid app name '{app_name}'. "
+            "Could not derive app name from the current directory. "
+            "Please provide --app-name."
+        )
+
+    if not re.fullmatch(r"[a-zA-Z0-9_]+", resolved_app_name):
+        raise ClickException(
+            f"Invalid app name '{resolved_app_name}'. "
             "Only letters, digits, and underscores are allowed."
         )
 
@@ -192,7 +199,9 @@ def snowflake_app_setup(
     resolved_values = {k: v[0] for k, v in resolved.items()}
 
     if not dry_run:
-        project_file.write_text(_generate_snowflake_yml(app_name, resolved_values))
+        project_file.write_text(
+            _generate_snowflake_yml(resolved_app_name, resolved_values)
+        )
 
     is_json = get_cli_context().output_format.is_json
     if is_json:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -83,7 +83,16 @@ def snowflake_app_setup(
     See the ``snow app setup`` command in
     :mod:`snowflake.cli._plugins.nativeapp.commands` for the CLI surface.
     """
-    resolved_app_name = app_name or Path.cwd().name
+    resolved_app_name = app_name
+    if resolved_app_name is None:
+        derived_app_name = Path.cwd().name
+        # For implicit names, normalize directory strings into a valid
+        # identifier by mapping common separators to "_" and stripping
+        # all other disallowed characters.
+        resolved_app_name = re.sub(
+            r"[^a-zA-Z0-9_]", "", derived_app_name.replace(" ", "_").replace("-", "_")
+        )
+
     if not resolved_app_name:
         raise ClickException(
             "Could not derive app name from the current directory. "

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -134,10 +134,10 @@ def _reject_snowflake_app_options(command: str, **options: object) -> None:
 
 @app.command("setup", requires_connection=True)
 def app_setup(
-    app_name: str = typer.Option(
-        ...,
+    app_name: Optional[str] = typer.Option(
+        None,
         "--app-name",
-        help="Name of the Snowflake Apps Deploy to initialize.",
+        help="Name of the Snowflake Apps Deploy to initialize. Defaults to the current directory name.",
     ),
     dry_run: bool = typer.Option(
         False,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -3168,16 +3168,15 @@
    does not apply to Native App projects.                                         
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | *  --app-name              TEXT  Name of the Snowflake Apps Deploy to        |
-  |                                  initialize.                                 |
-  |                                  [required]                                  |
-  |    --dry-run                     Only print the resolved configuration       |
-  |                                  values without writing snowflake.yml.       |
-  |    --compute-pool          TEXT  Compute pool for building and running the   |
-  |                                  app.                                        |
-  |    --build-eai             TEXT  External access integration used during the |
-  |                                  app build.                                  |
-  |    --help          -h            Show this message and exit.                 |
+  | --app-name              TEXT  Name of the Snowflake Apps Deploy to           |
+  |                               initialize. Defaults to the current directory  |
+  |                               name.                                          |
+  | --dry-run                     Only print the resolved configuration values   |
+  |                               without writing snowflake.yml.                 |
+  | --compute-pool          TEXT  Compute pool for building and running the app. |
+  | --build-eai             TEXT  External access integration used during the    |
+  |                               app build.                                     |
+  | --help          -h            Show this message and exit.                    |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1204,6 +1204,49 @@ class TestSetupCommand:
         assert resolved["build_compute_pool"] == "PARAM_POOL"
         assert resolved["build_eai"] == "PARAM_EAI"
 
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_init_uses_current_directory_name_when_app_name_not_provided(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+            "build_eai": "PARAM_EAI",
+        }
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup"])
+            assert result.exit_code == 0, result.output
+
+        assert mock_gen.call_args[0][0] == tmp_path.name
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_init_rejects_derived_invalid_directory_name(
+        self, mock_mgr_cls, runner, tmp_path
+    ):
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+        invalid_project = tmp_path / "invalid-name"
+        invalid_project.mkdir()
+
+        with change_directory(invalid_project):
+            result = runner.invoke(["app", "setup"])
+
+        assert result.exit_code == 1
+        assert "Invalid app name 'invalid-name'" in result.output
+
     def test_init_skips_when_file_exists(self, runner, tmp_path):
         (tmp_path / "snowflake.yml").write_text("existing content")
         with change_directory(tmp_path):

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1228,8 +1228,31 @@ class TestSetupCommand:
 
         assert mock_gen.call_args[0][0] == tmp_path.name
 
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_init_rejects_derived_invalid_directory_name(
+    def test_init_normalizes_derived_directory_name(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+        project_dir = tmp_path / "my app-name!@#"
+        project_dir.mkdir()
+
+        with change_directory(project_dir):
+            result = runner.invoke(["app", "setup"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_gen.call_args[0][0] == "my_app_name"
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_init_rejects_empty_normalized_directory_name(
         self, mock_mgr_cls, runner, tmp_path
     ):
         mock_mgr = mock_mgr_cls.return_value
@@ -1238,14 +1261,14 @@ class TestSetupCommand:
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
         }
-        invalid_project = tmp_path / "invalid-name"
+        invalid_project = tmp_path / "!@#"
         invalid_project.mkdir()
 
         with change_directory(invalid_project):
             result = runner.invoke(["app", "setup"])
 
         assert result.exit_code == 1
-        assert "Invalid app name 'invalid-name'" in result.output
+        assert "Could not derive app name from the current directory." in result.output
 
     def test_init_skips_when_file_exists(self, runner, tmp_path):
         (tmp_path / "snowflake.yml").write_text("existing content")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- Make `snow app setup --app-name` optional for Snowflake Apps Deploy
- Default app name to the current project directory name when `--app-name` is omitted

