### PR TITLE
fix: [SNOW-3417058] guard `snow snowpark build` against zip-slip in wheels

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Hardened wheel extraction during `snow snowpark build` against zip-slip: wheel archives whose entries resolve outside the extraction directory are now rejected with a clear error instead of writing files to arbitrary paths on disk.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/snowpark/models.py
+++ b/src/snowflake/cli/_plugins/snowpark/models.py
@@ -20,7 +20,29 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
+from click.exceptions import ClickException
 from requirements import requirement
+
+
+class UnsafeWheelEntryError(ClickException):
+    """Raised when a wheel archive contains an entry that would extract
+    outside of the extraction destination (a zip-slip attack)."""
+
+    def __init__(self, wheel_path: Path, member_name: str, destination: Path):
+        super().__init__(
+            f"Refusing to extract wheel '{wheel_path}': entry '{member_name}' "
+            f"would be written outside of '{destination}'. The wheel may be "
+            "malicious or corrupt."
+        )
+
+
+def _is_within_destination(member_path: Path, destination: Path) -> bool:
+    """Check that `member_path` would land inside `destination` once resolved."""
+    try:
+        member_path.resolve(strict=False).relative_to(destination)
+        return True
+    except ValueError:
+        return False
 
 
 class Requirement(requirement.Requirement):
@@ -79,8 +101,22 @@ class RequirementWithWheel:
     wheel_path: Path | None
 
     def extract_files(self, destination: Path) -> None:
-        if self.wheel_path is not None:
-            zipfile.ZipFile(self.wheel_path).extractall(destination)
+        if self.wheel_path is None:
+            return
+        # Validate every entry before extracting to guard against zip-slip
+        # attacks: a malicious wheel can contain paths like `../../etc/foo`
+        # that would write arbitrary files outside of `destination`.
+        # `zipfile.extractall` on Python 3.10/3.11 performs no such check,
+        # and the Python 3.12+ `filter=` argument is opt-in.
+        destination_root = Path(destination).resolve()
+        with zipfile.ZipFile(self.wheel_path) as zf:
+            for member in zf.infolist():
+                member_path = destination_root / member.filename
+                if not _is_within_destination(member_path, destination_root):
+                    raise UnsafeWheelEntryError(
+                        self.wheel_path, member.filename, destination_root
+                    )
+            zf.extractall(destination)
 
     def namelist(self) -> List[str]:
         if self.wheel_path is None:

--- a/tests/snowpark/test_models.py
+++ b/tests/snowpark/test_models.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import zipfile
-from pathlib import Path
 
 import pytest
 from snowflake.cli._plugins.snowpark.models import (

--- a/tests/snowpark/test_models.py
+++ b/tests/snowpark/test_models.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import zipfile
+from pathlib import Path
+
 import pytest
 from snowflake.cli._plugins.snowpark.models import (
     Requirement,
+    RequirementWithWheel,
+    UnsafeWheelEntryError,
     WheelMetadata,
     get_package_name,
 )
@@ -86,6 +91,124 @@ def test_wheel_metadata_parsing(test_root_path):
         assert meta.name == "zendesk"
         assert meta.wheel_path == wheel_path.path
         assert meta.dependencies == ["httplib2", "simplejson"]
+
+
+def _make_wheel(wheel_path, members):
+    """Write a .whl file with the given members (name -> bytes).
+    Paths are written verbatim with ZIP_STORED so traversal sequences
+    like '../../evil' are preserved."""
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_STORED) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+
+def test_extract_files_is_a_noop_when_wheel_path_is_none(tmp_path):
+    destination = tmp_path / "dest"
+    destination.mkdir()
+
+    RequirementWithWheel(
+        requirement=Requirement.parse_line("foo"),
+        wheel_path=None,
+    ).extract_files(destination)
+
+    assert list(destination.iterdir()) == []
+
+
+def test_extract_files_extracts_safe_wheel(tmp_path):
+    wheel_path = tmp_path / "safe-1.0-py3-none-any.whl"
+    _make_wheel(
+        wheel_path,
+        {
+            "safe/__init__.py": b"",
+            "safe/module.py": b"x = 1\n",
+        },
+    )
+    destination = tmp_path / "dest"
+    destination.mkdir()
+
+    RequirementWithWheel(
+        requirement=Requirement.parse_line("safe"),
+        wheel_path=wheel_path,
+    ).extract_files(destination)
+
+    assert (destination / "safe" / "__init__.py").exists()
+    assert (destination / "safe" / "module.py").read_text() == "x = 1\n"
+
+
+@pytest.mark.parametrize(
+    "malicious_member",
+    [
+        "../evil.py",
+        "../../evil.py",
+        "subdir/../../evil.py",
+    ],
+)
+def test_extract_files_rejects_zip_slip_relative_paths(tmp_path, malicious_member):
+    wheel_path = tmp_path / "evil-1.0-py3-none-any.whl"
+    _make_wheel(
+        wheel_path,
+        {
+            "evil/__init__.py": b"",
+            malicious_member: b"pwned\n",
+        },
+    )
+    destination = tmp_path / "dest"
+    destination.mkdir()
+
+    with pytest.raises(UnsafeWheelEntryError) as exc_info:
+        RequirementWithWheel(
+            requirement=Requirement.parse_line("evil"),
+            wheel_path=wheel_path,
+        ).extract_files(destination)
+
+    assert malicious_member in str(exc_info.value)
+    # Ensure nothing leaked outside the destination.
+    assert not (tmp_path / "evil.py").exists()
+
+
+def test_extract_files_rejects_absolute_path_entry(tmp_path):
+    wheel_path = tmp_path / "evil-1.0-py3-none-any.whl"
+    outside = tmp_path / "outside.txt"
+    _make_wheel(
+        wheel_path,
+        {
+            "evil/__init__.py": b"",
+            str(outside): b"pwned\n",
+        },
+    )
+    destination = tmp_path / "dest"
+    destination.mkdir()
+
+    with pytest.raises(UnsafeWheelEntryError):
+        RequirementWithWheel(
+            requirement=Requirement.parse_line("evil"),
+            wheel_path=wheel_path,
+        ).extract_files(destination)
+
+    assert not outside.exists()
+
+
+def test_extract_files_aborts_before_writing_any_file(tmp_path):
+    """The validation pass must run to completion before any file is written,
+    so a wheel that mixes safe and unsafe entries leaves the destination clean."""
+    wheel_path = tmp_path / "mixed-1.0-py3-none-any.whl"
+    _make_wheel(
+        wheel_path,
+        {
+            "mixed/safe.py": b"ok\n",
+            "../evil.py": b"pwned\n",
+        },
+    )
+    destination = tmp_path / "dest"
+    destination.mkdir()
+
+    with pytest.raises(UnsafeWheelEntryError):
+        RequirementWithWheel(
+            requirement=Requirement.parse_line("mixed"),
+            wheel_path=wheel_path,
+        ).extract_files(destination)
+
+    assert list(destination.iterdir()) == []
 
 
 def test_raise_error_when_artifact_contains_asterix(


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

**Ticket:** [SNOW-3417058](https://snowflakecomputing.atlassian.net/browse/SNOW-3417058) — *HIGH — Zip Slip Vulnerability in Wheel File Extraction*

#### The bug

`snow snowpark build` downloads dependency wheels with `pip wheel` and then extracts each `.whl` into the build directory via `RequirementWithWheel.extract_files`:

```python
def extract_files(self, destination: Path) -> None:
    if self.wheel_path is not None:
        zipfile.ZipFile(self.wheel_path).extractall(destination)
```

`zipfile.extractall` on Python 3.10 and 3.11 performs **no** path validation, and the hardening filter introduced in Python 3.12 (`extractall(filter=...)`) is **opt-in**. A malicious or corrupt wheel containing entries like `../../etc/something` or an absolute path would be written wherever the process has write permission — the classic **zip-slip** pattern (CWE-22).

#### The fix

Before calling `extractall`, walk `ZipFile.infolist()` and for each member verify that `(destination / member.filename).resolve()` is contained within the resolved destination. If any entry escapes, raise `UnsafeWheelEntryError` and abort — *before* writing any file, so a wheel that mixes safe and unsafe entries leaves the destination clean.

Containment is checked with `Path.resolve(strict=False).relative_to(destination)`, which correctly handles `..` segments and absolute paths regardless of platform.

#### Tests

New unit tests in `tests/snowpark/test_models.py` that build crafted wheels with `zipfile.ZipFile(..., 'w', ZIP_STORED)` and `writestr` (so traversal sequences are preserved verbatim):

* `test_extract_files_is_a_noop_when_wheel_path_is_none`
* `test_extract_files_extracts_safe_wheel` — legitimate wheels still extract
* `test_extract_files_rejects_zip_slip_relative_paths` — parametrized over `../evil.py`, `../../evil.py`, `subdir/../../evil.py`
* `test_extract_files_rejects_absolute_path_entry`
* `test_extract_files_aborts_before_writing_any_file` — safe + unsafe mix leaves destination empty

All 21 tests in `tests/snowpark/test_models.py` pass locally.

[SNOW-3417058]: https://snowflakecomputing.atlassian.net/browse/SNOW-3417058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ