### PR TITLE
fix: [SNOW-2208961] coerce boolean env-var connection overrides

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,7 @@
 * Fixed `snow connection list` crashing with `AttributeError` when `config.toml` contains a scalar value directly under `[connections]`. Such entries are now skipped with a warning so valid connections are still listed.
 * Fixed SQL injection via `FQN.sql_identifier`.
 * Fixed Snowsight URL generation (used by `snow streamlit deploy`, `snow streamlit get-url`, `snow app run`, `snow notebook`, and similar commands) for accounts whose host is 4-part (e.g. `<account>.us-east-1.snowflakecomputing.com`) or 5-part with a cloud suffix (e.g. `<account>.<region>.aws.snowflakecomputing.com`). These hosts now resolve to the correct regioned Snowsight URL instead of raising `"host (...) was missing or not in the expected format"`.
+* Fixed boolean connection parameters (`client_store_temporary_credential`, `oauth_disable_pkce`, `oauth_enable_refresh_tokens`, `oauth_enable_single_use_refresh_tokens`) being passed to the connector as raw strings when supplied via `SNOWFLAKE_*` or `SNOWFLAKE_CONNECTIONS_<name>_*` environment variables. Values like `false` / `0` are now correctly interpreted as `False` rather than truthy strings.
 
 
 # v3.17.1

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -45,6 +45,7 @@ from snowflake.cli.api.exceptions import (
 from snowflake.cli.api.feature_flags import FeatureFlag
 from snowflake.cli.api.secret import SecretType
 from snowflake.cli.api.secure_path import SecurePath
+from snowflake.cli.api.utils.types import try_cast_to_bool
 from snowflake.connector import SnowflakeConnection
 from snowflake.connector.auth.workload_identity import ApiFederatedAuthenticationType
 from snowflake.connector.errors import DatabaseError, ForbiddenError
@@ -98,6 +99,18 @@ CONNECTION_KEY_ALIASES = {
     "private_key_file_pwd": "private_key_passphrase",
 }
 
+# Env overrides that must be coerced to bool. Env vars arrive as strings; the
+# connector only warns on type mismatch and otherwise uses truthiness, so
+# `SNOWFLAKE_*=false` would incorrectly behave as True without coercion.
+_BOOLEAN_ENV_OVERRIDE_KEYS = frozenset(
+    {
+        "oauth_disable_pkce",
+        "oauth_enable_refresh_tokens",
+        "oauth_enable_single_use_refresh_tokens",
+        "client_store_temporary_credential",
+    }
+)
+
 
 class _BufferedMirrorStream(io.StringIO):
     """Buffer connector chatter while optionally mirroring to another stream."""
@@ -130,6 +143,21 @@ def _resolve_alias(key_or_alias: str):
     Given the key of an override / env var, what key should it be set as in the connection parameters?
     """
     return CONNECTION_KEY_ALIASES.get(key_or_alias, key_or_alias)
+
+
+def _coerce_boolean_parameter(connection_key: str, value):
+    if connection_key not in _BOOLEAN_ENV_OVERRIDE_KEYS or isinstance(value, bool):
+        return value
+    try:
+        return try_cast_to_bool(value)
+    except ValueError:
+        log.warning(
+            "Expected boolean-compatible value for %s but got %r; "
+            "using raw value without conversion.",
+            connection_key,
+            value,
+        )
+        return value
 
 
 def _build_silent_streams(
@@ -199,6 +227,15 @@ def connect_to_snowflake(
         connection_key = _resolve_alias(key)
         if connection_key not in connection_parameters and generic_env_value:
             connection_parameters[connection_key] = generic_env_value
+
+    # Coerce string booleans to real bools for parameters the connector expects
+    # as bool. Connection-specific env vars and TOML strings reach this point
+    # as strings, and the connector only warns on type mismatches — so
+    # `SNOWFLAKE_*=false` would pass through as truthy without coercion.
+    for connection_key in list(connection_parameters):
+        connection_parameters[connection_key] = _coerce_boolean_parameter(
+            connection_key, connection_parameters[connection_key]
+        )
 
     # Clean up connection params
     connection_parameters = {

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -131,10 +131,10 @@ def test_oauth_from_env_variables(mock_connect, runner, config_file):
         oauth_token_request_url="https://localhost:8000/token",
         oauth_redirect_uri="http://localhost:8001/snowflake/oauth-redirect",
         oauth_scope="session:role:PUBLIC",
-        oauth_disable_pkce="True",
-        oauth_enable_refresh_tokens="True",
-        oauth_enable_single_use_refresh_tokens="True",
-        client_store_temporary_credential="True",
+        oauth_disable_pkce=True,
+        oauth_enable_refresh_tokens=True,
+        oauth_enable_single_use_refresh_tokens=True,
+        client_store_temporary_credential=True,
     )
 
 
@@ -169,8 +169,33 @@ def test_oauth_from_env_variables_and_temporary_connection(mock_connect, runner)
         oauth_token_request_url="https://localhost:8000/token",
         oauth_redirect_uri="http://localhost:8001/snowflake/oauth-redirect",
         oauth_scope="session:role:PUBLIC",
-        oauth_disable_pkce="True",
-        oauth_enable_refresh_tokens="True",
-        oauth_enable_single_use_refresh_tokens="True",
-        client_store_temporary_credential="True",
+        oauth_disable_pkce=True,
+        oauth_enable_refresh_tokens=True,
+        oauth_enable_single_use_refresh_tokens=True,
+        client_store_temporary_credential=True,
     )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "SNOWFLAKE_AUTHENTICATOR": "externalbrowser",
+        "SNOWFLAKE_CLIENT_STORE_TEMPORARY_CREDENTIAL": "false",
+        "SNOWFLAKE_OAUTH_DISABLE_PKCE": "0",
+        "SNOWFLAKE_OAUTH_ENABLE_REFRESH_TOKENS": "False",
+        "SNOWFLAKE_OAUTH_ENABLE_SINGLE_USE_REFRESH_TOKENS": "false",
+    },
+    clear=True,
+)
+@mock.patch("snowflake.connector.connect")
+def test_boolean_env_overrides_coerce_falsy_values(mock_connect, runner):
+    """Regression test for #2495: env-var boolean values must be coerced so
+    that "false"/"0" do not pass through as truthy strings to the connector.
+    """
+    runner.invoke(["sql", "-q", "select 1", "-x", "--account", "acct"])
+
+    _, kwargs = mock_connect.call_args
+    assert kwargs["client_store_temporary_credential"] is False
+    assert kwargs["oauth_disable_pkce"] is False
+    assert kwargs["oauth_enable_refresh_tokens"] is False
+    assert kwargs["oauth_enable_single_use_refresh_tokens"] is False


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Closes #2495 / SNOW-2208961.

Boolean connection parameters passed via `SNOWFLAKE_*` or `SNOWFLAKE_CONNECTIONS_<name>_*` environment variables were reaching `snowflake.connector.connect` as raw strings, while the matching CLI flags produced proper Python bools. The connector only warns on type mismatch for these parameters and then evaluates them via truthiness, so values like `false` / `0` were being treated as `True` (non-empty strings are truthy). This reproduces the user report in #2495 where `SNOWFLAKE_CLIENT_STORE_TEMPORARY_CREDENTIAL=true` worked by accident, but turning it off with `=false` would not work as expected.

**Fix**: Normalize the four known boolean connection params after all override sources (flag / connection / env) have been merged in `connect_to_snowflake`, using the existing `try_cast_to_bool` helper. Keys handled:
- `client_store_temporary_credential`
- `oauth_disable_pkce`
- `oauth_enable_refresh_tokens`
- `oauth_enable_single_use_refresh_tokens`

This mirrors the `_BOOLEAN_ENV_CONFIG_KEYS` + `_coerce_env_value` logic that already exists in `src/snowflake/cli/api/config_ng/sources.py`, keeping behavior consistent between the two config subsystems.

**Tests**:
- Updated the two existing `test_oauth.py` env-var tests to assert real `bool` values (the prior assertions documented the buggy behavior by pinning the expected value to `"True"` strings).
- Added a regression test covering the falsy case (`false` / `0` / `False`) so a future regression on the falsy path can't slip through truthiness checks.