### PR TITLE
fix: [SNOW-3436033] parse regioned hosts for Snowsight URL construction

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,9 +41,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,10 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* Fixed Snowsight URL generation (used by `snow streamlit deploy`, `snow streamlit get-url`, `snow app run`, `snow notebook`, and similar commands) for accounts whose host is 4-part (e.g. `<account>.us-east-1.snowflakecomputing.com`) or 5-part with a cloud suffix (e.g. `<account>.<region>.aws|azure|gcp.snowflakecomputing.com`). These hosts now resolve to the correct regioned Snowsight URL instead of raising `"host (...) was missing or not in the expected format"`.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,7 @@
 * Upgraded `pip` to version 26.1.1.
 * Fixed `snow connection list` crashing with `AttributeError` when `config.toml` contains a scalar value directly under `[connections]`. Such entries are now skipped with a warning so valid connections are still listed.
 * Fixed SQL injection via `FQN.sql_identifier`.
+* Fixed Snowsight URL generation (used by `snow streamlit deploy`, `snow streamlit get-url`, `snow app run`, `snow notebook`, and similar commands) for accounts whose host is 4-part (e.g. `<account>.us-east-1.snowflakecomputing.com`) or 5-part with a cloud suffix (e.g. `<account>.<region>.aws.snowflakecomputing.com`). These hosts now resolve to the correct regioned Snowsight URL instead of raising `"host (...) was missing or not in the expected format"`.
 
 
 # v3.17.1
@@ -43,7 +44,6 @@
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 * The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
-* Fixed Snowsight URL generation (used by `snow streamlit deploy`, `snow streamlit get-url`, `snow app run`, `snow notebook`, and similar commands) for accounts whose host is 4-part (e.g. `<account>.us-east-1.snowflakecomputing.com`) or 5-part with a cloud suffix (e.g. `<account>.<region>.aws|azure|gcp.snowflakecomputing.com`). These hosts now resolve to the correct regioned Snowsight URL instead of raising `"host (...) was missing or not in the expected format"`.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/connection/util.py
+++ b/src/snowflake/cli/_plugins/connection/util.py
@@ -112,15 +112,38 @@ def is_regionless_redirect(conn: SnowflakeConnection) -> bool:
 
 def get_host_region(host: str) -> str | None:
     """
-    Looks for hosts of form
-    <account>.[x.y.z].snowflakecomputing.com
-    Returns the three-part [region identifier] or None.
+    Extract the Snowsight region segment from a Snowflake host.
+
+    Supported shapes (all ending in .snowflakecomputing.com):
+        <account>.<region>.snowflakecomputing.com                    -> <region>
+            e.g. <acct>.us-east-1.snowflakecomputing.com             -> us-east-1
+        <account>.<region>.<cloud>.snowflakecomputing.com            -> <region>.<cloud>
+            where <cloud> ∈ {aws, azure, gcp}
+        <account>.<x>.<y>.<z>.snowflakecomputing.com                 -> <x>.<y>.<z>
+            (legacy VPS / PrivateLink)
+        *.local                                                      -> LOCAL_DEPLOYMENT_REGION
+
+    Regionless aliases (<org>-<account>.<deployment>.snowflakecomputing.com, recognizable
+    by a dash in the account component) return None so callers fall back to the allowlist
+    lookup to find the real regioned host.
     """
     host_parts = host.split(".")
     if host_parts[-1] == "local":
         return LOCAL_DEPLOYMENT_REGION
-    elif len(host_parts) == 6:
-        return ".".join(host_parts[1:4])
+    if host_parts[-2:] != ["snowflakecomputing", "com"]:
+        return None
+    remaining = host_parts[:-2]
+    if len(remaining) < 2:
+        return None
+    account, region_parts = remaining[0], remaining[1:]
+    if "-" in account:
+        return None
+    if len(region_parts) == 1:
+        return region_parts[0]
+    if len(region_parts) == 2 and region_parts[-1] in ("aws", "azure", "gcp"):
+        return ".".join(region_parts)
+    if len(region_parts) == 3:
+        return ".".join(region_parts)
     return None
 
 

--- a/src/snowflake/cli/_plugins/connection/util.py
+++ b/src/snowflake/cli/_plugins/connection/util.py
@@ -124,8 +124,9 @@ def get_host_region(host: str) -> str | None:
         *.local                                                      -> LOCAL_DEPLOYMENT_REGION
 
     Regionless aliases (<org>-<account>.<deployment>.snowflakecomputing.com, recognizable
-    by a dash in the account component) return None so callers fall back to the allowlist
-    lookup to find the real regioned host.
+    by a dash in the account component of a 4- or 5-part host) return None so callers
+    fall back to the allowlist lookup to find the real regioned host. 6-part VPS hosts
+    with dashed accounts are not ambiguous and are still parsed as regioned.
     """
     host_parts = host.split(".")
     if host_parts[-1] == "local":
@@ -136,7 +137,11 @@ def get_host_region(host: str) -> str | None:
     if len(remaining) < 2:
         return None
     account, region_parts = remaining[0], remaining[1:]
-    if "-" in account:
+    # The regionless-alias / regioned-host ambiguity only exists for 4- and 5-part
+    # hosts (where the leading token could be either `<org>-<account>` or a plain
+    # account). 6-part VPS/PrivateLink hosts are unambiguously regioned, so a dash
+    # in the account component there is a real account, not an alias marker.
+    if "-" in account and len(region_parts) <= 2:
         return None
     if len(region_parts) == 1:
         return region_parts[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,7 +255,7 @@ def test_get_account_identifier(mock_get_account):
                     "type": "SNOWFLAKE_DEPLOYMENT",
                 },
                 {
-                    "host": "myacct.nonregioned.snowflakecomputing.com",
+                    "host": "myorg-myacct.nonregioned.snowflakecomputing.com",
                     "type": "SNOWFLAKE_DEPLOYMENT",
                 },
                 {"type": "unrelated"},
@@ -285,7 +285,7 @@ def test_get_context_non_regionless_uses_region(
     guess_regioned_host_from_allowlist, is_regionless_redirect
 ):
     mock_conn = mock.MagicMock(spec=SnowflakeConnection)
-    mock_conn.host = "myacct.regionless.snowflakecomputing.com"
+    mock_conn.host = "myorg-myacct.regionless.snowflakecomputing.com"
     guess_regioned_host_from_allowlist.return_value = (
         "myacct.x.y.z.snowflakecomputing.com"
     )
@@ -310,9 +310,19 @@ def test_get_context_local_non_regionless_gets_local_region(
     "host, expected",
     [
         ("some.dns.local", LOCAL_DEPLOYMENT_REGION),
+        # Regionless (<org>-<account>.<deployment>.snowflakecomputing.com) — the dash in
+        # the account component distinguishes it from a regioned 4-part host.
         ("org-acct.mydns.snowflakecomputing.com", None),
+        # 4-part regioned hosts (AWS legacy, e.g. us-east-1).
+        ("naf_test_pc.us-west-2.snowflakecomputing.com", "us-west-2"),
+        ("acct.us-east-1.snowflakecomputing.com", "us-east-1"),
+        # 5-part regioned hosts (cloud suffix).
+        ("acct.eu-central-1.aws.snowflakecomputing.com", "eu-central-1.aws"),
+        ("acct.west-europe.azure.snowflakecomputing.com", "west-europe.azure"),
+        ("acct.us-central1.gcp.snowflakecomputing.com", "us-central1.gcp"),
+        # 6-part regioned host (VPS / PrivateLink).
         ("account.x.us-west-2.aws.snowflakecomputing.com", "x.us-west-2.aws"),
-        ("naf_test_pc.us-west-2.snowflakecomputing.com", None),
+        # Non-Snowsight hosts (internal/legacy zones) return None so callers fall back.
         ("test_account.az.int.snowflakecomputing.com", None),
         ("frozenweb.prod3.external-zone.snowflakecomputing.com", None),
     ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ from snowflake.cli._plugins.connection.util import (
     UIParameter,
     get_context,
     get_host_region,
+    get_region,
     get_ui_parameter,
     get_ui_parameters,
     guess_regioned_host_from_allowlist,
@@ -262,6 +263,23 @@ def test_get_account_identifier(mock_get_account):
             ],
             "myacct.x.y.z.snowflakecomputing.com",
         ),
+        # 4-part regioned host in the allowlist is also picked up — the
+        # broadened parser recognizes it, so it should be returned just
+        # like the 6-part case above.
+        (
+            [
+                {
+                    "host": "myorg-myacct.nonregioned.snowflakecomputing.com",
+                    "type": "SNOWFLAKE_DEPLOYMENT",
+                },
+                {
+                    "host": "myacct.us-east-1.snowflakecomputing.com",
+                    "type": "SNOWFLAKE_DEPLOYMENT",
+                },
+                {"type": "unrelated"},
+            ],
+            "myacct.us-east-1.snowflakecomputing.com",
+        ),
         (
             [
                 {"type": "unrelated"},
@@ -277,6 +295,18 @@ def test_guess_regioned_host_from_allowlist(allowlist, expected, mock_cursor):
         mock_cursor([{"SYSTEM$ALLOWLIST()": json.dumps(allowlist)}], []),
     )
     assert guess_regioned_host_from_allowlist(mock_conn) == expected
+
+
+@patch("snowflake.cli._plugins.connection.util.guess_regioned_host_from_allowlist")
+def test_get_region_parses_4_part_host_without_allowlist(
+    guess_regioned_host_from_allowlist,
+):
+    # The primary fix: a regioned 4-part host should resolve directly through
+    # get_host_region without ever needing the SYSTEM$ALLOWLIST fallback.
+    mock_conn = mock.MagicMock(spec=SnowflakeConnection)
+    mock_conn.host = "myacct.us-east-1.snowflakecomputing.com"
+    assert get_region(mock_conn) == "us-east-1"
+    guess_regioned_host_from_allowlist.assert_not_called()
 
 
 @patch("snowflake.cli._plugins.connection.util.is_regionless_redirect")
@@ -322,6 +352,10 @@ def test_get_context_local_non_regionless_gets_local_region(
         ("acct.us-central1.gcp.snowflakecomputing.com", "us-central1.gcp"),
         # 6-part regioned host (VPS / PrivateLink).
         ("account.x.us-west-2.aws.snowflakecomputing.com", "x.us-west-2.aws"),
+        # 6-part VPS host with a dashed account is unambiguously regioned (the
+        # regionless-alias collision only exists for 4- and 5-part hosts), so
+        # the dash in the account component must not suppress the parse.
+        ("acct-foo.x.us-west-2.aws.snowflakecomputing.com", "x.us-west-2.aws"),
         # Non-Snowsight hosts (internal/legacy zones) return None so callers fall back.
         ("test_account.az.int.snowflakecomputing.com", None),
         ("frozenweb.prod3.external-zone.snowflakecomputing.com", None),


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes [SNOW-3436033](https://snowflakecomputing.atlassian.net/browse/SNOW-3436033) / #2912. Supersedes #2925, which wrapped `action_get_url` in a try/except; this PR fixes the underlying parser instead so callers get the correct regioned Snowsight URL rather than the generic `https://app.snowflake.com` fallback.

#### Root cause

`get_host_region` in `src/snowflake/cli/_plugins/connection/util.py` only recognized the 6-part form `<account>.<x>.<y>.<z>.snowflakecomputing.com`. Production hosts come in several shapes:

| Host shape | Example | Previously | Now |
|---|---|---|---|
| 4-part | `acct.us-east-1.snowflakecomputing.com` | `None` → error | `us-east-1` |
| 5-part AWS | `acct.eu-central-1.aws.snowflakecomputing.com` | `None` → error | `eu-central-1.aws` |
| 5-part Azure | `acct.west-europe.azure.snowflakecomputing.com` | `None` → error | `west-europe.azure` |
| 5-part GCP | `acct.us-central1.gcp.snowflakecomputing.com` | `None` → error | `us-central1.gcp` |
| 6-part (VPS/PrivateLink) | `account.x.us-west-2.aws.snowflakecomputing.com` | `x.us-west-2.aws` | `x.us-west-2.aws` |
| Regionless alias | `org-acct.deployment.snowflakecomputing.com` | `None` | `None` (falls back to `SYSTEM$ALLOWLIST`) |
| `.local` | `some.dns.local` | `LOCAL_DEPLOYMENT_REGION` | `LOCAL_DEPLOYMENT_REGION` |

When `get_host_region` returned `None` for the 4- and 5-part shapes, `get_region` fell through to `guess_regioned_host_from_allowlist` and, if that also failed, raised `MissingConnectionRegionError`. That surfaced as a user-visible failure at the very end of `snow streamlit deploy`, *after* the Streamlit object had already been created — also affecting `snow streamlit get-url`, `snow app run`, and notebook URL emission.

#### The fix

Broaden `get_host_region` to extract the region token verbatim for all three shapes. This matches the regioned Snowsight URL format — `https://app.snowflake.com/<region>/<account>/...` where `<region>` is the same legacy region token that appears in the host — per the internal Regionless URLs design doc (Confluence `EN/825950361`) and the deployment configmaps (`region_identifier: att.us-east-1.aws` etc.). No rewriting to `aws-us-east-1` / `azure-<region>` / `gcp-<region>`: the token is reused as-is.

Regionless aliases (`<org>-<account>.<deployment>.snowflakecomputing.com`) are detected by the dash in the account component and still return `None`, preserving the existing fallback to `SYSTEM$ALLOWLIST` for region discovery.

#### Tests

`tests/test_utils.py`:

- `test_get_host_region` — added cases for 4-part (`us-east-1`), 5-part AWS/Azure/GCP, and kept the 6-part / local / regionless / internal-zone cases.
- `test_guess_regioned_host_from_allowlist` — the existing fixture `myacct.nonregioned.snowflakecomputing.com` was a stand-in for an "unparseable" host that relied on the broken parser. Changed it to `myorg-myacct.nonregioned.snowflakecomputing.com` so it remains unparseable under the new rules (dashed org means regionless) and the test keeps exercising the fall-through to the next allowlist entry.
- `test_get_context_non_regionless_uses_region` — same fix: `myacct.regionless.snowflakecomputing.com` → `myorg-myacct.regionless.snowflakecomputing.com`.

Local runs:

- `tests/test_utils.py` and `tests/streamlit/` — 133 passed
- `tests/test_connection.py`, `tests/apps/test_commands.py`, `tests/spcs/`, `tests/auth/test_oidc_providers.py` — 425 passed (these touch the other `get_host_region` / Snowsight-URL call paths)

[SNOW-3436033]: https://snowflakecomputing.atlassian.net/browse/SNOW-3436033