### PR TITLE
fix: honor --temporary-connection in `snow connection generate-jwt` (SNOW-3000366)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -112,6 +112,12 @@ class ConnectionContext:
         return self
 
     def update_from_config(self) -> ConnectionContext:
+        if self.temporary_connection:
+            # For temporary connections, all parameters come from CLI/env rather
+            # than a named connection in config.toml, so there is no config to merge.
+            self._config_loaded = True
+            return self
+
         connection_config = get_connection_dict(connection_name=self.connection_name)
         if "private_key_path" in connection_config:
             connection_config["private_key_file"] = connection_config[

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -72,6 +72,30 @@ def test_clone_connection_context():
         assert getattr(old_ctx, key) == "value"
 
 
+@mock.patch("snowflake.cli.api.connections.get_connection_dict")
+def test_update_from_config_skips_load_for_temporary_connection(
+    mock_get_connection_dict,
+):
+    """Regression test for SNOW-3000366: update_from_config must not look up
+    a named connection when temporary_connection is set, since there is
+    nothing to merge and get_connection_dict(None) raises."""
+    ctx = ConnectionContext(
+        temporary_connection=True,
+        account="acct",
+        user="user",
+        private_key_file="/key",
+    )
+
+    result = ctx.update_from_config()
+
+    assert result is ctx
+    mock_get_connection_dict.assert_not_called()
+    # Ensure the explicit fields are preserved unchanged
+    assert ctx.account == "acct"
+    assert ctx.user == "user"
+    assert ctx.private_key_file == "/key"
+
+
 @mock.patch("snowflake.connector.connect")
 @mock.patch("snowflake.cli._app.snow_connector.command_info")
 def test_connection_cache_caches(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1556,6 +1556,43 @@ def test_generate_jwt_honors_params(
     mocked_get_token.assert_called_once_with(**expected_params)
 
 
+@mock.patch(
+    "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
+)
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_generate_jwt_with_temporary_connection(
+    mocked_get_token, runner, named_temporary_file
+):
+    """Regression test for SNOW-3000366: --temporary-connection must not require
+    a configured connection in config.toml when generating a JWT."""
+    mocked_get_token.return_value = "funny token"
+
+    with named_temporary_file() as f:
+        f.write_text("secret from file")
+        result = runner.invoke(
+            [
+                "connection",
+                "generate-jwt",
+                "--temporary-connection",
+                "--authenticator",
+                "SNOWFLAKE_JWT",
+                "--user",
+                "FooBar",
+                "--account",
+                "account1",
+                "--private-key-file",
+                f,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Connection None is not configured" not in result.output
+    assert result.output == "funny token\n"
+    mocked_get_token.assert_called_once_with(
+        user="FooBar", account="account1", privatekey_path=str(f), key_password=None
+    )
+
+
 @pytest.mark.parametrize("attribute", ["account", "user", "private_key_file"])
 @mock.patch(
     "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
@@ -1599,6 +1636,34 @@ def test_generate_workload_identity_token(mock_create_attestation, runner):
     )
 
     assert result.exit_code == 0, result.output
+    assert "test-wif-token" in result.output
+    from snowflake.connector.wif_util import AttestationProvider
+
+    mock_create_attestation.assert_called_once_with(
+        provider=AttestationProvider.GCP, token=None
+    )
+
+
+@mock.patch("snowflake.connector.wif_util.create_attestation")
+def test_generate_workload_identity_token_with_temporary_connection(
+    mock_create_attestation, runner
+):
+    """Regression test for SNOW-3000366: --temporary-connection must not require
+    a configured connection in config.toml when generating a WIF token."""
+    mock_create_attestation.return_value = mock.MagicMock(credential="test-wif-token")
+
+    result = runner.invoke(
+        [
+            "connection",
+            "generate-workload-identity-token",
+            "--temporary-connection",
+            "--workload-identity-provider",
+            "GCP",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Connection None is not configured" not in result.output
     assert "test-wif-token" in result.output
     from snowflake.connector.wif_util import AttestationProvider
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes [SNOW-3000366](https://snowflakecomputing.atlassian.net/browse/SNOW-3000366) / [#2733](https://github.com/snowflakedb/snowflake-cli/issues/2733).

**Problem.** Running

```
snow connection generate-jwt --temporary-connection --authenticator SNOWFLAKE_JWT \
    --account myacct --user myuser --private-key-file key.pem
```

fails with `Connection None is not configured`, even though the user has supplied every parameter on the command line and explicitly opted into `--temporary-connection`.

**Root cause.** Both `connection generate-jwt` and `connection generate-workload-identity-token` call `get_cli_context().connection_context.update_from_config()` before reading parameters. That method unconditionally calls `get_connection_dict(connection_name=self.connection_name)`, which raises when `connection_name is None`. With `--temporary-connection`, no connection name is set, and there is nothing in `config.toml` to merge from anyway.

**Fix.** Short-circuit `ConnectionContext.update_from_config()` when `temporary_connection` is set — in that mode all parameters come from CLI / env, so there is no named connection to look up. `build_connection()` already has a dedicated branch for `temporary_connection`, so this makes `update_from_config()` match.

**Tests.** Added regression coverage at three levels:
- Unit: `ConnectionContext.update_from_config()` with `temporary_connection=True` must not call `get_connection_dict` and must preserve explicit field values.
- CLI (JWT): `snow connection generate-jwt --temporary-connection --user ... --account ... --private-key-file ...` succeeds and prints the token.
- CLI (WIF): `snow connection generate-workload-identity-token --temporary-connection --workload-identity-provider GCP` succeeds.

All existing tests in `tests/test_connection.py` (83) and `tests/api/test_connections.py` continue to pass.

[SNOW-3000366]: https://snowflakecomputing.atlassian.net/browse/SNOW-3000366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ