### PR TITLE
Fix SQL injection via single-quote escaping in util helpers (SNOW-3411343, SNOW-3416954)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 ## Fixes and improvements
 * Updated `snowflake-connector-python` to version 4.5.0.
 * Fixed macOS arm64 installer incorrectly requiring Rosetta 2. The `Distribution.xml` package metadata now declares `hostArchitectures="arm64,x86_64"`, so the installer is recognized as native on Apple Silicon.
+* Fixed SQL string literal escaping in `identifier_to_show_like_pattern` and `to_string_literal` to use Snowflake's standard single-quote doubling (`''`) instead of backslash escaping, which is not interpreted under the default `STANDARD_ESCAPE_SEQUENCES=FALSE` session setting. This closes SQL injection vectors through `SHOW ... LIKE` queries driven by a project-controlled `snowflake.yml` or `manifest.yml`.
 
 
 # v3.17.1

--- a/src/snowflake/cli/_plugins/stage/manager.py
+++ b/src/snowflake/cli/_plugins/stage/manager.py
@@ -299,7 +299,9 @@ class StageManager(SqlExecutionMixin):
         uri = f"file://{local_path}"
         if re.fullmatch(UNQUOTED_FILE_URI_REGEX, uri):
             return uri
-        return to_string_literal(uri)
+        # Snowflake's PUT/GET file-URI parser interprets `\` as an escape prefix
+        # even inside a string literal, so Windows paths need `\` doubled.
+        return to_string_literal(uri.replace("\\", "\\\\"))
 
     def list_files(
         self, stage_name: str | StagePath, pattern: str | None = None

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -175,12 +175,15 @@ def to_string_literal(raw_value: str) -> str:
     """
     Converts the raw string value to a correctly escaped, single-quoted string literal.
 
-    Uses Snowflake's standard single-quote doubling (``''``) to escape embedded single
-    quotes. Backslash escaping is not safe because Snowflake's default session parameter
-    ``STANDARD_ESCAPE_SEQUENCES=FALSE`` treats backslash as a literal character rather
-    than an escape prefix.
+    Single quotes are doubled (``''``), Snowflake's native quote escape. A backslash
+    that would otherwise sit immediately before our doubled ``''`` is itself doubled:
+    the connector's client-side ``split_statements`` always interprets ``\\'`` as an
+    escape pair when slicing input, so a raw ``\\`` in front of our ``''`` would
+    consume the first ``'`` and turn the rest of the payload into a second statement.
+    Non-quote-adjacent backslashes are left alone so LIKE-escape sequences (``\\%``,
+    ``\\_``) reach the server intact under the default ``STANDARD_ESCAPE_SEQUENCES=FALSE``.
     """
-    escaped = raw_value.replace("'", "''")
+    escaped = raw_value.replace("\\'", "\\\\'").replace("'", "''")
     return f"'{escaped}'"
 
 

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import codecs
 import os
 import re
 from typing import List, Optional
@@ -175,13 +174,13 @@ def is_valid_string_literal(literal: str) -> bool:
 def to_string_literal(raw_value: str) -> str:
     """
     Converts the raw string value to a correctly escaped, single-quoted string literal.
+
+    Uses Snowflake's standard single-quote doubling (``''``) to escape embedded single
+    quotes. Backslash escaping is not safe because Snowflake's default session parameter
+    ``STANDARD_ESCAPE_SEQUENCES=FALSE`` treats backslash as a literal character rather
+    than an escape prefix.
     """
-    # encode escape sequences
-    escaped = str(codecs.encode(raw_value, "unicode-escape"), "utf-8")
-
-    # escape single quotes
-    escaped = re.sub(r"^'|(?<!')'", r"\'", escaped)
-
+    escaped = raw_value.replace("'", "''")
     return f"'{escaped}'"
 
 
@@ -257,9 +256,12 @@ def escape_like_pattern(pattern: str, escape_sequence: str = r"\\") -> str:
 def identifier_to_show_like_pattern(identifier: str) -> str:
     """
     Takes an identifier and converts it into a pattern to be used with SHOW ... LIKE ... to get all rows with name
-    matching this identifier
+    matching this identifier.
+
+    Single quotes within the identifier are escaped via ``to_string_literal`` to prevent
+    the embedded quote from closing the SQL string literal (SQL injection).
     """
-    return f"'{escape_like_pattern(unquote_identifier(identifier))}'"
+    return to_string_literal(escape_like_pattern(unquote_identifier(identifier)))
 
 
 def append_test_resource_suffix(identifier: str) -> str:

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -708,8 +708,9 @@ class TestDatabaseExists:
 
         SnowflakeAppManager().database_exists("BAD'DB")
         query = mock_execute.call_args[0][0]
-        assert "BAD\\'DB" in query
-        assert "BAD'DB" not in query
+        # Single quotes are escaped by doubling them (''), not by backslash prefix.
+        assert "'BAD''DB'" in query
+        assert "BAD\\'DB" not in query
 
 
 class TestSchemaExists:
@@ -929,8 +930,11 @@ class TestSnowflakeAppManager:
         build_query = self._find_query(
             mock_execute.call_args_list, "SPCS_TEST_BUILD_APP_ARTIFACT_REPO"
         )
-        assert "app'injection" not in build_query
-        assert "app\\'injection" in build_query
+        # Single quotes are escaped by doubling (Snowflake's native escape mechanism);
+        # the raw payload 'app\'injection' must not appear as a literal unescaped quote.
+        assert "'app''injection'" in build_query
+        assert "app'injection'," not in build_query
+        assert "app'injection)" not in build_query
 
     def test_build_app_artifact_repo_requires_repo_and_app_id(self):
         stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
@@ -2751,8 +2755,9 @@ class TestRoleHasBindServiceEndpoint:
         mock_execute.return_value = cursor
         SnowflakeAppManager().role_has_bind_service_endpoint("BAD'ROLE")
         query = mock_execute.call_args[0][0]
-        assert "BAD\\'ROLE" in query
-        assert "BAD'ROLE" not in query
+        # Single quotes are escaped by doubling them (''), not by backslash prefix.
+        assert "'BAD''ROLE'" in query
+        assert "BAD\\'ROLE" not in query
 
 
 # ── Open CLI command tests ────────────────────────────────────────────

--- a/tests/nativeapp/codegen/snowpark/test_extension_function_utils.py
+++ b/tests/nativeapp/codegen/snowpark/test_extension_function_utils.py
@@ -116,6 +116,9 @@ def test_ensure_string_literal():
     # Unterminated leading/trailing single quotes are escaped by doubling ('').
     assert ef_utils.ensure_string_literal("'abc") == "'''abc'"
     assert ef_utils.ensure_string_literal("abc'") == "'abc'''"
+    # Regression guard: SINGLE_QUOTED_STRING_LITERAL_REGEX's '' alternation
+    # must keep this a valid literal so ensure_string_literal is idempotent.
+    assert ef_utils.ensure_string_literal("'abc''def'") == "'abc''def'"
 
 
 def test_ensure_all_string_literals():

--- a/tests/nativeapp/codegen/snowpark/test_extension_function_utils.py
+++ b/tests/nativeapp/codegen/snowpark/test_extension_function_utils.py
@@ -113,8 +113,9 @@ def test_ensure_string_literal():
     assert ef_utils.ensure_string_literal("abc") == "'abc'"
     assert ef_utils.ensure_string_literal("'abc'") == "'abc'"
     assert ef_utils.ensure_string_literal("'abc def'") == "'abc def'"
-    assert ef_utils.ensure_string_literal("'abc") == r"'\'abc'"
-    assert ef_utils.ensure_string_literal("abc'") == r"'abc\''"
+    # Unterminated leading/trailing single quotes are escaped by doubling ('').
+    assert ef_utils.ensure_string_literal("'abc") == "'''abc'"
+    assert ef_utils.ensure_string_literal("abc'") == "'abc'''"
 
 
 def test_ensure_all_string_literals():

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -265,11 +265,11 @@ def test_escape_like_pattern(raw_string, escaped):
         # must not close the SQL string literal. The embedded single quote is escaped
         # by being doubled ('') so the entire payload ends up as a harmless LIKE pattern.
         (
-            "\"stream'lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--\"",
+            '"stream\'lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--"',
             "'stream''lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--'",
         ),
         # A bare single quote in the identifier is doubled.
-        ("\"a'b\"", "'a''b'"),
+        ('"a\'b"', "'a''b'"),
         # Multiple embedded single quotes are each doubled.
         ("\"a'b'c\"", "'a''b''c'"),
     ],

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -209,11 +209,11 @@ def test_is_valid_string_literal(literal, valid):
     [
         ("abc", "'abc'"),
         # Single quotes escaped by doubling them (Snowflake's native escape mechanism).
-        # Backslash escaping is unsafe when STANDARD_ESCAPE_SEQUENCES=FALSE (the default).
         ("'abc'", "'''abc'''"),
         ("_aBc_$", "'_aBc_$'"),
         ('"abc"', "'\"abc\"'"),
-        # Non-quote characters (including control characters) are preserved verbatim.
+        # Non-quote characters (including control characters and bare backslashes)
+        # are preserved verbatim under STANDARD_ESCAPE_SEQUENCES=FALSE.
         ("a\bbc", "'a\bbc'"),
         ("a\fbc", "'a\fbc'"),
         ("a\nbc", "'a\nbc'"),
@@ -221,16 +221,25 @@ def test_is_valid_string_literal(literal, valid):
         ("a\tbc", "'a\tbc'"),
         ("a\vbc", "'a\vbc'"),
         ("\xf6", "'\xf6'"),
+        ("a\\b", "'a\\b'"),  # bare backslash passes through
+        ("C:\\Users\\RUNNER~1", "'C:\\Users\\RUNNER~1'"),
         ("'abc", "'''abc'"),  # leading unterminated single quote
         ("a'c", "'a''c'"),  # nested single quote
         ("abc'", "'abc'''"),  # trailing single quote
         ('a"bc', "'a\"bc'"),  # double quote
+        # Backslash immediately before a quote is doubled so the connector's
+        # client-side split_statements cannot consume our '' quote-doubling as
+        # an escape pair.
+        ("a\\'b", "'a\\\\''b'"),
         # SQL injection payloads are neutralised by quote-doubling.
         (
             "x'; GRANT ROLE ACCOUNTADMIN TO USER attacker; --",
             "'x''; GRANT ROLE ACCOUNTADMIN TO USER attacker; --'",
         ),
         ("'; DROP TABLE t; --", "'''; DROP TABLE t; --'"),
+        # Backslash-quote payload: the connector's splitter would otherwise treat
+        # \' as an escape pair and slice on the injected ;.
+        ("x\\';DROP TABLE t;--", "'x\\\\'';DROP TABLE t;--'"),
     ],
 )
 def test_to_string_literal(raw_string, literal):
@@ -272,6 +281,11 @@ def test_escape_like_pattern(raw_string, escaped):
         ('"a\'b"', "'a''b'"),
         # Multiple embedded single quotes are each doubled.
         ("\"a'b'c\"", "'a''b''c'"),
+        # Backslash-then-quote payload: the connector's client-side
+        # split_statements treats \' as an escape pair. Doubling the backslash
+        # (\\) keeps the '' quote-doubling effective and blocks statement
+        # slicing on the injected ';'.
+        ('"x\\\';DROP TABLE t;--"', "'x\\\\'';DROP TABLE t;--'"),
     ],
 )
 def test_identifier_to_show_like_pattern(identifier, expected):

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -20,6 +20,7 @@ from snowflake.cli.api.project.util import (
     concat_identifiers,
     escape_like_pattern,
     identifier_in_list,
+    identifier_to_show_like_pattern,
     identifier_to_str,
     is_valid_identifier,
     is_valid_object_name,
@@ -207,20 +208,29 @@ def test_is_valid_string_literal(literal, valid):
     "raw_string,literal",
     [
         ("abc", "'abc'"),
-        ("'abc'", r"'\'abc\''"),
+        # Single quotes escaped by doubling them (Snowflake's native escape mechanism).
+        # Backslash escaping is unsafe when STANDARD_ESCAPE_SEQUENCES=FALSE (the default).
+        ("'abc'", "'''abc'''"),
         ("_aBc_$", "'_aBc_$'"),
         ('"abc"', "'\"abc\"'"),
-        ("a\bbc", r"'a\x08bc'"),  # escape sequences
-        ("a\fbc", r"'a\x0cbc'"),
-        ("a\nbc", r"'a\nbc'"),
-        ("a\rbc", r"'a\rbc'"),
-        ("a\tbc", r"'a\tbc'"),
-        ("a\vbc", r"'a\x0bbc'"),
-        ("\xf6", r"'\xf6'"),  # unicode escapes
-        ("'abc", r"'\'abc'"),  # leading unterminated single quote
-        ("a'c", r"'a\'c'"),  # nested single quote
-        ("abc'", r"'abc\''"),  # trailing single quote
+        # Non-quote characters (including control characters) are preserved verbatim.
+        ("a\bbc", "'a\bbc'"),
+        ("a\fbc", "'a\fbc'"),
+        ("a\nbc", "'a\nbc'"),
+        ("a\rbc", "'a\rbc'"),
+        ("a\tbc", "'a\tbc'"),
+        ("a\vbc", "'a\vbc'"),
+        ("\xf6", "'\xf6'"),
+        ("'abc", "'''abc'"),  # leading unterminated single quote
+        ("a'c", "'a''c'"),  # nested single quote
+        ("abc'", "'abc'''"),  # trailing single quote
         ('a"bc', "'a\"bc'"),  # double quote
+        # SQL injection payloads are neutralised by quote-doubling.
+        (
+            "x'; GRANT ROLE ACCOUNTADMIN TO USER attacker; --",
+            "'x''; GRANT ROLE ACCOUNTADMIN TO USER attacker; --'",
+        ),
+        ("'; DROP TABLE t; --", "'''; DROP TABLE t; --'"),
     ],
 )
 def test_to_string_literal(raw_string, literal):
@@ -239,6 +249,33 @@ def test_to_string_literal(raw_string, literal):
 )
 def test_escape_like_pattern(raw_string, escaped):
     assert escape_like_pattern(raw_string) == escaped
+
+
+@pytest.mark.parametrize(
+    "identifier, expected",
+    [
+        # Unquoted identifiers are upper-cased by unquote_identifier, then wrapped.
+        ("streamlit", "'STREAMLIT'"),
+        ("my_table", "'MY\\\\_TABLE'"),
+        # Quoted identifiers preserve case and special chars, with LIKE wildcards escaped.
+        ('"streamlit"', "'streamlit'"),
+        ('"my_table"', "'my\\\\_table'"),
+        ('"pct%table"', "'pct\\\\%table'"),
+        # Regression for SNOW-3411343: a quoted identifier containing a single quote
+        # must not close the SQL string literal. The embedded single quote is escaped
+        # by being doubled ('') so the entire payload ends up as a harmless LIKE pattern.
+        (
+            "\"stream'lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--\"",
+            "'stream''lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--'",
+        ),
+        # A bare single quote in the identifier is doubled.
+        ("\"a'b\"", "'a''b'"),
+        # Multiple embedded single quotes are each doubled.
+        ("\"a'b'c\"", "'a''b''c'"),
+    ],
+)
+def test_identifier_to_show_like_pattern(identifier, expected):
+    assert identifier_to_show_like_pattern(identifier) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -307,6 +307,26 @@ def test_stage_copy_local_to_remote_quoted_path(
     )
 
 
+@pytest.mark.parametrize(
+    "local_path,expected_uri",
+    [
+        # Simple Windows path (no chars requiring a quoted literal) — backslashes
+        # are allowed by UNQUOTED_FILE_URI_REGEX, so returned bare.
+        ("C:\\Users\\dev\\tmp", "file://C:\\Users\\dev\\tmp"),
+        # Path with `~` forces a quoted literal. Backslashes must be doubled so
+        # Snowflake's file-URI parser sees the original path.
+        (
+            "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp4r6z_9uw",
+            "'file://C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\tmp4r6z_9uw'",
+        ),
+        # Space also forces a quoted literal; backslashes still need doubling.
+        ("C:\\My Files\\x", "'file://C:\\\\My Files\\\\x'"),
+    ],
+)
+def test_stage_manager_to_uri_escapes_backslashes(local_path, expected_uri):
+    assert StageManager()._to_uri(local_path) == expected_uri  # noqa: SLF001
+
+
 @mock.patch(f"{STAGE_MANAGER}.execute_query")
 def test_stage_copy_local_to_remote_star(mock_execute, runner, mock_cursor):
     mock_execute.return_value = mock_cursor(["row"], [])

--- a/tests/stage/test_stage.py
+++ b/tests/stage/test_stage.py
@@ -147,8 +147,8 @@ def test_stage_copy_remote_to_local_quoted_stage_recursive(
         ("{}/dest_?dir", "file://{}/dest_?dir/"),
         ("{}/dest%dir", "file://{}/dest%dir/"),
         ('{}/dest"dir', 'file://{}/dest"dir/'),
-        ("{}/dest'dir", r"'file://{}/dest\'dir/'"),
-        ("{}/dest\tdir", r"'file://{}/dest\tdir/'"),
+        ("{}/dest'dir", "'file://{}/dest''dir/'"),
+        ("{}/dest\tdir", "'file://{}/dest\tdir/'"),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}.execute_query")
@@ -179,8 +179,8 @@ def test_stage_copy_remote_to_local_quoted_uri(
         ("{}/dest_?dir", "file://{}/dest_?dir/"),
         ("{}/dest%dir", "file://{}/dest%dir/"),
         ('{}/dest"dir', 'file://{}/dest"dir/'),
-        ("{}/dest'dir", r"'file://{}/dest\'dir/'"),
-        ("{}/dest\tdir", r"'file://{}/dest\tdir/'"),
+        ("{}/dest'dir", "'file://{}/dest''dir/'"),
+        ("{}/dest\tdir", "'file://{}/dest\tdir/'"),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}.execute_query")
@@ -273,8 +273,8 @@ def test_stage_copy_local_to_remote_quoted_stage(mock_execute, runner, mock_curs
         ("{}/read_?me.md", "file://{}/read_?me.md"),
         ("{}/read%me.md", "file://{}/read%me.md"),
         ('{}/read"me.md', 'file://{}/read"me.md'),
-        ("{}/read'me.md", r"'file://{}/read\'me.md'"),
-        ("{}/read\tme.md", r"'file://{}/read\tme.md'"),
+        ("{}/read'me.md", "'file://{}/read''me.md'"),
+        ("{}/read\tme.md", "'file://{}/read\tme.md'"),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}.execute_query")
@@ -976,8 +976,8 @@ def test_stage_internal_put_quoted_stage(mock_execute, mock_cursor):
         ("{}/read_?me.md", "file://{}/read_?me.md"),
         ("{}/read%me.md", "file://{}/read%me.md"),
         ('{}/read"me.md', 'file://{}/read"me.md'),
-        ("{}/read'me.md", r"'file://{}/read\'me.md'"),
-        ("{}/read\tme.md", r"'file://{}/read\tme.md'"),
+        ("{}/read'me.md", "'file://{}/read''me.md'"),
+        ("{}/read\tme.md", "'file://{}/read\tme.md'"),
     ],
 )
 @mock.patch(f"{STAGE_MANAGER}.execute_query")

--- a/tests_integration/test_object.py
+++ b/tests_integration/test_object.py
@@ -16,6 +16,8 @@ from unittest import mock
 
 import pytest
 
+from snowflake.cli.api.project.util import identifier_to_show_like_pattern
+
 from tests_integration.test_utils import row_from_cursor
 from tests_integration.testing_utils.naming_utils import ObjectNameProvider
 
@@ -522,3 +524,27 @@ def test_drop_without_if_exists_fails_for_nonexistent_object(runner, test_databa
     )
     assert result.exit_code == 1, result.output
     assert "does not exist" in result.output.lower()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "payload_identifier",
+    [
+        '"stream\'lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--"',
+        '"a\'b"',
+        # Backslash must not start an escape under the default
+        # STANDARD_ESCAPE_SEQUENCES=FALSE session setting.
+        '"x\\\';DROP TABLE t;--"',
+    ],
+)
+def test_show_like_rejects_sql_injection_payload(
+    snowflake_session, test_database, payload_identifier
+):
+    """Server-side check that '' escaping in identifier_to_show_like_pattern is
+    treated as data by Snowflake. A broken escape would either raise or split
+    on the injected ';' and execute the chained GRANT/DROP.
+    """
+    pattern = identifier_to_show_like_pattern(payload_identifier)
+    cursors = snowflake_session.execute_string(f"show streamlits like {pattern}")
+    assert len(cursors) == 1
+    assert row_from_cursor(cursors[0]) == []


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes two related SQL injection findings in `src/snowflake/cli/api/project/util.py`:

**SNOW-3411343** — `identifier_to_show_like_pattern()` wrapped the escaped identifier in a bare `f"'{...}'"`. `unquote_identifier()` strips only the outer `"`-delimiters and preserves embedded `'` verbatim, and `escape_like_pattern()` only escapes `%`/`_`. A quoted identifier such as `"stream'lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--"` read from a malicious `snowflake.yml` would emit:

```
show streamlits like 'stream'lit); GRANT ROLE ACCOUNTADMIN TO USER attacker;--'
```

`execute_stream` splits on `;`, so the `GRANT` runs as a second statement under the victim's session role. This protects all five call sites — `sql_execution.show_specific_object`, `sf_sql_facade` stage existence / generic show, `application_package` version query, `apps/manager` image repository lookup.

**SNOW-3416954** — `to_string_literal()` escaped single quotes with a backslash (`\'`). Snowflake's default `STANDARD_ESCAPE_SEQUENCES=FALSE` treats `\` as a literal character, so `'x\';` is parsed as the literal `'x\'` followed by `; GRANT ...` — the same vulnerability on the `snow app version create` / `add-patch` flow via `manifest.yml` `version.label`.

**Fix:** both helpers now use Snowflake's standard single-quote doubling (`''`). `identifier_to_show_like_pattern` delegates to the fixed `to_string_literal`, so the SHOW-LIKE fix automatically tracks the string-literal helper. This avoids `codecs.encode(..., \"unicode-escape\")`, but the old behaviour of encoding control characters into `\xNN` / `\n` etc. was itself unsound under `STANDARD_ESCAPE_SEQUENCES=FALSE` — treating non-quote bytes as literal is the correct behaviour. Tests updated to reflect the new canonical encoding.

### Links

- Jira: [SNOW-3411343](https://snowflakecomputing.atlassian.net/browse/SNOW-3411343), [SNOW-3416954](https://snowflakecomputing.atlassian.net/browse/SNOW-3416954)
- CWE-89: Improper Neutralization of Special Elements used in an SQL Command
- Related (separate fix): [SNOW-3392936](https://snowflakecomputing.atlassian.net/browse/SNOW-3392936) — `FQN.sql_identifier` uses `IDENTIFIER(...)` wrapper, different sink.

[SNOW-3411343]: https://snowflakecomputing.atlassian.net/browse/SNOW-3411343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ