### PR TITLE
feat: [SNOW-1998955] add --force flag to `snow spcs service drop`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@
 
 ## New additions
 * Added a `--secondary-roles` option (plus matching `SNOWFLAKE_SECONDARY_ROLES` env var and `secondary_roles` config key) to `snow connection add` and the global connection overrides. The value is forwarded to `snowflake-connector-python` and accepts `ALL` or `NONE`, so sessions can be pinned to the primary role without running an extra `USE SECONDARY ROLES` statement.
+* Added `--force` flag to `snow spcs service drop` to allow dropping services that contain block storage volumes.
 
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).

--- a/src/snowflake/cli/_plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/_plugins/spcs/services/commands.py
@@ -39,6 +39,7 @@ from snowflake.cli._plugins.stage.manager import StageManager
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.decorators import with_project_definition
 from snowflake.cli.api.commands.flags import (
+    IfExistsOption,
     IfNotExistsOption,
     OverrideableOption,
     entity_argument,
@@ -177,7 +178,30 @@ add_object_command_aliases(
         help_example='`list --like "my%"` lists all services that begin with “my”.'
     ),
     scope_option=scope_option(help_example="`list --in compute-pool my_pool`"),
+    ommit_commands=["drop"],
 )
+
+
+@app.command(requires_connection=True)
+def drop(
+    name: FQN = ServiceNameArgument,
+    if_exists: bool = IfExistsOption(),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Drops the service along with any block storage volumes it contains. Without this flag, dropping a service that contains block storage volumes fails.",
+        is_flag=True,
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Drops a service.
+    """
+    return SingleQueryResult(
+        ServiceManager().drop(
+            service_name=name.sql_identifier, if_exists=if_exists, force=force
+        )
+    )
 
 
 @app.command(requires_connection=True)

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -711,6 +711,15 @@ class ServiceManager(SqlExecutionMixin):
     def resume(self, service_name: str):
         return self.execute_query(f"alter service {service_name} resume")
 
+    def drop(
+        self, service_name: str, if_exists: bool = False, force: bool = False
+    ) -> SnowflakeCursor:
+        if_exists_clause = " if exists" if if_exists else ""
+        force_clause = " force" if force else ""
+        return self.execute_query(
+            f"drop service{if_exists_clause} {service_name}{force_clause}"
+        )
+
     def set_property(
         self,
         service_name: str,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -19082,7 +19082,7 @@
                                                                                   
    Usage: root spcs service drop [OPTIONS] NAME                                   
                                                                                   
-   Drops service with given name.                                                 
+   Drops a service.                                                               
                                                                                   
   +- Arguments ------------------------------------------------------------------+
   | *    name      TEXT  Identifier of the service; for example: my_service      |
@@ -19091,6 +19091,9 @@
   +- Options --------------------------------------------------------------------+
   | --if-exists            Only apply this operation if the specified object     |
   |                        exists.                                               |
+  | --force                Drops the service along with any block storage        |
+  |                        volumes it contains. Without this flag, dropping a    |
+  |                        service that contains block storage volumes fails.    |
   | --help       -h        Show this message and exit.                           |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
@@ -21397,7 +21400,7 @@
   | deploy            Deploys a service defined in the project                   |
   |                   definition file.                                           |
   | describe          Provides description of service.                           |
-  | drop              Drops service with given name.                             |
+  | drop              Drops a service.                                           |
   | execute-job       Creates and executes a job service in the                  |
   |                   current schema.                                            |
   | list              Lists all available services.                              |
@@ -24857,7 +24860,7 @@
   | deploy            Deploys a service defined in the project                   |
   |                   definition file.                                           |
   | describe          Provides description of service.                           |
-  | drop              Drops service with given name.                             |
+  | drop              Drops a service.                                           |
   | execute-job       Creates and executes a job service in the                  |
   |                   current schema.                                            |
   | list              Lists all available services.                              |

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -1550,6 +1550,71 @@ def test_resume_cli(mock_resume, mock_cursor, runner):
     assert "Statement executed successfully" in result.output
 
 
+@pytest.mark.parametrize(
+    "if_exists, force, expected_query",
+    [
+        (False, False, "drop service test_service"),
+        (True, False, "drop service if exists test_service"),
+        (False, True, "drop service test_service force"),
+        (True, True, "drop service if exists test_service force"),
+    ],
+)
+@patch(EXECUTE_QUERY)
+def test_drop(mock_execute_query, if_exists, force, expected_query):
+    service_name = "test_service"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    result = ServiceManager().drop(
+        service_name=service_name, if_exists=if_exists, force=force
+    )
+    mock_execute_query.assert_called_once_with(expected_query)
+    assert result == cursor
+
+
+@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager.drop")
+def test_drop_cli_default(mock_drop, mock_cursor, runner):
+    service_name = "test_service"
+    cursor = mock_cursor(
+        rows=[["Statement executed successfully."]], columns=["status"]
+    )
+    mock_drop.return_value = cursor
+    result = runner.invoke(["spcs", "service", "drop", service_name])
+    assert result.exit_code == 0, result.output
+    mock_drop.assert_called_once_with(
+        service_name=f"IDENTIFIER('{service_name}')", if_exists=False, force=False
+    )
+
+
+@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager.drop")
+def test_drop_cli_force(mock_drop, mock_cursor, runner):
+    service_name = "test_service"
+    cursor = mock_cursor(
+        rows=[["Statement executed successfully."]], columns=["status"]
+    )
+    mock_drop.return_value = cursor
+    result = runner.invoke(["spcs", "service", "drop", service_name, "--force"])
+    assert result.exit_code == 0, result.output
+    mock_drop.assert_called_once_with(
+        service_name=f"IDENTIFIER('{service_name}')", if_exists=False, force=True
+    )
+
+
+@patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager.drop")
+def test_drop_cli_if_exists_and_force(mock_drop, mock_cursor, runner):
+    service_name = "test_service"
+    cursor = mock_cursor(
+        rows=[["Statement executed successfully."]], columns=["status"]
+    )
+    mock_drop.return_value = cursor
+    result = runner.invoke(
+        ["spcs", "service", "drop", service_name, "--if-exists", "--force"]
+    )
+    assert result.exit_code == 0, result.output
+    mock_drop.assert_called_once_with(
+        service_name=f"IDENTIFIER('{service_name}')", if_exists=True, force=True
+    )
+
+
 @patch(EXECUTE_QUERY)
 def test_set_property(mock_execute_query):
     service_name = "test_service"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Jira: [SNOW-1998955](https://snowflakecomputing.atlassian.net/browse/SNOW-1998955)

Exposes the Snowflake SQL `DROP SERVICE ... FORCE` syntax via a new `--force` flag on `snow spcs service drop`. This flag is required to drop a service that contains block storage volumes; without it, the server rejects the drop.

**What changed**
- `ServiceManager.drop(service_name, if_exists=False, force=False)` issues `drop service [if exists] <name> [force]`.
- A service-specific `snow spcs service drop` command replaces the generic-alias version, adding `--if-exists` and `--force`. Generic alias is omitted via `ommit_commands=["drop"]`.
- `snow object drop service NAME` still produces the same SQL (`drop service IDENTIFIER('NAME')`) and remains covered by `test_command_aliases`.

**Tests**
- Parametrized `ServiceManager.drop()` unit tests cover all four combinations of `if_exists`/`force`.
- New CLI tests cover default, `--force`, and `--if-exists --force` invocations.
- `test_command_aliases[drop-parameters3]` continues to pass, verifying backward compatibility of the generic object path.

**Usage**
```
snow spcs service drop MY_SERVICE --force
snow spcs service drop MY_SERVICE --if-exists --force
```

[SNOW-1998955]: https://snowflakecomputing.atlassian.net/browse/SNOW-1998955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ