### PR TITLE
fix: support private_key_file_pwd in connections.toml (SNOW-3012806)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## Fixes and improvements
 * Fixed macOS arm64 installer incorrectly requiring Rosetta 2. The `Distribution.xml` package metadata now declares `hostArchitectures="arm64,x86_64"`, so the installer is recognized as native on Apple Silicon.
+* Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -68,6 +68,8 @@ SUPPORTED_ENV_OVERRIDES = [
     "workload_identity_provider",
     "private_key_file",
     "private_key_path",
+    "private_key_file_pwd",
+    "private_key_passphrase",
     "private_key_raw",
     "database",
     "schema",
@@ -91,7 +93,12 @@ SUPPORTED_ENV_OVERRIDES = [
 ]
 
 # mapping of found key -> key to set
-CONNECTION_KEY_ALIASES = {"private_key_path": "private_key_file"}
+CONNECTION_KEY_ALIASES = {
+    "private_key_path": "private_key_file",
+    # `private_key_file_pwd` is the name used by the snowflake-connector-python
+    # TOML config; we normalize it to the CLI-native `private_key_passphrase`.
+    "private_key_file_pwd": "private_key_passphrase",
+}
 
 
 class _BufferedMirrorStream(io.StringIO):
@@ -308,9 +315,13 @@ def _load_private_key(connection_parameters: Dict, private_key_var_name: str) ->
         private_key_pem = _load_pem_from_file(
             connection_parameters[private_key_var_name]
         )
-        private_key = _load_pem_to_der(private_key_pem)
+        private_key = _load_pem_to_der(
+            private_key_pem,
+            config_passphrase=connection_parameters.get("private_key_passphrase"),
+        )
         connection_parameters["private_key"] = private_key.value
         del connection_parameters[private_key_var_name]
+        connection_parameters.pop("private_key_passphrase", None)
     else:
         raise CliError(
             "Private Key authentication requires authenticator set to SNOWFLAKE_JWT"
@@ -324,9 +335,13 @@ def _load_private_key_from_parameters(
         private_key_pem = _load_pem_from_parameters(
             connection_parameters[private_key_var_name]
         )
-        private_key = _load_pem_to_der(private_key_pem)
+        private_key = _load_pem_to_der(
+            private_key_pem,
+            config_passphrase=connection_parameters.get("private_key_passphrase"),
+        )
         connection_parameters["private_key"] = private_key.value
         del connection_parameters[private_key_var_name]
+        connection_parameters.pop("private_key_passphrase", None)
     else:
         raise CliError(
             "Private Key authentication requires authenticator set to SNOWFLAKE_JWT"
@@ -363,8 +378,9 @@ def _load_pem_from_parameters(private_key_raw: str) -> SecretType:
 def _validate_passphrase(passphrase: SecretType) -> None:
     if passphrase.value is None:
         raise CliError(
-            "Encrypted private key, you must provide the "
-            "passphrase in the environment variable PRIVATE_KEY_PASSPHRASE."
+            "Encrypted private key, you must provide the passphrase via the "
+            "`private_key_file_pwd` key in your connection config or the "
+            "`PRIVATE_KEY_PASSPHRASE` environment variable."
         )
     if passphrase.value == "":
         raise CliError(
@@ -373,12 +389,18 @@ def _validate_passphrase(passphrase: SecretType) -> None:
         )
 
 
-def _load_pem_to_der(private_key_pem: SecretType) -> SecretType:
+def _load_pem_to_der(
+    private_key_pem: SecretType, config_passphrase: Optional[str] = None
+) -> SecretType:
     """
     Given a private key file path (in PEM format), decode key data into DER
-    format
+    format. ``PRIVATE_KEY_PASSPHRASE`` takes precedence over ``config_passphrase``
+    (from ``private_key_file_pwd`` / ``private_key_passphrase`` in the
+    connection config) so existing setups keep working.
     """
-    private_key_passphrase = SecretType(os.getenv("PRIVATE_KEY_PASSPHRASE", None))
+    env_passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE")
+    resolved_passphrase = env_passphrase if env_passphrase is not None else config_passphrase
+    private_key_passphrase = SecretType(resolved_passphrase)
 
     if private_key_pem.value.startswith(ENCRYPTED_PKCS8_PK_HEADER):
         _validate_passphrase(private_key_passphrase)

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -399,7 +399,9 @@ def _load_pem_to_der(
     connection config) so existing setups keep working.
     """
     env_passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE")
-    resolved_passphrase = env_passphrase if env_passphrase is not None else config_passphrase
+    resolved_passphrase = (
+        env_passphrase if env_passphrase is not None else config_passphrase
+    )
     private_key_passphrase = SecretType(resolved_passphrase)
 
     if private_key_pem.value.startswith(ENCRYPTED_PKCS8_PK_HEADER):

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -68,8 +68,6 @@ SUPPORTED_ENV_OVERRIDES = [
     "workload_identity_provider",
     "private_key_file",
     "private_key_path",
-    "private_key_file_pwd",
-    "private_key_passphrase",
     "private_key_raw",
     "database",
     "schema",
@@ -317,7 +315,7 @@ def _load_private_key(connection_parameters: Dict, private_key_var_name: str) ->
         )
         private_key = _load_pem_to_der(
             private_key_pem,
-            config_passphrase=connection_parameters.get("private_key_passphrase"),
+            passphrase=connection_parameters.get("private_key_passphrase"),
         )
         connection_parameters["private_key"] = private_key.value
         del connection_parameters[private_key_var_name]
@@ -337,7 +335,7 @@ def _load_private_key_from_parameters(
         )
         private_key = _load_pem_to_der(
             private_key_pem,
-            config_passphrase=connection_parameters.get("private_key_passphrase"),
+            passphrase=connection_parameters.get("private_key_passphrase"),
         )
         connection_parameters["private_key"] = private_key.value
         del connection_parameters[private_key_var_name]
@@ -390,30 +388,29 @@ def _validate_passphrase(passphrase: SecretType) -> None:
 
 
 def _load_pem_to_der(
-    private_key_pem: SecretType, config_passphrase: Optional[str] = None
+    private_key_pem: SecretType, passphrase: Optional[str] = None
 ) -> SecretType:
     """
     Given a private key file path (in PEM format), decode key data into DER
-    format. ``PRIVATE_KEY_PASSPHRASE`` takes precedence over ``config_passphrase``
-    (from ``private_key_file_pwd`` / ``private_key_passphrase`` in the
-    connection config) so existing setups keep working.
+    format. The ``PRIVATE_KEY_PASSPHRASE`` env var takes precedence over the
+    ``passphrase`` argument (sourced from ``private_key_file_pwd`` /
+    ``private_key_passphrase`` in the connection config) so existing setups
+    keep working.
     """
     env_passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE")
-    resolved_passphrase = (
-        env_passphrase if env_passphrase is not None else config_passphrase
-    )
-    private_key_passphrase = SecretType(resolved_passphrase)
+    resolved_passphrase = env_passphrase if env_passphrase is not None else passphrase
+    passphrase_secret = SecretType(resolved_passphrase)
 
     if private_key_pem.value.startswith(ENCRYPTED_PKCS8_PK_HEADER):
-        _validate_passphrase(private_key_passphrase)
+        _validate_passphrase(passphrase_secret)
     elif private_key_pem.value.startswith(UNENCRYPTED_PKCS8_PK_HEADER):
-        private_key_passphrase = SecretType(None)
+        passphrase_secret = SecretType(None)
     else:
         raise CliError(
             "Private key provided is not in PKCS#8 format. Please use correct format."
         )
 
-    return prepare_private_key(private_key_pem, private_key_passphrase)
+    return prepare_private_key(private_key_pem, passphrase_secret)
 
 
 def prepare_private_key(

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -445,7 +445,15 @@ def generate_jwt(
     if not connection_details.private_key_file:
         raise UsageError(msq_template.format("Private key file"))
 
-    passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE", None)
+    # `PRIVATE_KEY_PASSPHRASE` env var takes precedence over the config-sourced
+    # `private_key_passphrase` (populated from `private_key_file_pwd` or
+    # `private_key_passphrase` in connections.toml) for back-compat.
+    env_passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE")
+    passphrase = (
+        env_passphrase
+        if env_passphrase is not None
+        else connection_details.private_key_passphrase
+    )
 
     def _decrypt(passphrase: str | None):
         return connector.auth.get_token_from_private_key(

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -96,6 +96,9 @@ FEATURE_FLAGS_SECTION_PATH = [CLI_SECTION, "features"]
 LEGACY_OAUTH_PKCE_KEY: Literal["oatuh_enable_pkce"] = "oatuh_enable_pkce"
 LEGACY_CONNECTION_SETTING_ALIASES: Final[dict[str, str]] = {
     LEGACY_OAUTH_PKCE_KEY: "oauth_enable_pkce",
+    # `private_key_file_pwd` is the name supported by snowflake-connector-python
+    # in connections.toml; normalize it to the CLI-native `private_key_passphrase`.
+    "private_key_file_pwd": "private_key_passphrase",
 }
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -914,6 +914,66 @@ def test_key_pair_authentication_from_config(
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
+@pytest.mark.parametrize(
+    "passphrase_key", ["private_key_file_pwd", "private_key_passphrase"]
+)
+@mock.patch("snowflake.connector.connect")
+def test_key_pair_authentication_passphrase_from_config(
+    mock_connector, mock_ctx, runner, passphrase_key
+):
+    """SNOW-3012806: encrypted private key files work when the passphrase is
+    stored in connections.toml (under `private_key_file_pwd` or
+    `private_key_passphrase`), without PRIVATE_KEY_PASSPHRASE set."""
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    passphrase = "from-config-pass"
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    encrypted_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(
+            passphrase.encode("utf-8")
+        ),
+    )
+    expected_der = serialization.load_pem_private_key(
+        encrypted_pem, passphrase.encode("utf-8"), default_backend()
+    ).private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    with NamedTemporaryFile("wb", suffix=".p8") as pk_file:
+        pk_file.write(encrypted_pem)
+        pk_file.flush()
+
+        connection_details = {
+            "account": "my_account",
+            "user": "jdoe",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": pk_file.name,
+            passphrase_key: passphrase,
+        }
+        data = tomlkit.dumps({"connections": {"jwt": connection_details}})
+
+        with NamedTemporaryFile("w+", suffix=".toml") as toml_file:
+            toml_file.write(data)
+            toml_file.flush()
+            result = runner.invoke_with_config_file(
+                toml_file.name,
+                ["object", "list", "warehouse", "-c", "jwt"],
+            )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_connector.call_args.kwargs
+    assert kwargs["private_key"] == expected_der
+    # Config passphrase and its alias must not leak into connector kwargs.
+    assert "private_key_file_pwd" not in kwargs
+    assert "private_key_passphrase" not in kwargs
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_key_pair_authentication_no_passphrase_error(
     mock_ctx, temporary_directory, runner
 ):
@@ -1492,6 +1552,89 @@ def test_generate_jwt_with_pass_phrase_from_env(
     assert result.output == "funny token\n"
     mocked_get_token.assert_called_once_with(
         user="FooBar", account="account1", privatekey_path=str(f), key_password="123"
+    )
+
+
+@pytest.mark.parametrize(
+    "passphrase_key", ["private_key_file_pwd", "private_key_passphrase"]
+)
+@mock.patch.dict(os.environ, {}, clear=True)
+@mock.patch(
+    "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
+)
+def test_generate_jwt_with_pass_phrase_from_config(
+    mocked_get_token, runner, named_temporary_file, passphrase_key
+):
+    """SNOW-3012806: generate-jwt reads the passphrase from
+    `private_key_file_pwd` (connector-python name) or `private_key_passphrase`
+    (CLI-native) in connections.toml when the env var is not set."""
+    mocked_get_token.return_value = "funny token"
+
+    with named_temporary_file() as f:
+        f.write_text("secret from file")
+        connection_details = {
+            "account": "account1",
+            "user": "FooBar",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": str(f),
+            passphrase_key: "from-config",
+        }
+        data = tomlkit.dumps({"connections": {"jwt": connection_details}})
+
+        with NamedTemporaryFile("w+", suffix="toml") as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            result = runner.invoke_with_config_file(
+                tmp_file.name,
+                ["connection", "generate-jwt", "-c", "jwt"],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "funny token\n"
+    mocked_get_token.assert_called_once_with(
+        user="FooBar",
+        account="account1",
+        privatekey_path=str(f),
+        key_password="from-config",
+    )
+
+
+@mock.patch.dict(os.environ, {"PRIVATE_KEY_PASSPHRASE": "from-env"}, clear=True)
+@mock.patch(
+    "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
+)
+def test_generate_jwt_env_passphrase_takes_precedence_over_config(
+    mocked_get_token, runner, named_temporary_file
+):
+    """PRIVATE_KEY_PASSPHRASE continues to win over the config-sourced
+    passphrase so existing setups are not broken by SNOW-3012806."""
+    mocked_get_token.return_value = "funny token"
+
+    with named_temporary_file() as f:
+        f.write_text("secret from file")
+        connection_details = {
+            "account": "account1",
+            "user": "FooBar",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": str(f),
+            "private_key_file_pwd": "from-config",
+        }
+        data = tomlkit.dumps({"connections": {"jwt": connection_details}})
+
+        with NamedTemporaryFile("w+", suffix="toml") as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            result = runner.invoke_with_config_file(
+                tmp_file.name,
+                ["connection", "generate-jwt", "-c", "jwt"],
+            )
+
+    assert result.exit_code == 0, result.output
+    mocked_get_token.assert_called_once_with(
+        user="FooBar",
+        account="account1",
+        privatekey_path=str(f),
+        key_password="from-env",
     )
 
 

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -182,7 +182,7 @@ def test_private_key_loading_and_aliases(
         )
         if expected_private_key_file_value is not None:
             mock_load_pem_from_file.assert_called_with(expected_private_key_file_value)
-            mock_load_pem_to_der.assert_called_with(key, config_passphrase=None)
+            mock_load_pem_to_der.assert_called_with(key, passphrase=None)
 
 
 @mock.patch.dict(os.environ, {}, clear=True)

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -182,7 +182,7 @@ def test_private_key_loading_and_aliases(
         )
         if expected_private_key_file_value is not None:
             mock_load_pem_from_file.assert_called_with(expected_private_key_file_value)
-            mock_load_pem_to_der.assert_called_with(key)
+            mock_load_pem_to_der.assert_called_with(key, config_passphrase=None)
 
 
 @mock.patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes https://github.com/snowflakedb/snowflake-cli/issues/2738 / SNOW-3012806.

`snowflake-connector-python` supports storing the private-key passphrase in `connections.toml` under `private_key_file_pwd`, but Snowflake CLI ignored that field and only read `PRIVATE_KEY_PASSPHRASE` from the environment. A user whose connector-python config already worked would hit:

> Encrypted private key, you must provide the passphrase in the environment variable PRIVATE_KEY_PASSPHRASE.

and be forced to also set an env var. This PR makes the CLI read the passphrase from `connections.toml` while keeping the env var as a precedence override so existing setups are not broken.

**What the fix does**

- **TOML alias** (`src/snowflake/cli/api/config.py`): `LEGACY_CONNECTION_SETTING_ALIASES` now maps `private_key_file_pwd` → `private_key_passphrase`, so entries in `connections.toml` populate the existing CLI-native field used throughout the codebase (`ConnectionContext.private_key_passphrase`).
- **Connector-override alias** (`src/snowflake/cli/_app/snow_connector.py`): `CONNECTION_KEY_ALIASES` gets the same mapping so `--private-key-file-pwd`-style overrides and env vars are normalized.
- **Env-var surface**: Both `private_key_file_pwd` and `private_key_passphrase` added to `SUPPORTED_ENV_OVERRIDES`, so `SNOWFLAKE_PRIVATE_KEY_FILE_PWD` and `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` work as expected.
- **Private-key loading** (`_load_pem_to_der`): accepts an optional `config_passphrase` parameter. Resolution order: `PRIVATE_KEY_PASSPHRASE` env var (wins for back-compat) → config passphrase → error.
- **`snow connection generate-jwt`**: same precedence logic (env var → config-sourced `connection_details.private_key_passphrase` → interactive prompt).
- **Leak guard**: `connection_parameters.pop(\"private_key_passphrase\", None)` after key loading so the passphrase does not leak into `snowflake.connector.connect(**kwargs)`.
- **Error message** updated to mention both the config key and the env var.
- **Masking**: no code change needed — `mask_sensitive_value` already masks any key containing `passphrase` or `pwd`.

**Tests added (`tests/test_connection.py`):**

- `test_key_pair_authentication_passphrase_from_config` — parametrized over `private_key_file_pwd` and `private_key_passphrase`; writes a real encrypted PKCS#8 key, loads via config, asserts the DER the connector receives matches what `load_pem_private_key` produces with the correct passphrase, and that neither alias leaks into connector kwargs.
- `test_generate_jwt_with_pass_phrase_from_config` — parametrized over both aliases; asserts `generate-jwt` passes the config-sourced passphrase to `get_token_from_private_key`.
- `test_generate_jwt_env_passphrase_takes_precedence_over_config` — sets both env var and config, asserts env wins.

Full `tests/test_connection.py` (88 tests) and `tests/test_config.py` (80 tests) pass locally.

### Related

- Issue: #2738
- Jira: SNOW-3012806