### PR TITLE
fix: [SNOW-3436033] fall back to default Snowsight URL in streamlit deploy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Fixed `snow streamlit deploy` surfacing a "host (...) was missing or not in the expected format" error after the Streamlit object had already been created successfully on accounts whose host cannot be resolved to a Snowsight region (for example accounts hosted in regions with hyphens like `us-east-1`). The deploy action now falls back to `https://app.snowflake.com` when the Snowsight URL cannot be built, matching the behavior of `snow streamlit get-url`.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from typing import Optional
 
 from click import ClickException
-from snowflake.cli._plugins.connection.util import make_snowsight_url
+from snowflake.cli._plugins.connection.util import (
+    MissingConnectionAccountError,
+    MissingConnectionRegionError,
+    make_snowsight_url,
+)
 from snowflake.cli._plugins.nativeapp.artifacts import build_bundle
 from snowflake.cli._plugins.stage.manager import StageManager
 from snowflake.cli._plugins.streamlit.manager import StreamlitManager
@@ -62,9 +66,12 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         self, action_ctx: ActionContext, *args, **kwargs
     ):  # maybe this should be a property
         name = self._entity_model.fqn.using_connection(self._conn)
-        return make_snowsight_url(
-            self._conn, f"/#/streamlit-apps/{name.url_identifier}"
-        )
+        try:
+            return make_snowsight_url(
+                self._conn, f"/#/streamlit-apps/{name.url_identifier}"
+            )
+        except (MissingConnectionRegionError, MissingConnectionAccountError):
+            return "https://app.snowflake.com"
 
     def _is_spcs_runtime_v2_mode(self) -> bool:
         """Check if SPCS runtime v2 mode is enabled."""

--- a/tests/streamlit/test_streamlit_entity.py
+++ b/tests/streamlit/test_streamlit_entity.py
@@ -141,6 +141,21 @@ class TestStreamlitEntity(StreamlitTestClass):
             f"CREATE STREAMLIT IDENTIFIER('{STREAMLIT_NAME}')\nROOT_LOCATION = '@streamlit/test_streamlit'\nMAIN_FILE = 'streamlit_app.py'\nQUERY_WAREHOUSE = test_warehouse\nTITLE = 'My Fancy Streamlit';"
         )
 
+    def test_action_get_url_falls_back_on_missing_region(
+        self, example_entity, action_context
+    ):
+        from snowflake.cli._plugins.connection.util import (
+            MissingConnectionRegionError,
+        )
+
+        self.mock_snowsight_url.side_effect = MissingConnectionRegionError(
+            "acct.us-east-1.snowflakecomputing.com"
+        )
+
+        url = example_entity.action_get_url(action_context)
+
+        assert url == "https://app.snowflake.com"
+
     def test_drop(self, example_entity, action_context):
         example_entity.action_drop(action_context)
         self.mock_execute.assert_called_with(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes [SNOW-3436033](https://snowflakecomputing.atlassian.net/browse/SNOW-3436033) / [#2912](https://github.com/snowflakedb/snowflake-cli/issues/2912).

`snow streamlit deploy` raised

```
The connection host (<locator>.us-east-1.snowflakecomputing.com) was missing or not in
the expected format (<account>.<deployment>.snowflakecomputing.com)
```

after the Streamlit object had already been created, for accounts whose host does not match the 6-part `<acct>.x.y.z.snowflakecomputing.com` shape that `get_host_region` recognizes (for example accounts in regions with hyphens such as `us-east-1`, `us-west-2`, `eu-west-1`, `ap-southeast-1`, …). The deploy itself succeeded — the failure happened at the very end, in `StreamlitEntity.action_get_url`, which calls `make_snowsight_url` to report the app URL.

`StreamlitManager.get_url` — used by `snow streamlit get-url` — already handles this path by catching `MissingConnectionRegionError` / `MissingConnectionAccountError` and returning `https://app.snowflake.com`. This PR makes `StreamlitEntity.action_get_url` behave the same way, so the deploy reports the fallback URL instead of failing at the URL-building step after the object has been successfully created.

Scope is intentionally tight — this mirrors existing behavior in the sibling manager path. A fuller fix for regioned URL resolution for 4-part hosts would be a broader change and belongs in a separate PR.

#### Tests

Added `test_action_get_url_falls_back_on_missing_region` which forces `make_snowsight_url` to raise `MissingConnectionRegionError` and asserts that `action_get_url` returns `https://app.snowflake.com` instead of propagating the error.

Local run of `tests/streamlit/` (130 tests) and `tests/test_utils.py` passes.

[SNOW-3436033]: https://snowflakecomputing.atlassian.net/browse/SNOW-3436033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ