### PR TITLE
Snowflake Apps: emit app_flow in telemetry for `snow app *` commands

### DIFF
--- a/src/snowflake/cli/_app/telemetry.py
+++ b/src/snowflake/cli/_app/telemetry.py
@@ -86,6 +86,18 @@ class CLITelemetryField(Enum):
     # Project context
     PROJECT_DEFINITION_VERSION = "project_definition_version"
     MODE = "mode"
+    # Which "snow app" product flow ran for this command:
+    # "native_app" for Native App (application / application package entities),
+    # "snowflake_app" for Snowflake Apps Deploy (snowflake-app entities).
+    # Only emitted for "snow app *" commands; absent for everything else.
+    #
+    # Note: the field appears on TelemetryEvent.CMD_EXECUTION_RESULT and
+    # CMD_EXECUTION_ERROR but NOT on CMD_EXECUTION, because the routing
+    # decorators that resolve the flow run inside the command callable --
+    # i.e. AFTER log_command_usage fires in pre_execute. Consumers who need
+    # the flow on the executing_command event should join on
+    # COMMAND_EXECUTION_ID across the three events for an invocation.
+    APP_FLOW = "app_flow"
 
 
 class TelemetryEvent(Enum):
@@ -169,7 +181,7 @@ def _find_command_info() -> TelemetryDict:
     if format_value is None:
         format_value = OutputFormat.TABLE
 
-    return {
+    info: TelemetryDict = {
         CLITelemetryField.COMMAND: command_path,
         CLITelemetryField.COMMAND_GROUP: command_path[0],
         CLITelemetryField.COMMAND_FLAGS: command_flags,
@@ -177,6 +189,12 @@ def _find_command_info() -> TelemetryDict:
         CLITelemetryField.PROJECT_DEFINITION_VERSION: str(_get_definition_version()),
         CLITelemetryField.MODE: _get_cli_running_mode(),
     }
+
+    app_flow = _get_app_flow()
+    if app_flow is not None:
+        info[CLITelemetryField.APP_FLOW] = app_flow
+
+    return info
 
 
 def _get_cli_running_mode() -> str:
@@ -198,6 +216,23 @@ def _get_definition_version() -> str | None:
         # (especially for commands that don't normally load it)
         pass
     return None
+
+
+def _get_app_flow() -> str | None:
+    """Return the resolved "snow app" product flow for the current command.
+
+    See ``snowflake.cli._plugins.nativeapp.v2_conversions.compat.AppFlow``;
+    this returns ``"native_app"``, ``"snowflake_app"``, or ``None`` for any
+    command outside the ``snow app`` group (or when the routing helpers
+    haven't run yet).
+    """
+    try:
+        return get_cli_context().app_flow
+    except AttributeError:
+        # CLI context not yet populated (e.g. during early startup or in
+        # contrived test scenarios where the manager was reset). Treat as
+        # "no flow recorded" rather than failing the whole telemetry call.
+        return None
 
 
 def _is_env_truthy(name: str) -> bool:

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -50,6 +50,7 @@ from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
     find_entity,
     force_project_definition_v2,
     native_app_only,
+    set_app_flow,
     with_app_flow_routing,
 )
 from snowflake.cli._plugins.nativeapp.version.commands import app as versions_app
@@ -84,6 +85,18 @@ app = SnowTyperFactory(
 app.add_typer(versions_app)
 app.add_typer(release_directives_app)
 app.add_typer(release_channels_app)
+
+
+@app.callback()
+def _app_group_callback() -> None:
+    """Default the telemetry ``app_flow`` to ``snowflake_app`` for every
+    ``snow app *`` invocation so new commands are correctly attributed by
+    default. Native-App routing decorators (``with_app_flow_routing``,
+    ``force_project_definition_v2``, ``native_app_only``) override this
+    when they detect or assert a Native App project.
+    """
+    set_app_flow(AppFlow.SNOWFLAKE_APP)
+
 
 log = logging.getLogger(__name__)
 

--- a/src/snowflake/cli/_plugins/nativeapp/v2_conversions/compat.py
+++ b/src/snowflake/cli/_plugins/nativeapp/v2_conversions/compat.py
@@ -57,6 +57,16 @@ NATIVE_APP_ENTITY_TYPES = {"application", "application package"}
 SNOWFLAKE_APP_ENTITY_TYPES = {"snowflake-app"}
 
 
+def set_app_flow(flow: AppFlow) -> None:
+    """Record the resolved ``snow app`` product flow on the CLI context so
+    telemetry (see ``CLITelemetryField.APP_FLOW``) can distinguish Native App
+    invocations from Snowflake Apps Deploy invocations.
+
+    Safe to call multiple times; the last call wins.
+    """
+    get_cli_context_manager().app_flow = flow.value
+
+
 APP_AND_PACKAGE_OPTIONS = [
     inspect.Parameter(
         "package_entity_id",
@@ -256,6 +266,12 @@ def force_project_definition_v2(
                         # This happens after templates are rendered,
                         # so we can safely remove the entity
                         del original_pdf.entities[entity_id]
+            # All paths above either converted a v1 PDF (always Native App)
+            # or resolved Native App entities (raising on a snowflake-app
+            # project). Stamp the flow only after that resolution succeeds
+            # so failed lookups don't mis-attribute a snowflake-app project
+            # as native_app in the error event.
+            set_app_flow(AppFlow.NATIVE_APP)
             return func(*args, **kwargs)
 
         if single_app_and_package:
@@ -316,6 +332,8 @@ def native_app_only(command: str):
                     f"projects (entity types: application, application "
                     f"package). Your project contains snowflake-app entities."
                 )
+            # Defensive: if the guard passed, this command is Native-App-only.
+            set_app_flow(AppFlow.NATIVE_APP)
             return func(*args, **kwargs)
 
         return wrapper
@@ -437,6 +455,7 @@ def with_app_flow_routing(
 
                 get_cli_context_manager().override_project_definition = pdfv2
                 kwargs["app_flow"] = AppFlow.NATIVE_APP
+                set_app_flow(AppFlow.NATIVE_APP)
                 return func(*args, **kwargs)
 
             flow = _detect_flow_from_project(
@@ -445,6 +464,7 @@ def with_app_flow_routing(
                 package_entity_id=package_entity_id,
                 app_entity_id=app_entity_id,
             )
+            set_app_flow(flow)
 
             if flow == AppFlow.NATIVE_APP and single_app_and_package:
                 app_definition, app_package_definition = _find_app_and_package_entities(

--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -70,6 +70,13 @@ class _CliGlobalContextManager:
     # in order to remove this logic (then make project_definition a non-cloned @property)
     override_project_definition: ProjectDefinition | None = None
 
+    # Identifies which "snow app" product flow the current command is running:
+    # "native_app" for Native App entities (application / application package),
+    # "snowflake_app" for Snowflake Apps Deploy entities (snowflake-app), or
+    # None for any other command. Set by the routing/decoration helpers in
+    # _plugins/nativeapp/v2_conversions/compat.py and read by telemetry.
+    app_flow: str | None = None
+
     _definition_manager: DefinitionManager | None = None
     enhanced_exit_codes: bool = False
 
@@ -289,6 +296,10 @@ class _CliGlobalContextAccess:
     @property
     def is_repl(self) -> bool:
         return self._manager.is_repl
+
+    @property
+    def app_flow(self) -> str | None:
+        return self._manager.app_flow
 
     @property
     def repl(self) -> Repl | None:

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -358,6 +358,68 @@ def test_executing_command_sends_project_definition_in_telemetry_data(
 
 
 @mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.connection.commands.ObjectManager")
+def test_app_flow_is_absent_for_non_app_commands(_, mock_conn, runner):
+    """Commands outside the ``snow app *`` group must never emit
+    ``app_flow``. Check every telemetry call, not just the first/last,
+    so a regression that mis-attaches the field anywhere in the lifecycle
+    surfaces here."""
+    result = runner.invoke(["connection", "test"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    telemetry = mock_conn.return_value._telemetry  # noqa: SLF001
+    for call in telemetry.try_add_log_to_batch.call_args_list:
+        message = call.args[0].to_dict()["message"]
+        assert "app_flow" not in message, message
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.streamlit.commands.StreamlitEntity")
+def test_app_flow_is_absent_for_streamlit_commands(
+    mock_entity, mock_conn, project_directory, runner
+):
+    """Loading a project definition for a non-``snow app`` command must not
+    leak ``app_flow`` into telemetry."""
+    with project_directory("streamlit_full_definition_v2"):
+        result = runner.invoke(["streamlit", "deploy"])
+    assert result.exit_code == 0, result.output
+
+    telemetry = mock_conn.return_value._telemetry  # noqa: SLF001
+    for call in telemetry.try_add_log_to_batch.call_args_list:
+        message = call.args[0].to_dict()["message"]
+        assert "app_flow" not in message, message
+
+
+@mock.patch("snowflake.connector.connect")
+def test_app_flow_native_app_in_telemetry_data(mock_conn, project_directory, runner):
+    """``snow app *`` invocations against a Native App project must report
+    ``app_flow=native_app``. The ``napp_post_deploy_missing_file`` fixture
+    is a v1 Native App project, exercising the in-memory v1->v2 conversion
+    path in ``force_project_definition_v2``.
+
+    The flow is detected during command execution, after
+    ``log_command_usage`` (the ``executing_command`` event) runs. We
+    therefore check the ``error_executing_command`` event, which is
+    emitted from ``post_execute`` after the routing decorator has
+    resolved the flow. (Native App and Snowflake Apps Deploy events can
+    be joined on ``command_execution_id``.)
+    """
+    with project_directory("napp_post_deploy_missing_file"):
+        runner.invoke(["app", "run"], catch_exceptions=False)
+
+    error_command_event = (
+        mock_conn.return_value._telemetry.try_add_log_to_batch.call_args_list[  # noqa: SLF001
+            1
+        ]
+        .args[0]
+        .to_dict()
+    )
+
+    assert error_command_event["message"]["type"] == "error_executing_command"
+    assert error_command_event["message"]["app_flow"] == "native_app"
+
+
+@mock.patch("snowflake.connector.connect")
 @mock.patch("uuid.uuid4")
 @mock.patch("snowflake.cli._plugins.streamlit.commands.StreamlitManager")
 def test_failing_executing_command_sends_telemetry_data(

--- a/tests/nativeapp/test_app_flow_routing.py
+++ b/tests/nativeapp/test_app_flow_routing.py
@@ -393,8 +393,11 @@ def _find_force_v2_callers(src_root: Path) -> set[tuple[str, str]]:
     """
     callers: set[tuple[str, str]] = set()
     for path in src_root.rglob("*.py"):
+        # Force UTF-8: Path.read_text() defaults to the platform encoding,
+        # which is cp1252 on Windows and trips on UTF-8 source files (e.g.
+        # ones containing em-dashes or smart quotes).
         try:
-            tree = ast.parse(path.read_text(), filename=str(path))
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         except SyntaxError:
             continue
         for node in ast.walk(tree):

--- a/tests/nativeapp/test_app_flow_routing.py
+++ b/tests/nativeapp/test_app_flow_routing.py
@@ -15,17 +15,36 @@
 """Tests for the Native App / Snowflake Apps Deploy flow-routing decorator and its
 flow-detection helper used by the shared ``snow app`` subcommands."""
 
+import ast
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+import snowflake.cli
 from click import ClickException
 from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
     AppFlow,
     _detect_flow_from_project,
     has_snowflake_app_entities_only,
+    set_app_flow,
+)
+from snowflake.cli.api.cli_global_context import (
+    get_cli_context,
+    get_cli_context_manager,
 )
 
 from tests_common import change_directory
+
+
+class _ResetAppFlowMixin:
+    """Reset ``app_flow`` on the CLI context before/after each test so the
+    autouse fixtures don't leak state across tests in the same process."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_app_flow(self):
+        get_cli_context_manager().app_flow = None
+        yield
+        get_cli_context_manager().app_flow = None
 
 
 def _make_project(entity_types_by_id):
@@ -283,6 +302,51 @@ class TestCrossFlowOptionValidation:
         assert "--follow-interval" in result.output
 
 
+class TestSetAppFlow(_ResetAppFlowMixin):
+    """``set_app_flow`` records the resolved product flow on the CLI context
+    so telemetry can attribute commands without inspecting kwargs."""
+
+    def test_set_native_app(self):
+        set_app_flow(AppFlow.NATIVE_APP)
+        assert get_cli_context().app_flow == "native_app"
+
+    def test_set_snowflake_app(self):
+        set_app_flow(AppFlow.SNOWFLAKE_APP)
+        assert get_cli_context().app_flow == "snowflake_app"
+
+    def test_set_app_flow_is_overwritable(self):
+        set_app_flow(AppFlow.NATIVE_APP)
+        set_app_flow(AppFlow.SNOWFLAKE_APP)
+        assert get_cli_context().app_flow == "snowflake_app"
+
+
+class TestAppFlowRoutingPropagatesToContext(_ResetAppFlowMixin):
+    """The routing decorators must record the flow on the CLI context for
+    telemetry, even when the command later raises (e.g. cross-flow option
+    validation)."""
+
+    def _write_yml(self, tmp_path, content):
+        (tmp_path / "snowflake.yml").write_text(content)
+
+    def test_snowflake_app_project_sets_context_flow(self, runner, tmp_path):
+        self._write_yml(tmp_path, _SNOWFLAKE_APP_YML)
+
+        with change_directory(tmp_path):
+            # Triggering the routing decorator is enough; we don't need the
+            # command to succeed (it will error on cross-flow option).
+            runner.invoke(["app", "deploy", "--prune"])
+
+        assert get_cli_context().app_flow == "snowflake_app"
+
+    def test_native_app_project_sets_context_flow(self, runner, tmp_path):
+        self._write_yml(tmp_path, _NATIVE_APP_YML)
+
+        with change_directory(tmp_path):
+            runner.invoke(["app", "deploy", "--upload-only"])
+
+        assert get_cli_context().app_flow == "native_app"
+
+
 class TestNativeAppOnlyGuards:
     """Commands like ``run`` / ``publish`` / ``diff`` that only make sense for
     Native App projects must produce a clear error when the project contains
@@ -314,3 +378,130 @@ class TestNativeAppOnlyGuards:
 
         assert result.exit_code != 0
         assert "only available for Native App" in result.output
+
+
+# ── force_project_definition_v2 caller allowlist ─────────────────────
+
+
+def _find_force_v2_callers(src_root: Path) -> set[tuple[str, str]]:
+    """Walk *src_root* recursively and return the set of
+    ``(relative_path, function_name)`` tuples for every function decorated
+    with ``force_project_definition_v2`` (with or without arguments).
+
+    Uses ``ast`` rather than text search so e.g. commented-out usages or
+    string occurrences don't false-positive.
+    """
+    callers: set[tuple[str, str]] = set()
+    for path in src_root.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                # Match either @force_project_definition_v2 or
+                # @force_project_definition_v2(...).
+                target = (
+                    decorator.func if isinstance(decorator, ast.Call) else decorator
+                )
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "force_project_definition_v2"
+                ):
+                    rel = path.relative_to(src_root).as_posix()
+                    callers.add((rel, node.name))
+    return callers
+
+
+class TestForceProjectDefinitionV2Callers:
+    """``force_project_definition_v2`` stamps ``app_flow=native_app`` on
+    the CLI context (after entity resolution succeeds) on the assumption
+    that every caller is a Native-App-only command. Lock that assumption
+    in: any new caller MUST be added to ``EXPECTED_CALLERS`` below after
+    confirming the command is in fact a Native App command (operates on
+    ``application`` / ``application package`` entities).
+
+    If a future command needs ``force_project_definition_v2`` but is NOT
+    Native App (e.g. a shared command, or a Snowflake Apps Deploy
+    command), use a different decorator -- this one would silently
+    misattribute its telemetry.
+    """
+
+    EXPECTED_CALLERS: frozenset[tuple[str, str]] = frozenset(
+        {
+            ("snowflake/cli/_plugins/nativeapp/commands.py", "app_diff"),
+            ("snowflake/cli/_plugins/nativeapp/commands.py", "app_run"),
+            ("snowflake/cli/_plugins/nativeapp/commands.py", "app_publish"),
+            ("snowflake/cli/_plugins/nativeapp/version/commands.py", "create"),
+            ("snowflake/cli/_plugins/nativeapp/version/commands.py", "drop"),
+            ("snowflake/cli/_plugins/nativeapp/version/commands.py", "version_list"),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_channel/commands.py",
+                "release_channel_list",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_channel/commands.py",
+                "release_channel_add_accounts",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_channel/commands.py",
+                "release_channel_remove_accounts",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_channel/commands.py",
+                "release_channel_set_accounts",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_channel/commands.py",
+                "release_channel_add_version",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_channel/commands.py",
+                "release_channel_remove_version",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_directive/commands.py",
+                "release_directive_list",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_directive/commands.py",
+                "release_directive_set",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_directive/commands.py",
+                "release_directive_unset",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_directive/commands.py",
+                "release_directive_add_accounts",
+            ),
+            (
+                "snowflake/cli/_plugins/nativeapp/release_directive/commands.py",
+                "release_directive_remove_accounts",
+            ),
+        }
+    )
+
+    def test_callers_match_expected_set(self):
+        # Resolve src/ from the snowflake.cli package location:
+        # <repo>/src/snowflake/cli/__init__.py -> <repo>/src
+        src_root = Path(snowflake.cli.__file__).resolve().parents[2]
+        actual = _find_force_v2_callers(src_root)
+
+        unexpected = actual - self.EXPECTED_CALLERS
+        missing = self.EXPECTED_CALLERS - actual
+
+        assert not unexpected, (
+            f"force_project_definition_v2 was applied to a new function: "
+            f"{sorted(unexpected)}. If the new caller is a Native App "
+            f"command (operates on application / application package "
+            f"entities), add it to EXPECTED_CALLERS. If it's a Snowflake "
+            f"Apps Deploy or shared command, use a different decorator -- "
+            f"this one stamps app_flow=native_app for telemetry."
+        )
+        assert not missing, (
+            f"Expected callers no longer present: {sorted(missing)}. "
+            f"Update EXPECTED_CALLERS to remove them."
+        )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

This PR adds an `app_flow` field to the CLI telemetry payload (values: `native_app` or `snowflake_app`) so the two flows can be distinguished.
