### PR TITLE
feat: [SNOW-1904824] add `snow helpers generate-project-schema`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@
 
 ## New additions
 * Added a `--protocol` option (plus matching `SNOWFLAKE_PROTOCOL` env var and `protocol` config key) to `snow connection add` and the global connection overrides. This allows selecting `http` or `https` as the connection protocol without editing `config.toml`, which is primarily useful for local development against `http` deployments.
+* Added `snow helpers generate-project-schema` command to emit a JSON Schema for the `snowflake.yml` project definition file. The output follows [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/schema) and can be plugged into supported editors (e.g. VS Code via the YAML extension) or CI pipelines for completion and validation. Use `--version` to select the project definition version (`1`, `1.1`, or `2`; defaults to `2`) and `--output-file`/`-o` to write the schema to a file.
 
 ## Fixes and improvements
 * Fixed `TooManyFilesError` during `snow streamlit deploy` when `main_file` is a descendant of a directory listed in `artifacts`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,7 +20,7 @@
 
 ## New additions
 * Added a `--protocol` option (plus matching `SNOWFLAKE_PROTOCOL` env var and `protocol` config key) to `snow connection add` and the global connection overrides. This allows selecting `http` or `https` as the connection protocol without editing `config.toml`, which is primarily useful for local development against `http` deployments.
-* Added `snow helpers generate-project-schema` command to emit a JSON Schema for the `snowflake.yml` project definition file. The output follows [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/schema) and can be plugged into supported editors (e.g. VS Code via the YAML extension) or CI pipelines for completion and validation. Use `--version` to select the project definition version (`1`, `1.1`, or `2`; defaults to `2`) and `--output-file`/`-o` to write the schema to a file.
+* Added `snow helpers generate-project-schema` command to emit a JSON Schema for the `snowflake.yml` project definition file. The output follows [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/schema) and can be plugged into supported editors (e.g. VS Code via the YAML extension) or CI pipelines to get completion and to catch structural mistakes (unknown keys, wrong types, missing required fields) before a deploy. The schema is generated from the CLI's own models, so some cross-field and semantic checks are still only applied at load/deploy time. Use `--definition-version` to select the project definition version (`1`, `1.1`, or `2`; defaults to `2`) and `--output-file`/`-o` to write the schema to a file.
 
 ## Fixes and improvements
 * Fixed `TooManyFilesError` during `snow streamlit deploy` when `main_file` is a descendant of a directory listed in `artifacts`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* Added `snow helpers generate-project-schema` command to emit a JSON Schema for the `snowflake.yml` project definition file. The output follows [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/schema) and can be plugged into supported editors (e.g. VS Code via the YAML extension) or CI pipelines for completion and validation. Use `--version` to select the project definition version (`1`, `1.1`, or `2`; defaults to `2`) and `--output-file`/`-o` to write the schema to a file.
 
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).

--- a/src/snowflake/cli/_plugins/helpers/commands.py
+++ b/src/snowflake/cli/_plugins/helpers/commands.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -24,6 +25,7 @@ import click
 import typer
 import yaml
 from snowflake.cli._plugins.helpers.snowsl_vars_reader import check_env_vars
+from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
 from snowflake.cli.api.config import (
     ConnectionConfig,
@@ -38,15 +40,13 @@ from snowflake.cli.api.output.types import (
     CommandResult,
     MessageResult,
     MultipleResults,
+    ObjectResult,
 )
 from snowflake.cli.api.project.definition_conversion import (
     convert_project_definition_to_v2,
 )
 from snowflake.cli.api.project.definition_manager import DefinitionManager
 from snowflake.cli.api.project.schemas.project_definition import (
-    DefinitionV10,
-    DefinitionV11,
-    DefinitionV20,
     get_version_map,
 )
 from snowflake.cli.api.secure_path import SecurePath
@@ -382,38 +382,53 @@ def show_config_sources(
     )
 
 
-_PROJECT_DEFINITION_MODELS = {
-    "1": DefinitionV10,
-    "1.1": DefinitionV11,
-    "2": DefinitionV20,
-}
+# Enum of supported project definition versions, derived from the single source
+# of truth in the project schemas module so the CLI surface cannot drift from it.
+ProjectDefinitionVersion = Enum(  # type: ignore[misc]
+    "ProjectDefinitionVersion",
+    {f"V{version.replace('.', '_')}": version for version in get_version_map()},
+    type=str,
+)
+_DEFAULT_DEFINITION_VERSION = ProjectDefinitionVersion("2")
+
+
+def _accepted_version_scalars(version: str) -> list[Any]:
+    """Scalar forms a user may write for ``definition_version`` in YAML.
+
+    YAML leaves ``definition_version: 2`` as an int and ``1.1`` as a float, while
+    quoting produces a string; the CLI accepts all of these. Pinning the schema to
+    these forms lets an editor flag a version that does not match the schema in use.
+    """
+    numeric: Any = float(version) if "." in version else int(version)
+    return [version, numeric]
 
 
 def _build_project_definition_schema(version: str) -> dict[str, Any]:
-    model = _PROJECT_DEFINITION_MODELS[version]
+    model = get_version_map()[version]
     schema = model.model_json_schema()
     schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
-    schema["$id"] = (
-        "https://raw.githubusercontent.com/snowflakedb/snowflake-cli/main/"
-        f"schemas/project_definition_v{version.replace('.', '_')}.json"
-    )
     schema["title"] = f"Snowflake CLI project definition v{version}"
     schema["description"] = (
-        "JSON Schema for Snowflake CLI project definition files "
-        f"(snowflake.yml) at definition_version {version}."
+        "JSON Schema for Snowflake CLI project definition files (snowflake.yml) at "
+        f"definition_version {version}. Generated from the Snowflake CLI pydantic "
+        "models: it captures structural validation (field names, types, required "
+        "keys) but not every semantic check the CLI performs at load/deploy time."
     )
+    # Pin definition_version so each schema self-identifies; otherwise the v2
+    # schema would happily accept `definition_version: 1`, etc.
+    version_property = schema.get("properties", {}).get("definition_version")
+    if version_property is not None:
+        version_property.pop("anyOf", None)
+        version_property["enum"] = _accepted_version_scalars(version)
     return schema
 
 
 @app.command(name="generate-project-schema", requires_connection=False)
 def generate_project_schema(
-    version: str = typer.Option(
-        "2",
-        "--version",
-        help=(
-            "Project definition schema version to generate. "
-            f"Supported: {', '.join(get_version_map())}."
-        ),
+    version: ProjectDefinitionVersion = typer.Option(  # type: ignore[valid-type]
+        _DEFAULT_DEFINITION_VERSION,
+        "--definition-version",
+        help="Project definition version to generate the schema for.",
     ),
     output_file: Optional[Path] = typer.Option(
         None,
@@ -428,21 +443,25 @@ def generate_project_schema(
     """
     Generate a JSON Schema for the Snowflake CLI project definition file (snowflake.yml).
 
-    The produced schema follows the JSON Schema Store format and can be plugged into editors
-    (for example via the YAML VS Code extension) or CI pipelines to provide completion and
-    linting for snowflake.yml files before they reach Snowflake.
+    Save the output and reference it from your editor (for example the YAML VS Code
+    extension, via a `# yaml-language-server: $schema=...` modeline or the extension's
+    schema mapping) or a CI pipeline to get completion and to catch typos and type
+    errors in snowflake.yml before a deploy. The schema is generated from the CLI's
+    own pydantic models, so it stays in sync with the structural rules the CLI
+    enforces; some cross-field/semantic checks are only applied at load/deploy time.
     """
-    if version not in _PROJECT_DEFINITION_MODELS:
-        supported = ", ".join(get_version_map())
-        raise click.ClickException(
-            f"Unsupported project definition version '{version}'. Supported: {supported}."
-        )
-
-    schema = _build_project_definition_schema(version)
-    payload = json.dumps(schema, indent=2, sort_keys=True)
+    schema = _build_project_definition_schema(version.value)
 
     if output_file is not None:
+        payload = json.dumps(schema, indent=2, sort_keys=True)
         SecurePath(output_file).write_text(payload + "\n")
         return MessageResult(f"Project definition schema written to {output_file}.")
 
-    return MessageResult(payload)
+    # Under a structured output format, return the schema as an object so the
+    # command emits the JSON Schema document itself rather than a stringified
+    # blob nested under a "message" key.
+    output_format = get_cli_context().output_format
+    if output_format is not None and output_format.is_json:
+        return ObjectResult(schema)
+
+    return MessageResult(json.dumps(schema, indent=2, sort_keys=True))

--- a/src/snowflake/cli/_plugins/helpers/commands.py
+++ b/src/snowflake/cli/_plugins/helpers/commands.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -42,6 +43,12 @@ from snowflake.cli.api.project.definition_conversion import (
     convert_project_definition_to_v2,
 )
 from snowflake.cli.api.project.definition_manager import DefinitionManager
+from snowflake.cli.api.project.schemas.project_definition import (
+    DefinitionV10,
+    DefinitionV11,
+    DefinitionV20,
+    get_version_map,
+)
 from snowflake.cli.api.secure_path import SecurePath
 
 log = logging.getLogger(__name__)
@@ -373,3 +380,69 @@ def show_config_sources(
     return get_configuration_explanation_results(
         key=key, verbose=show_details, connection=connection
     )
+
+
+_PROJECT_DEFINITION_MODELS = {
+    "1": DefinitionV10,
+    "1.1": DefinitionV11,
+    "2": DefinitionV20,
+}
+
+
+def _build_project_definition_schema(version: str) -> dict[str, Any]:
+    model = _PROJECT_DEFINITION_MODELS[version]
+    schema = model.model_json_schema()
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema["$id"] = (
+        "https://raw.githubusercontent.com/snowflakedb/snowflake-cli/main/"
+        f"schemas/project_definition_v{version.replace('.', '_')}.json"
+    )
+    schema["title"] = f"Snowflake CLI project definition v{version}"
+    schema["description"] = (
+        "JSON Schema for Snowflake CLI project definition files "
+        f"(snowflake.yml) at definition_version {version}."
+    )
+    return schema
+
+
+@app.command(name="generate-project-schema", requires_connection=False)
+def generate_project_schema(
+    version: str = typer.Option(
+        "2",
+        "--version",
+        help=(
+            "Project definition schema version to generate. "
+            f"Supported: {', '.join(get_version_map())}."
+        ),
+    ),
+    output_file: Optional[Path] = typer.Option(
+        None,
+        "--output-file",
+        "-o",
+        help="Write the JSON Schema to this file. When omitted, schema is printed to stdout.",
+        dir_okay=False,
+        writable=True,
+    ),
+    **options,
+) -> CommandResult:
+    """
+    Generate a JSON Schema for the Snowflake CLI project definition file (snowflake.yml).
+
+    The produced schema follows the JSON Schema Store format and can be plugged into editors
+    (for example via the YAML VS Code extension) or CI pipelines to provide completion and
+    linting for snowflake.yml files before they reach Snowflake.
+    """
+    if version not in _PROJECT_DEFINITION_MODELS:
+        supported = ", ".join(get_version_map())
+        raise click.ClickException(
+            f"Unsupported project definition version '{version}'. Supported: {supported}."
+        )
+
+    schema = _build_project_definition_schema(version)
+    payload = json.dumps(schema, indent=2, sort_keys=True)
+
+    if output_file is not None:
+        SecurePath(output_file).write_text(payload + "\n")
+        return MessageResult(f"Project definition schema written to {output_file}.")
+
+    return MessageResult(payload)

--- a/src/snowflake/cli/_plugins/helpers/commands.py
+++ b/src/snowflake/cli/_plugins/helpers/commands.py
@@ -453,6 +453,10 @@ def generate_project_schema(
     schema = _build_project_definition_schema(version.value)
 
     if output_file is not None:
+        if not output_file.parent.exists():
+            raise click.ClickException(
+                f"Directory '{output_file.parent}' does not exist."
+            )
         payload = json.dumps(schema, indent=2, sort_keys=True)
         SecurePath(output_file).write_text(payload + "\n")
         return MessageResult(f"Project definition schema written to {output_file}.")
@@ -460,8 +464,7 @@ def generate_project_schema(
     # Under a structured output format, return the schema as an object so the
     # command emits the JSON Schema document itself rather than a stringified
     # blob nested under a "message" key.
-    output_format = get_cli_context().output_format
-    if output_format is not None and output_format.is_json:
+    if get_cli_context().output_format.is_json:
         return ObjectResult(schema)
 
     return MessageResult(json.dumps(schema, indent=2, sort_keys=True))

--- a/tests/helpers/test_generate_project_schema.py
+++ b/tests/helpers/test_generate_project_schema.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+COMMAND = "generate-project-schema"
+
+
+def _extract_json(text: str) -> dict:
+    """Find the first top-level JSON object in the CLI output and parse it."""
+    start = text.find("{")
+    assert start != -1, f"No JSON object found in output: {text!r}"
+    depth = 0
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(text[start : idx + 1])
+    raise AssertionError(f"Unbalanced JSON object in output: {text!r}")
+
+
+def test_default_version_is_v2(runner):
+    result = runner.invoke(["helpers", COMMAND])
+    assert result.exit_code == 0, result.output
+    schema = _extract_json(result.output)
+    assert schema["title"] == "Snowflake CLI project definition v2"
+    assert "entities" in schema["properties"]
+    assert "mixins" in schema["properties"]
+
+
+@pytest.mark.parametrize(
+    "version, expected_title, expected_top_level",
+    [
+        (
+            "1",
+            "Snowflake CLI project definition v1",
+            {"native_app", "snowpark", "streamlit"},
+        ),
+        (
+            "1.1",
+            "Snowflake CLI project definition v1.1",
+            {"native_app", "snowpark", "streamlit", "env"},
+        ),
+        ("2", "Snowflake CLI project definition v2", {"entities", "env", "mixins"}),
+    ],
+)
+def test_supported_versions(runner, version, expected_title, expected_top_level):
+    result = runner.invoke(["helpers", COMMAND, "--version", version])
+    assert result.exit_code == 0, result.output
+    schema = _extract_json(result.output)
+    assert schema["title"] == expected_title
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"].endswith(
+        f"project_definition_v{version.replace('.', '_')}.json"
+    )
+    assert schema["type"] == "object"
+    assert "definition_version" in schema["properties"]
+    assert expected_top_level.issubset(set(schema["properties"].keys()))
+
+
+def test_output_file_writes_schema(runner, tmp_path):
+    out = tmp_path / "schema.json"
+    result = runner.invoke(
+        ["helpers", COMMAND, "--version", "2", "--output-file", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    assert f"Project definition schema written to {out}" in result.output
+    assert out.exists()
+
+    payload = json.loads(out.read_text())
+    assert payload["title"] == "Snowflake CLI project definition v2"
+    assert "entities" in payload["properties"]
+
+
+def test_unsupported_version_fails(runner):
+    result = runner.invoke(["helpers", COMMAND, "--version", "999"])
+    assert result.exit_code != 0
+    assert "Unsupported project definition version '999'" in result.output
+
+
+def test_output_short_option(runner, tmp_path):
+    out = tmp_path / "schema-v11.json"
+    result = runner.invoke(["helpers", COMMAND, "--version", "1.1", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(out.read_text())
+    assert payload["title"] == "Snowflake CLI project definition v1.1"
+    assert "env" in payload["properties"]
+
+
+def test_schema_is_stable_json(runner):
+    """Running the command twice should produce byte-identical JSON."""
+    first = runner.invoke(["helpers", COMMAND, "--version", "2"])
+    second = runner.invoke(["helpers", COMMAND, "--version", "2"])
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert _extract_json(first.output) == _extract_json(second.output)
+
+
+def test_schema_validates_simple_v2_project(runner):
+    """Minimal v2 project definition should validate against the generated schema."""
+    jsonschema = pytest.importorskip("jsonschema")
+
+    result = runner.invoke(["helpers", COMMAND, "--version", "2"])
+    assert result.exit_code == 0
+    schema = _extract_json(result.output)
+
+    sample = {
+        "definition_version": "2",
+        "entities": {
+            "hello": {
+                "type": "streamlit",
+                "identifier": "hello",
+                "stage": "streamlit",
+                "query_warehouse": "xsmall",
+                "main_file": "app.py",
+                "artifacts": ["app.py"],
+            }
+        },
+    }
+
+    try:
+        jsonschema.validate(instance=sample, schema=schema)
+    except jsonschema.ValidationError as err:  # pragma: no cover - aid debugging
+        pytest.fail(f"Valid sample failed schema validation: {err}")

--- a/tests/helpers/test_generate_project_schema.py
+++ b/tests/helpers/test_generate_project_schema.py
@@ -135,6 +135,20 @@ def test_output_short_option(runner, tmp_path):
     assert "env" in payload["properties"]
 
 
+def test_output_file_missing_parent_raises(runner, tmp_path):
+    """Writing to a path under a nonexistent directory fails with a clean
+    ClickException rather than an unhandled FileNotFoundError."""
+    out = tmp_path / "nonexistent_dir" / "schema.json"
+    result = runner.invoke(
+        ["helpers", COMMAND, "--definition-version", "2", "-o", str(out)]
+    )
+    assert result.exit_code != 0
+    # The error panel word-wraps the long temp path, so assert on the stable
+    # tail of the message instead of the wrapped directory name.
+    assert "does not exist" in result.output
+    assert not out.exists()
+
+
 def test_schema_is_stable(runner, tmp_path):
     """Generation is deterministic: two runs produce byte-identical files."""
     first = tmp_path / "first.json"

--- a/tests/helpers/test_generate_project_schema.py
+++ b/tests/helpers/test_generate_project_schema.py
@@ -45,82 +45,134 @@ def test_default_version_is_v2(runner):
 
 
 @pytest.mark.parametrize(
-    "version, expected_title, expected_top_level",
+    "version, expected_title, expected_top_level, pinned_version",
     [
         (
             "1",
             "Snowflake CLI project definition v1",
             {"native_app", "snowpark", "streamlit"},
+            ["1", 1],
         ),
         (
             "1.1",
             "Snowflake CLI project definition v1.1",
             {"native_app", "snowpark", "streamlit", "env"},
+            ["1.1", 1.1],
         ),
-        ("2", "Snowflake CLI project definition v2", {"entities", "env", "mixins"}),
+        (
+            "2",
+            "Snowflake CLI project definition v2",
+            {"entities", "env", "mixins"},
+            ["2", 2],
+        ),
     ],
 )
-def test_supported_versions(runner, version, expected_title, expected_top_level):
-    result = runner.invoke(["helpers", COMMAND, "--version", version])
+def test_supported_versions(
+    runner, version, expected_title, expected_top_level, pinned_version
+):
+    result = runner.invoke(["helpers", COMMAND, "--definition-version", version])
     assert result.exit_code == 0, result.output
     schema = _extract_json(result.output)
+
     assert schema["title"] == expected_title
     assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
-    assert schema["$id"].endswith(
-        f"project_definition_v{version.replace('.', '_')}.json"
-    )
     assert schema["type"] == "object"
-    assert "definition_version" in schema["properties"]
+    # The dead "$id" pointing at a non-existent URL was removed; assert it stays gone.
+    assert "$id" not in schema
+
+    # Each schema must self-identify its version, otherwise the v2 schema would
+    # happily accept `definition_version: 1`. Both YAML scalar forms are pinned.
+    definition_version = schema["properties"]["definition_version"]
+    assert definition_version["enum"] == pinned_version
+    assert "definition_version" in schema["required"]
+
+    # extra="forbid" on the models is what powers the "catch typos" promise.
+    assert schema["additionalProperties"] is False
+
     assert expected_top_level.issubset(set(schema["properties"].keys()))
+
+
+def test_removed_version_flag_is_rejected(runner):
+    """The option is --definition-version; the old --version must not resurface."""
+    result = runner.invoke(["helpers", COMMAND, "--version", "2"])
+    assert result.exit_code != 0
+    assert "No such option: --version" in result.output
+
+
+def test_unsupported_version_fails(runner):
+    result = runner.invoke(["helpers", COMMAND, "--definition-version", "999"])
+    assert result.exit_code != 0
+    # typer renders the allowed values from the version enum.
+    assert "is not one of" in result.output
+    assert "999" in result.output
 
 
 def test_output_file_writes_schema(runner, tmp_path):
     out = tmp_path / "schema.json"
     result = runner.invoke(
-        ["helpers", COMMAND, "--version", "2", "--output-file", str(out)]
+        ["helpers", COMMAND, "--definition-version", "2", "--output-file", str(out)]
     )
     assert result.exit_code == 0, result.output
     assert f"Project definition schema written to {out}" in result.output
     assert out.exists()
 
-    payload = json.loads(out.read_text())
+    text = out.read_text()
+    assert text.endswith("\n")
+    payload = json.loads(text)
     assert payload["title"] == "Snowflake CLI project definition v2"
     assert "entities" in payload["properties"]
-
-
-def test_unsupported_version_fails(runner):
-    result = runner.invoke(["helpers", COMMAND, "--version", "999"])
-    assert result.exit_code != 0
-    assert "Unsupported project definition version '999'" in result.output
+    assert "$id" not in payload
 
 
 def test_output_short_option(runner, tmp_path):
     out = tmp_path / "schema-v11.json"
-    result = runner.invoke(["helpers", COMMAND, "--version", "1.1", "-o", str(out)])
+    result = runner.invoke(
+        ["helpers", COMMAND, "--definition-version", "1.1", "-o", str(out)]
+    )
     assert result.exit_code == 0, result.output
     payload = json.loads(out.read_text())
     assert payload["title"] == "Snowflake CLI project definition v1.1"
     assert "env" in payload["properties"]
 
 
-def test_schema_is_stable_json(runner):
-    """Running the command twice should produce byte-identical JSON."""
-    first = runner.invoke(["helpers", COMMAND, "--version", "2"])
-    second = runner.invoke(["helpers", COMMAND, "--version", "2"])
-    assert first.exit_code == 0
-    assert second.exit_code == 0
-    assert _extract_json(first.output) == _extract_json(second.output)
+def test_schema_is_stable(runner, tmp_path):
+    """Generation is deterministic: two runs produce byte-identical files."""
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    for out in (first, second):
+        result = runner.invoke(
+            ["helpers", COMMAND, "--definition-version", "2", "-o", str(out)]
+        )
+        assert result.exit_code == 0, result.output
+    assert first.read_bytes() == second.read_bytes()
 
 
-def test_schema_validates_simple_v2_project(runner):
-    """Minimal v2 project definition should validate against the generated schema."""
-    jsonschema = pytest.importorskip("jsonschema")
+def test_json_format_emits_schema_object(runner):
+    """Under --format json the schema is the document, not a stringified blob
+    nested under a "message" key."""
+    result = runner.invoke(
+        ["helpers", COMMAND, "--definition-version", "2", "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "message" not in payload
+    assert payload["title"] == "Snowflake CLI project definition v2"
+    assert "$defs" in payload
+    assert "entities" in payload["properties"]
 
-    result = runner.invoke(["helpers", COMMAND, "--version", "2"])
-    assert result.exit_code == 0
+
+def test_entities_forbid_unknown_keys(runner):
+    """Structural guard for the "catch typos" promise that does not need a
+    JSON Schema validator installed: entity models reject unknown keys."""
+    result = runner.invoke(["helpers", COMMAND, "--definition-version", "2"])
+    assert result.exit_code == 0, result.output
     schema = _extract_json(result.output)
+    streamlit = schema["$defs"]["StreamlitEntityModel"]
+    assert streamlit["additionalProperties"] is False
 
-    sample = {
+
+def _valid_v2_project() -> dict:
+    return {
         "definition_version": "2",
         "entities": {
             "hello": {
@@ -134,7 +186,48 @@ def test_schema_validates_simple_v2_project(runner):
         },
     }
 
+
+def test_schema_validates_valid_v2_project(runner):
+    """A minimal valid v2 project validates against the generated schema."""
+    jsonschema = pytest.importorskip("jsonschema")
+
+    result = runner.invoke(["helpers", COMMAND, "--definition-version", "2"])
+    assert result.exit_code == 0
+    schema = _extract_json(result.output)
+
     try:
-        jsonschema.validate(instance=sample, schema=schema)
+        jsonschema.validate(instance=_valid_v2_project(), schema=schema)
     except jsonschema.ValidationError as err:  # pragma: no cover - aid debugging
         pytest.fail(f"Valid sample failed schema validation: {err}")
+
+
+@pytest.mark.parametrize(
+    "mutate, reason",
+    [
+        (
+            lambda d: d["entities"]["hello"].__setitem__("bogus_field", 1),
+            "unknown entity key (typo)",
+        ),
+        (
+            lambda d: d.__setitem__("definition_version", "1"),
+            "wrong definition_version for this schema",
+        ),
+        (
+            lambda d: d.__setitem__("native_app", {"name": "x"}),
+            "v1-only top-level key",
+        ),
+    ],
+)
+def test_schema_rejects_invalid_v2_projects(runner, mutate, reason):
+    """The schema is only useful if it rejects the mistakes it advertises:
+    typos, the wrong definition_version, and v1-shaped keys."""
+    jsonschema = pytest.importorskip("jsonschema")
+
+    result = runner.invoke(["helpers", COMMAND, "--definition-version", "2"])
+    assert result.exit_code == 0
+    schema = _extract_json(result.output)
+
+    sample = _valid_v2_project()
+    mutate(sample)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=sample, schema=schema)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Linux.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Closes [SNOW-1904824](https://snowflakecomputing.atlassian.net/browse/SNOW-1904824) / #2037.

Adds a new `snow helpers generate-project-schema` command that emits a [JSON Schema (Draft 2020-12)](https://json-schema.org/draft/2020-12/schema) for the `snowflake.yml` project definition file. The schema is generated directly from the pydantic `DefinitionV10` / `DefinitionV11` / `DefinitionV20` models, so it always matches what the CLI itself validates against.

**Why:** Today, `snowflake.yml` authors:
1. Need to keep the online documentation open while editing, and
2. Only find out about typos (e.g. `strring` instead of `string`) once Snowflake rejects the object server-side.

With a published JSON Schema, editors that support the [JSON Schema Store project](https://www.schemastore.org/json/) (VS Code via the YAML extension, IntelliJ, etc.) and CI pipelines can auto-complete valid keys and flag typos long before a deploy.

**Usage:**

```sh
# Emit the v2 schema to stdout (default)
snow helpers generate-project-schema

# Target a specific definition version
snow helpers generate-project-schema --version 1.1

# Write the schema to a file (for checking into a repo / referencing from editors)
snow helpers generate-project-schema --output-file schema.json
snow helpers generate-project-schema -o schema.json
```

The output includes `$schema`, `$id`, `title`, and `description` fields so it can be consumed directly by JSON Schema tooling without further post-processing.

**Scope:**
* `requires_connection=False` — runs fully offline.
* Supports the same three definition versions the CLI itself supports (`1`, `1.1`, `2`); an unsupported version raises a clear `ClickException`.
* Unit tests cover default-version behaviour, all supported versions, `--output-file`, `-o` short option, the error path, and JSON stability (same input → byte-identical output). An optional test validates a minimal v2 project against the generated schema when `jsonschema` is available.

[SNOW-1904824]: https://snowflakecomputing.atlassian.net/browse/SNOW-1904824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ