### PR TITLE
fix: [SNOW-3417002] escape $$ in SPCS service spec to prevent SQL injection

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,6 +43,9 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed SQL injection in `snow spcs service create`, `execute-job`, and `upgrade` where a `$$` sequence in a YAML spec file could break out of the dollar-quoted SQL literal and execute arbitrary SQL with the caller's session privileges. `$$` sequences in spec content are now neutralized before the spec is embedded in SQL.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,6 +32,7 @@
 * Fixed SQL injection via `FQN.sql_identifier`.
 * Fixed Snowsight URL generation (used by `snow streamlit deploy`, `snow streamlit get-url`, `snow app run`, `snow notebook`, and similar commands) for accounts whose host is 4-part (e.g. `<account>.us-east-1.snowflakecomputing.com`) or 5-part with a cloud suffix (e.g. `<account>.<region>.aws.snowflakecomputing.com`). These hosts now resolve to the correct regioned Snowsight URL instead of raising `"host (...) was missing or not in the expected format"`.
 * Fixed boolean connection parameters (`client_store_temporary_credential`, `oauth_disable_pkce`, `oauth_enable_refresh_tokens`, `oauth_enable_single_use_refresh_tokens`) being passed to the connector as raw strings when supplied via `SNOWFLAKE_*` or `SNOWFLAKE_CONNECTIONS_<name>_*` environment variables. Values like `false` / `0` are now correctly interpreted as `False` rather than truthy strings.
+* Fixed SQL injection in `snow spcs service create`, `execute-job`, and `upgrade` where a `$$` sequence in a YAML spec file could break out of the dollar-quoted SQL literal and execute arbitrary SQL with the caller's session privileges. `$$` sequences in spec content are now neutralized before the spec is embedded in SQL.
 
 
 # v3.17.1
@@ -43,9 +44,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* Fixed SQL injection in `snow spcs service create`, `execute-job`, and `upgrade` where a `$$` sequence in a YAML spec file could break out of the dollar-quoted SQL literal and execute arbitrary SQL with the caller's session privileges. `$$` sequences in spec content are now neutralized before the spec is embedded in SQL.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -403,7 +403,7 @@ class ServiceManager(SqlExecutionMixin):
             }
         }
 
-        spec_json = json.dumps(spec)
+        spec_json = self._serialize_spec(spec)
 
         return self._execute_job_service(
             job_service_name=job_service_name,
@@ -417,7 +417,14 @@ class ServiceManager(SqlExecutionMixin):
         # TODO(aivanou): Add validation towards schema
         with SecurePath(path).open("r", read_file_limit_mb=DEFAULT_SIZE_LIMIT_MB) as fh:
             data = yaml.safe_load(fh)
-        return json.dumps(data)
+        return self._serialize_spec(data)
+
+    @staticmethod
+    def _serialize_spec(data) -> str:
+        # The returned JSON is embedded inside $$...$$ dollar-quoted SQL
+        # literals; json.dumps does not escape $, so a spec value containing
+        # $$ would close the literal early and allow SQL injection.
+        return json.dumps(data).replace("$$", "$ $")
 
     def status(self, service_name: str) -> SnowflakeCursor:
         return self.execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -425,10 +425,12 @@ class ServiceManager(SqlExecutionMixin):
         # The returned JSON is embedded inside $$...$$ dollar-quoted SQL
         # literals; json.dumps does not escape $, so any run of two or more
         # $ in spec content would close the literal early and allow SQL
-        # injection. Break up every adjacent $$ pair — this handles runs of
-        # any length ($$, $$$, $$$$, ...) without mutating legitimate
-        # single-$ values.
-        return re.sub(r"\$(?=\$)", "$ ", json.dumps(data))
+        # injection. Replace each $ that is followed by another $ with its
+        # JSON unicode escape — this handles runs of any length
+        # ($$, $$$, $$$$, ...) without mutating legitimate single-$ values,
+        # and the server-side JSON parser decodes the escape back to $ so
+        # spec values reach Snowflake unchanged.
+        return re.sub(r"\$(?=\$)", r"\\u0024", json.dumps(data))
 
     def status(self, service_name: str) -> SnowflakeCursor:
         return self.execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import re
 import time
 from datetime import datetime
 from pathlib import Path
@@ -422,9 +423,12 @@ class ServiceManager(SqlExecutionMixin):
     @staticmethod
     def _serialize_spec(data) -> str:
         # The returned JSON is embedded inside $$...$$ dollar-quoted SQL
-        # literals; json.dumps does not escape $, so a spec value containing
-        # $$ would close the literal early and allow SQL injection.
-        return json.dumps(data).replace("$$", "$ $")
+        # literals; json.dumps does not escape $, so any run of two or more
+        # $ in spec content would close the literal early and allow SQL
+        # injection. Break up every adjacent $$ pair — this handles runs of
+        # any length ($$, $$$, $$$$, ...) without mutating legitimate
+        # single-$ values.
+        return re.sub(r"\$(?=\$)", "$ ", json.dumps(data))
 
     def status(self, service_name: str) -> SnowflakeCursor:
         return self.execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -1351,6 +1351,99 @@ def test_read_yaml(temporary_directory):
     assert result == json.dumps(SPEC_DICT)
 
 
+def test_read_yaml_escapes_dollar_quote_breakout(temporary_directory):
+    # A spec value containing $$ must not be passed through verbatim:
+    # the JSON is later embedded inside $$...$$ SQL literals by
+    # create(), _execute_job_service(), and upgrade_spec(), and an unescaped
+    # $$ in spec content would close the literal and allow injected SQL.
+    tmp_dir = Path(temporary_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            """
+            spec:
+                containers:
+                - name: main
+                  image: /db/repo:tag
+                  env:
+                    PAYLOAD: "$$ ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
+            """
+        )
+    )
+    result = ServiceManager()._read_yaml(spec_path)  # noqa: SLF001
+    assert "$$" not in result
+    assert "$ $" in result
+
+
+@pytest.mark.parametrize(
+    "method_name,query_fragment",
+    [
+        ("create", "FROM SPECIFICATION $$"),
+        ("execute_job", "FROM SPECIFICATION $$"),
+        ("upgrade_spec", "from specification $$"),
+    ],
+)
+@patch(EXECUTE_QUERY)
+def test_service_spec_dollar_quote_not_broken_out(
+    mock_execute_query, temporary_directory, method_name, query_fragment
+):
+    # End-to-end check: a spec value containing $$ must not appear verbatim
+    # inside the generated SQL, otherwise the dollar-quoted literal is
+    # terminated early and the rest is parsed as SQL.
+    tmp_dir = Path(temporary_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            """
+            spec:
+                containers:
+                - name: main
+                  image: /db/repo:tag
+                  env:
+                    PAYLOAD: "$$ ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
+            """
+        )
+    )
+
+    if method_name == "create":
+        ServiceManager().create(
+            service_name="svc",
+            compute_pool="pool",
+            spec_path=spec_path,
+            min_instances=1,
+            max_instances=1,
+            auto_resume=True,
+            external_access_integrations=None,
+            query_warehouse=None,
+            tags=None,
+            comment=None,
+            if_not_exists=False,
+        )
+    elif method_name == "execute_job":
+        mock_conn = Mock()
+        mock_conn.database = None
+        mock_conn.schema = None
+        ServiceManager(connection=mock_conn).execute_job(
+            job_service_name="svc",
+            compute_pool="pool",
+            spec_path=spec_path,
+            external_access_integrations=None,
+            query_warehouse=None,
+            comment=None,
+            async_mode=False,
+        )
+    else:
+        ServiceManager().upgrade_spec("svc", spec_path)
+
+    query = mock_execute_query.mock_calls[0].args[0]
+    # The spec is embedded inside $$...$$ — the only $$ occurrences in the
+    # final SQL must be the opening and closing delimiters, never inside the
+    # spec payload.
+    assert query.count("$$") == 2, query
+    assert "GRANT ROLE ACCOUNTADMIN" in query  # payload still present, just neutralized
+    assert query_fragment in query
+
+
 @patch(EXECUTE_QUERY)
 def test_upgrade_spec(mock_execute_query, temporary_directory):
     service_name = "test_service"

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -1366,7 +1366,9 @@ def test_read_yaml_escapes_dollar_quote_breakout(payload, temporary_directory):
     # A spec value containing two or more consecutive $ must not survive
     # verbatim: the JSON is later embedded inside $$...$$ SQL literals by
     # create(), _execute_job_service(), and upgrade_spec(), and any $$ in
-    # spec content would close the literal and allow injected SQL.
+    # spec content would close the literal and allow injected SQL. The
+    # escape uses JSON unicode sequences so a JSON-aware parser on the
+    # server side recovers the original spec value unchanged.
     tmp_dir = Path(temporary_directory)
     spec_path = tmp_dir / "spec.yml"
     spec_path.write_text(
@@ -1383,6 +1385,11 @@ def test_read_yaml_escapes_dollar_quote_breakout(payload, temporary_directory):
     )
     result = ServiceManager()._read_yaml(spec_path)  # noqa: SLF001
     assert "$$" not in result
+    # Round-trip: parsing the serialized JSON must yield the original
+    # payload with the $ run intact, otherwise we would silently corrupt
+    # legitimate spec values (env vars, passwords, etc.) that happen to
+    # contain $$.
+    assert json.loads(result)["spec"]["containers"][0]["env"]["PAYLOAD"] == payload
 
 
 def test_read_yaml_preserves_single_dollar(temporary_directory):
@@ -1481,6 +1488,12 @@ def test_service_spec_dollar_quote_not_broken_out(
     assert query.count("$$") == 2, query
     assert "GRANT ROLE ACCOUNTADMIN" in query  # payload still present, just neutralized
     assert query_fragment in query
+    # Fidelity check: the bytes between the two $$ delimiters parse back
+    # to the original payload string. The server side does the same JSON
+    # parse, so this is what Snowflake actually receives as the spec value.
+    spec_json = query[query.find("$$") + 2 : query.rfind("$$")].strip()
+    payload = json.loads(spec_json)["spec"]["containers"][0]["env"]["PAYLOAD"]
+    assert payload == f"{dollar_run} ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
 
 
 @patch(EXECUTE_QUERY)

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -1351,11 +1351,44 @@ def test_read_yaml(temporary_directory):
     assert result == json.dumps(SPEC_DICT)
 
 
-def test_read_yaml_escapes_dollar_quote_breakout(temporary_directory):
-    # A spec value containing $$ must not be passed through verbatim:
-    # the JSON is later embedded inside $$...$$ SQL literals by
-    # create(), _execute_job_service(), and upgrade_spec(), and an unescaped
-    # $$ in spec content would close the literal and allow injected SQL.
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "$$ ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --",
+        # Odd-length runs must also be neutralized — a naive replace("$$", "$ $")
+        # would leave the trailing $$ intact and still allow breakout.
+        "$$$); DROP TABLE users;--",
+        "$$$$); DROP TABLE users;--",
+        "$$$$$); DROP TABLE users;--",
+    ],
+)
+def test_read_yaml_escapes_dollar_quote_breakout(payload, temporary_directory):
+    # A spec value containing two or more consecutive $ must not survive
+    # verbatim: the JSON is later embedded inside $$...$$ SQL literals by
+    # create(), _execute_job_service(), and upgrade_spec(), and any $$ in
+    # spec content would close the literal and allow injected SQL.
+    tmp_dir = Path(temporary_directory)
+    spec_path = tmp_dir / "spec.yml"
+    spec_path.write_text(
+        dedent(
+            f"""
+            spec:
+                containers:
+                - name: main
+                  image: /db/repo:tag
+                  env:
+                    PAYLOAD: "{payload}"
+            """
+        )
+    )
+    result = ServiceManager()._read_yaml(spec_path)  # noqa: SLF001
+    assert "$$" not in result
+
+
+def test_read_yaml_preserves_single_dollar(temporary_directory):
+    # A single $ is not a dollar-quote delimiter and must pass through
+    # unchanged — legitimate spec values (env var references, passwords,
+    # etc.) often contain a lone $.
     tmp_dir = Path(temporary_directory)
     spec_path = tmp_dir / "spec.yml"
     spec_path.write_text(
@@ -1366,13 +1399,14 @@ def test_read_yaml_escapes_dollar_quote_breakout(temporary_directory):
                 - name: main
                   image: /db/repo:tag
                   env:
-                    PAYLOAD: "$$ ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
+                    HOME_PATH: "$HOME/data"
+                    PRICE: "cost is $5"
             """
         )
     )
     result = ServiceManager()._read_yaml(spec_path)  # noqa: SLF001
-    assert "$$" not in result
-    assert "$ $" in result
+    assert "$HOME/data" in result
+    assert "cost is $5" in result
 
 
 @pytest.mark.parametrize(
@@ -1383,24 +1417,29 @@ def test_read_yaml_escapes_dollar_quote_breakout(temporary_directory):
         ("upgrade_spec", "from specification $$"),
     ],
 )
+@pytest.mark.parametrize(
+    "dollar_run",
+    ["$$", "$$$", "$$$$", "$$$$$"],
+)
 @patch(EXECUTE_QUERY)
 def test_service_spec_dollar_quote_not_broken_out(
-    mock_execute_query, temporary_directory, method_name, query_fragment
+    mock_execute_query, temporary_directory, method_name, query_fragment, dollar_run
 ):
-    # End-to-end check: a spec value containing $$ must not appear verbatim
-    # inside the generated SQL, otherwise the dollar-quoted literal is
-    # terminated early and the rest is parsed as SQL.
+    # End-to-end check: any run of >=2 $ in spec content must not appear
+    # verbatim inside the generated SQL, otherwise the dollar-quoted literal
+    # is terminated early and the rest is parsed as SQL. Covers odd-length
+    # runs where a naive pairwise escape would leave a trailing $$ intact.
     tmp_dir = Path(temporary_directory)
     spec_path = tmp_dir / "spec.yml"
     spec_path.write_text(
         dedent(
-            """
+            f"""
             spec:
                 containers:
                 - name: main
                   image: /db/repo:tag
                   env:
-                    PAYLOAD: "$$ ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
+                    PAYLOAD: "{dollar_run} ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
             """
         )
     )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Resolves [SNOW-3417002](https://snowflakecomputing.atlassian.net/browse/SNOW-3417002) — SQL injection via dollar-quote breakout in SPCS service spec.

#### The bug

`ServiceManager._read_yaml()` (`src/snowflake/cli/_plugins/spcs/services/manager.py:413`) reads a YAML spec with `yaml.safe_load` and returns `json.dumps(data)`. That string is then interpolated into `$$...$$` dollar-quoted SQL literals by three call sites:

- `create()` — `FROM SPECIFICATION $$ {spec} $$` (manager.py:75-80)
- `_execute_job_service()` — `FROM SPECIFICATION $$ {spec_json} $$` (manager.py:248-253)
- `upgrade_spec()` — `from specification $$ {spec} $$` (manager.py:691-693)

`json.dumps` does not escape `$` (it has no meaning in JSON). A spec string value containing `$$` — e.g.

```yaml
spec:
  containers:
    - env:
        PAYLOAD: "$$ ); GRANT ROLE ACCOUNTADMIN TO USER attacker; --"
```

survives serialization verbatim. Snowflake's SQL parser treats the inner `$$` as the closing delimiter of the dollar-quoted literal, so everything after it is parsed as SQL. `execute_query` routes through `_execute_string` → `execute_stream` (`sql_execution.py:85`), which splits on `;` and executes each statement independently, so the injected `GRANT` runs with the caller's session privileges.

Vulnerable commands: `snow spcs service create`, `snow spcs service execute-job`, `snow spcs service upgrade`. `snow spcs service deploy` is not affected because it passes `SPECIFICATION_FILE = '<stage path>'` rather than inlining spec contents.

#### The fix

Replace `$$` with `$ $` in the serialized spec before embedding. The substitution only changes the JSON-level bytes being inlined in SQL — `$$` has no meaning in JSON or in the spec schema, so the parsed spec values Snowflake receives are unchanged for any legitimate input. Extracted to `ServiceManager._serialize_spec` so `build_image()` (which also hands a JSON spec to `_execute_job_service`) gets the same treatment.

#### Tests

- `test_read_yaml_escapes_dollar_quote_breakout` — asserts a spec value containing `$$` is neutralized in `_read_yaml`'s output.
- `test_service_spec_dollar_quote_not_broken_out` — parametrized over `create` / `execute_job` / `upgrade_spec`, asserts the final SQL contains exactly two `$$` tokens (the opening and closing delimiters) and that the payload is retained inside the literal rather than executed.
- Existing `test_read_yaml`, `test_create_service`, `test_create_service_if_not_exists`, `test_upgrade_spec`, `test_execute_job_service`, `test_build_image` continue to pass unchanged — the existing fixture values contain no `$`, so the escape is a no-op for them.

Full `tests/spcs/` suite passes locally (177 tests).

#### References

- CWE-89 (SQL Injection), OWASP A03:2021 (Injection)
- Sinks: `manager.py:79`, `manager.py:252`, `manager.py:693`
- Source: `manager.py:413` (`_read_yaml`)

[SNOW-3417002]: https://snowflakecomputing.atlassian.net/browse/SNOW-3417002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ