### PR TITLE
Snowflake Apps: fix open command to use URL from DESCRIBE

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -557,14 +557,13 @@ def snowflake_app_deploy(
         return d.get("status", "").upper() == "FAILED"
 
     def _url_is_ready(d: dict) -> bool:
-        url = d.get("url", "")
-        return bool(url) and "provisioning in progress" not in url.lower()
+        return manager.resolve_application_service_url_from_describe(d) is not None
 
     if did_upgrade:
         cli_console.step("Waiting for upgrade to complete...")
         desc = _poll_until(
             poll_fn=lambda: manager.describe_app_service(service_fqn),
-            is_done=lambda d: not _svc_is_upgrading(d) and _url_is_ready(d),
+            is_done=_url_is_ready,
             is_error=_svc_has_failed,
             format_status=lambda d: ("upgrading" if _svc_is_upgrading(d) else "ready"),
             timeout_message=(
@@ -585,9 +584,12 @@ def snowflake_app_deploy(
             ),
         )
 
-    endpoint_url = desc.get("url", "")
-    if endpoint_url and not endpoint_url.startswith(("http://", "https://")):
-        endpoint_url = f"https://{endpoint_url}"
+    endpoint_url = manager.resolve_application_service_url_from_describe(desc)
+    if not endpoint_url:
+        raise CliError(
+            "Application service URL is not available after deploy. "
+            f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
+        )
     return MessageResult(f"App ready at {endpoint_url}")
 
 

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -533,18 +533,12 @@ class SnowflakeAppManager(SqlExecutionMixin):
             url = f"https://{url}"
         return url
 
-    def get_service_endpoint_url(
-        self, service_fqn: FQN, endpoint_name: str = "app-endpoint"
-    ) -> Optional[str]:
+    def get_service_endpoint_url(self, service_fqn: FQN) -> Optional[str]:
         """Get the public URL for an application service.
 
         Uses ``DESCRIBE APPLICATION SERVICE`` (same source as the deploy wait
-        loop), not ``SHOW ENDPOINTS``.
-
-        The *endpoint_name* argument is kept for backwards compatibility and is
-        ignored: the URL is taken from the describe result's ``url`` column.
+        loop): the ``url`` column from the describe result.
         """
-        _ = endpoint_name
         desc = self.describe_app_service(service_fqn)
         return self.resolve_application_service_url_from_describe(desc)
 

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -513,25 +513,40 @@ class SnowflakeAppManager(SqlExecutionMixin):
         row = cursor.fetchone()
         return row[0] if row else ""
 
+    def resolve_application_service_url_from_describe(
+        self, desc: Dict[str, Any]
+    ) -> Optional[str]:
+        """Return a browser-ready URL from :meth:`describe_app_service` output.
+
+        Returns *None* when the row is empty, the service is upgrading, the URL
+        is missing, or the URL is still the *provisioning* placeholder. Otherwise
+        returns the ``url`` value with an ``https://`` prefix when needed.
+        """
+        if not desc:
+            return None
+        if str(desc.get("is_upgrading", "")).lower() in ("true", "1", "yes"):
+            return None
+        url = (desc.get("url") or "").strip()
+        if not url or "provisioning in progress" in url.lower():
+            return None
+        if not url.startswith(("http://", "https://")):
+            url = f"https://{url}"
+        return url
+
     def get_service_endpoint_url(
         self, service_fqn: FQN, endpoint_name: str = "app-endpoint"
     ) -> Optional[str]:
-        """Get the ingress URL for an application service endpoint."""
-        cursor = self.execute_query(
-            f"SHOW ENDPOINTS IN APPLICATION SERVICE {service_fqn.identifier}",
-            cursor_class=DictCursor,
-        )
-        for row in cursor:
-            if row["name"].upper() == endpoint_name.upper():
-                url = row["ingress_url"]
-                if (
-                    url
-                    and not url.startswith(("http://", "https://"))
-                    and "provisioning in progress" not in url.lower()
-                ):
-                    url = f"https://{url}"
-                return url
-        return None
+        """Get the public URL for an application service.
+
+        Uses ``DESCRIBE APPLICATION SERVICE`` (same source as the deploy wait
+        loop), not ``SHOW ENDPOINTS``.
+
+        The *endpoint_name* argument is kept for backwards compatibility and is
+        ignored: the URL is taken from the describe result's ``url`` column.
+        """
+        _ = endpoint_name
+        desc = self.describe_app_service(service_fqn)
+        return self.resolve_application_service_url_from_describe(desc)
 
     def fetch_snow_apps_parameters(self) -> Dict[str, str]:
         """Fetch SnowApps default parameters for the current user.

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -657,6 +657,34 @@ class TestSnowflakeAppManager:
         desc = SnowflakeAppManager().describe_app_service(fqn)
         assert desc == {}
 
+    def test_resolve_application_service_url_from_describe(self):
+        mgr = SnowflakeAppManager()
+        assert mgr.resolve_application_service_url_from_describe({}) is None
+        assert (
+            mgr.resolve_application_service_url_from_describe(
+                {"url": "x.snowflakecomputing.app", "is_upgrading": "false"}
+            )
+            == "https://x.snowflakecomputing.app"
+        )
+        assert (
+            mgr.resolve_application_service_url_from_describe(
+                {"url": "https://x.snowflakecomputing.app", "is_upgrading": "false"}
+            )
+            == "https://x.snowflakecomputing.app"
+        )
+        assert (
+            mgr.resolve_application_service_url_from_describe(
+                {"url": "", "is_upgrading": "false"}
+            )
+            is None
+        )
+        assert (
+            mgr.resolve_application_service_url_from_describe(
+                {"url": "x.app", "is_upgrading": "true"}
+            )
+            is None
+        )
+
     @patch(EXECUTE_QUERY)
     def test_get_build_status_done(self, mock_execute):
         cursor = Mock()
@@ -799,16 +827,10 @@ class TestSnowflakeAppManager:
     @patch(EXECUTE_QUERY)
     def test_get_service_endpoint_url(self, mock_execute):
         cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "name": "app-endpoint",
-                        "ingress_url": "https://my-endpoint.snowflakecomputing.app",
-                    }
-                ]
-            )
-        )
+        cursor.fetchone.return_value = {
+            "url": "https://my-endpoint.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
@@ -816,23 +838,16 @@ class TestSnowflakeAppManager:
         assert url == "https://my-endpoint.snowflakecomputing.app"
         mock_execute.assert_called_once()
         assert (
-            mock_execute.call_args[0][0]
-            == "SHOW ENDPOINTS IN APPLICATION SERVICE DB.SCHEMA.SVC"
+            mock_execute.call_args[0][0] == "DESCRIBE APPLICATION SERVICE DB.SCHEMA.SVC"
         )
 
     @patch(EXECUTE_QUERY)
     def test_get_service_endpoint_url_adds_https_prefix(self, mock_execute):
         cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "name": "app-endpoint",
-                        "ingress_url": "my-endpoint.snowflakecomputing.app",
-                    }
-                ]
-            )
-        )
+        cursor.fetchone.return_value = {
+            "url": "my-endpoint.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
@@ -842,7 +857,7 @@ class TestSnowflakeAppManager:
     @patch(EXECUTE_QUERY)
     def test_get_service_endpoint_url_not_found(self, mock_execute):
         cursor = Mock()
-        cursor.__iter__ = Mock(return_value=iter([]))
+        cursor.fetchone.return_value = None
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
@@ -850,29 +865,34 @@ class TestSnowflakeAppManager:
         assert url is None
         mock_execute.assert_called_once()
         assert (
-            "SHOW ENDPOINTS IN APPLICATION SERVICE DB.SCHEMA.SVC"
-            in mock_execute.call_args[0][0]
+            "DESCRIBE APPLICATION SERVICE DB.SCHEMA.SVC" in mock_execute.call_args[0][0]
         )
 
     @patch(EXECUTE_QUERY)
     def test_get_service_endpoint_url_provisioning_in_progress(self, mock_execute):
         cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "name": "app-endpoint",
-                        "ingress_url": "Provisioning in progress... check back later",
-                    }
-                ]
-            )
-        )
+        cursor.fetchone.return_value = {
+            "url": "Provisioning in progress... check back later",
+            "is_upgrading": "false",
+        }
         mock_execute.return_value = cursor
 
         fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
         url = SnowflakeAppManager().get_service_endpoint_url(fqn)
-        assert url == "Provisioning in progress... check back later"
-        assert not url.startswith("https://")
+        assert url is None
+
+    @patch(EXECUTE_QUERY)
+    def test_get_service_endpoint_url_while_upgrading(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "true",
+        }
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="SVC")
+        url = SnowflakeAppManager().get_service_endpoint_url(fqn)
+        assert url is None
 
 
 # ── fetch_snow_apps_parameters tests ──────────────────────────────────
@@ -2552,6 +2572,10 @@ class TestDeployCommand:
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
             "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
         )
         mock_poll.side_effect = [
             "DONE",  # build status poll


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Snowflake Apps Deploy `snow app open` used the legacy `SHOW ENDPOINTS` SQL for SPCS services. Instead, we need to reuse the same DESCRIBE-based URL logic as deploy.
