### PR TITLE
Snowflake Apps: Stream build logs in `snow app deploy --verbose`

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -23,9 +23,10 @@ dispatched to from the unified handlers without CLI-framework coupling.
 """
 
 import json
+import logging
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import typer
 from click import ClickException
@@ -57,6 +58,8 @@ from snowflake.cli.api.output.types import (
 )
 from snowflake.cli.api.project.util import get_env_username, identifier_for_url
 from snowflake.connector.errors import ProgrammingError
+
+log = logging.getLogger(__name__)
 
 # Default number of log lines returned by ``snow app events`` for the
 # Snowflake Apps Deploy flow. The unified command accepts ``--last`` with a ``None``
@@ -351,6 +354,34 @@ def snowflake_app_events(
     return MessageResult(logs)
 
 
+def _make_build_log_streamer(
+    manager: SnowflakeAppManager, build_job_fqn: FQN
+) -> Callable[[], None]:
+    """Return an ``on_poll`` callback that streams new build log lines.
+
+    Lines are emitted at INFO level so they only appear when the user
+    runs the deploy with ``--verbose`` (or ``--debug``).  The callback
+    keeps a running count of lines already shown and only emits the
+    delta on each invocation.  Failures fetching logs are swallowed so
+    they never interrupt the surrounding polling loop.
+    """
+    seen_count = 0
+
+    def _stream() -> None:
+        nonlocal seen_count
+        try:
+            logs = manager.get_build_job_logs(build_job_fqn)
+        except Exception:
+            log.debug("Failed to fetch build logs", exc_info=True)
+            return
+        new_lines = logs[seen_count:]
+        for line in new_lines:
+            log.info(line)
+        seen_count = len(logs)
+
+    return _stream
+
+
 def snowflake_app_deploy(
     entity_id: Optional[str],
     upload_only: bool,
@@ -506,6 +537,7 @@ def snowflake_app_deploy(
                 f"  SELECT * FROM TABLE("
                 f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
             ),
+            on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
         )
 
     if build_only:

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -73,6 +73,7 @@ def _poll_until(
     max_attempts: int = 240,
     interval_seconds: int = 5,
     timeout_message: str = "Operation timed out.",
+    on_poll: Optional[Callable[[], None]] = None,
 ) -> T:
     """Poll *poll_fn* until the result satisfies a done condition.
 
@@ -86,11 +87,25 @@ def _poll_until(
         Call *is_done(result)* each iteration.  Optionally supply *is_error*
         to detect error values.
 
+    If *on_poll* is provided it is called every second between status
+    checks, so log output streams continuously rather than in bursts
+    every *interval_seconds*.  Exceptions from *on_poll* are logged and
+    swallowed so they never interrupt the polling loop.
+
     Raises ``CliError`` on error or timeout.  Returns the final value on
     success.
     """
     for _attempt in range(max_attempts):
-        time.sleep(interval_seconds)
+        if on_poll is not None:
+            for _ in range(interval_seconds):
+                time.sleep(1)
+                try:
+                    on_poll()
+                except Exception:
+                    log.debug("on_poll callback failed", exc_info=True)
+        else:
+            time.sleep(interval_seconds)
+
         result = poll_fn()
         cli_console.step(f"Status: {format_status(result)}")
 
@@ -729,3 +744,10 @@ class SnowflakeAppManager(SqlExecutionMixin):
         )
         row = cursor.fetchone()
         return row[0] if row else ""
+
+    def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
+        """Fetch build logs for an artifact-repo build job."""
+        cursor = self.execute_query(
+            f"SELECT LOG FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
+        )
+        return [str(row[0]) for row in cursor if row[0]]

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -15,6 +15,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from snowflake.cli._plugins.apps.commands import _make_build_log_streamer
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
 )
@@ -305,6 +306,161 @@ class TestPollUntilStateSetMode:
                 timeout_message="timed out",
             )
         assert mock_sleep.call_count == 2
+
+
+class TestPollUntilOnPoll:
+    """Tests for the ``on_poll`` callback used to stream log lines."""
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_invoked_each_second(self, mock_sleep):
+        """``on_poll`` runs once per second within each ``interval_seconds``."""
+        on_poll = Mock()
+        values = iter(["PENDING", "DONE"])
+        _poll_until(
+            poll_fn=lambda: next(values),
+            done_states={"DONE"},
+            error_states={"FAILED"},
+            known_pending_states={"PENDING"},
+            interval_seconds=3,
+            timeout_message="timed out",
+            on_poll=on_poll,
+        )
+        # 2 polling iterations × 3 seconds = 6 calls
+        assert on_poll.call_count == 6
+        assert mock_sleep.call_count == 6
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_exception_swallowed(self, mock_sleep):
+        """Exceptions raised by ``on_poll`` must not interrupt polling."""
+        on_poll = Mock(side_effect=RuntimeError("transient"))
+        values = iter(["PENDING", "DONE"])
+        result = _poll_until(
+            poll_fn=lambda: next(values),
+            done_states={"DONE"},
+            error_states={"FAILED"},
+            known_pending_states={"PENDING"},
+            interval_seconds=2,
+            timeout_message="timed out",
+            on_poll=on_poll,
+        )
+        assert result == "DONE"
+        assert on_poll.call_count == 4
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_on_poll_omitted_uses_single_sleep(self, mock_sleep):
+        """Without ``on_poll``, ``_poll_until`` sleeps once per iteration."""
+        values = iter(["PENDING", "DONE"])
+        _poll_until(
+            poll_fn=lambda: next(values),
+            done_states={"DONE"},
+            error_states={"FAILED"},
+            known_pending_states={"PENDING"},
+            interval_seconds=3,
+            timeout_message="timed out",
+        )
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(3)
+
+
+# ── Build log streamer tests ──────────────────────────────────────────
+
+
+class TestMakeBuildLogStreamer:
+    """Tests for ``_make_build_log_streamer`` incremental log diffing.
+
+    The streamer is wired into ``snow app deploy`` as a ``_poll_until``
+    ``on_poll`` callback so build logs stream to the user when they
+    pass ``--verbose``.
+    """
+
+    def test_first_call_prints_all_lines(self):
+        manager = Mock()
+        manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+
+        streamer = _make_build_log_streamer(manager, fqn)
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            streamer()
+
+        assert mock_log.info.call_count == 3
+        mock_log.info.assert_any_call("line1")
+        mock_log.info.assert_any_call("line2")
+        mock_log.info.assert_any_call("line3")
+
+    def test_subsequent_call_prints_only_new_lines(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            manager.get_build_job_logs.return_value = ["line1", "line2"]
+            streamer()
+            assert mock_log.info.call_count == 2
+
+            mock_log.info.reset_mock()
+            manager.get_build_job_logs.return_value = [
+                "line1",
+                "line2",
+                "line3",
+                "line4",
+            ]
+            streamer()
+            assert mock_log.info.call_count == 2
+            mock_log.info.assert_any_call("line3")
+            mock_log.info.assert_any_call("line4")
+
+    def test_no_new_lines_prints_nothing(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            manager.get_build_job_logs.return_value = ["line1"]
+            streamer()
+            mock_log.info.reset_mock()
+
+            manager.get_build_job_logs.return_value = ["line1"]
+            streamer()
+            mock_log.info.assert_not_called()
+
+    def test_empty_logs_prints_nothing(self):
+        manager = Mock()
+        manager.get_build_job_logs.return_value = []
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            streamer()
+            mock_log.info.assert_not_called()
+
+    def test_exception_is_swallowed(self):
+        manager = Mock()
+        manager.get_build_job_logs.side_effect = RuntimeError("connection lost")
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        streamer()  # should not raise
+
+    def test_exception_does_not_reset_seen_count(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.BUILD_JOB")
+        streamer = _make_build_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            manager.get_build_job_logs.return_value = ["line1", "line2"]
+            streamer()
+            assert mock_log.info.call_count == 2
+
+            mock_log.info.reset_mock()
+            manager.get_build_job_logs.side_effect = RuntimeError("transient")
+            streamer()
+            mock_log.info.assert_not_called()
+
+            manager.get_build_job_logs.side_effect = None
+            manager.get_build_job_logs.return_value = ["line1", "line2", "line3"]
+            streamer()
+            assert mock_log.info.call_count == 1
+            mock_log.info.assert_called_with("line3")
 
 
 # ── _generate_snowflake_yml tests ─────────────────────────────────────


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Restores the `_make_build_log_streamer` helper that was accidentally removed in #2881 and wires it back into the artifact-repo build phase of `snow app deploy` so users can watch the build progress in real time.
