### PR TITLE
fix(connection): skip non-table [connections] entries instead of crashing (SNOW-3480430)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,6 +27,7 @@
 * Fixed macOS arm64 installer incorrectly requiring Rosetta 2. The `Distribution.xml` package metadata now declares `hostArchitectures="arm64,x86_64"`, so the installer is recognized as native on Apple Silicon.
 * Fixed SQL string literal escaping in `identifier_to_show_like_pattern` and `to_string_literal` to use Snowflake's standard single-quote doubling (`''`) instead of backslash escaping, which is not interpreted under the default `STANDARD_ESCAPE_SEQUENCES=FALSE` session setting. This closes SQL injection vectors through `SHOW ... LIKE` queries driven by a project-controlled `snowflake.yml` or `manifest.yml`.
 * Upgraded `pip` to version 26.1.1.
+* Fixed `snow connection list` crashing with `AttributeError` when `config.toml` contains a scalar value directly under `[connections]`. Such entries are now skipped with a warning so valid connections are still listed.
 
 
 # v3.17.1

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -34,6 +34,7 @@ import tomlkit
 from click import ClickException
 from snowflake.cli.api.exceptions import (
     ConfigFileTooWidePermissionsError,
+    InvalidConnectionConfigurationError,
     MissingConfigurationError,
     UnsupportedConfigSectionTypeError,
 )
@@ -139,6 +140,13 @@ class ConnectionConfig:
 
     @classmethod
     def from_dict(cls, config_dict: dict) -> ConnectionConfig:
+        if not isinstance(config_dict, dict):
+            raise InvalidConnectionConfigurationError(
+                "Expected a TOML table with key/value pairs "
+                f"(e.g. `[connections.my_conn]`), got {type(config_dict).__name__}. "
+                "Check your config.toml for a connection entry that was written as a "
+                "plain value instead of a table."
+            )
         known_settings = {}
         other_settings = {}
         for key, value in config_dict.items():

--- a/src/snowflake/cli/api/config_provider.py
+++ b/src/snowflake/cli/api/config_provider.py
@@ -32,6 +32,31 @@ ALTERNATIVE_CONFIG_ENV_VAR: Final[str] = "SNOWFLAKE_CLI_CONFIG_V2_ENABLED"
 log = logging.getLogger(__name__)
 
 
+def _is_connection_table(name: str, config: Any) -> bool:
+    """Return True if ``config`` is a mapping suitable for ``ConnectionConfig.from_dict``.
+
+    A connection entry in ``config.toml`` must be a TOML table (e.g.
+    ``[connections.my_conn]``). If a user writes a plain value under
+    ``[connections]`` — for example ``my_conn = "value"`` at the top of the
+    section — downstream code crashes with ``AttributeError: 'String' object
+    has no attribute 'items'``. Skip those entries with a warning so
+    ``snow connection list`` still surfaces the valid ones.
+
+    ``tomlkit.items.Table`` inherits from ``dict``, so ``isinstance(x, dict)``
+    accepts the types we actually get from parsed config files.
+    """
+    if isinstance(config, dict):
+        return True
+    from snowflake.cli.api.console import cli_console
+
+    cli_console.warning(
+        f"Skipping connection '{name}' in config: expected a table "
+        f"(e.g. [connections.{name}]), got {type(config).__name__}. "
+        "Fix or remove this entry to silence this warning."
+    )
+    return False
+
+
 class ConfigProvider(ABC):
     """
     Abstract base class for configuration providers.
@@ -143,6 +168,7 @@ class LegacyConfigProvider(ConfigProvider):
         return {
             name: ConnectionConfig.from_dict(config)
             for name, config in connections.items()
+            if _is_connection_table(name, config)
         }
 
 
@@ -490,6 +516,7 @@ class AlternativeConfigProvider(ConfigProvider):
         return {
             name: ConnectionConfig.from_dict(config)
             for name, config in connections_dict.items()
+            if _is_connection_table(name, config)
         }
 
     def _get_file_based_connections(self) -> dict:
@@ -551,7 +578,7 @@ class AlternativeConfigProvider(ConfigProvider):
         filtered_connections: Dict[str, Dict[str, Any]] = {}
         if isinstance(raw_connections, dict):
             for conn_name, conn_config in raw_connections.items():
-                if isinstance(conn_config, dict):
+                if _is_connection_table(conn_name, conn_config):
                     filtered_connections[conn_name] = conn_config
 
         if general_params:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ import pytest
 from snowflake.cli.api.cli_global_context import fork_cli_context
 from snowflake.cli.api.config import (
     ConfigFileTooWidePermissionsError,
+    ConnectionConfig,
     config_init,
     get_config_section,
     get_connection_dict,
@@ -685,3 +686,33 @@ def test_corrupted_config_raises_human_friendly_error(
 )
 def test_get_env_variable_name(path, key, expected):
     assert get_env_variable_name(*path, key=key) == expected
+
+
+@pytest.mark.parametrize("bad_value", ["just-a-string", 42, True, ["a", "b"]])
+def test_connection_config_from_dict_rejects_non_mapping(bad_value):
+    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
+
+    with pytest.raises(InvalidConnectionConfigurationError) as exc_info:
+        ConnectionConfig.from_dict(bad_value)
+    assert "TOML table" in exc_info.value.message
+    assert type(bad_value).__name__ in exc_info.value.message
+    assert "Invalid connection configuration." in exc_info.value.format_message()
+
+
+def test_connection_config_from_dict_accepts_empty_mapping():
+    config = ConnectionConfig.from_dict({})
+    assert config.account is None
+    assert config.user is None
+
+
+def test_connection_config_from_dict_preserves_known_and_other_settings():
+    config = ConnectionConfig.from_dict(
+        {"account": "acc", "user": "u", "custom_setting": "value"}
+    )
+    assert config.account == "acc"
+    assert config.user == "u"
+    assert config.to_dict_of_all_non_empty_values() == {
+        "account": "acc",
+        "user": "u",
+        "custom_setting": "value",
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,10 @@ from snowflake.cli.api.config import (
     get_env_variable_name,
     set_config_value,
 )
-from snowflake.cli.api.exceptions import MissingConfigurationError
+from snowflake.cli.api.exceptions import (
+    InvalidConnectionConfigurationError,
+    MissingConfigurationError,
+)
 from snowflake.cli.api.feature_flags import FeatureFlag
 
 from tests.testing_utils.files_and_dirs import assert_file_permissions_are_strict
@@ -690,8 +693,6 @@ def test_get_env_variable_name(path, key, expected):
 
 @pytest.mark.parametrize("bad_value", ["just-a-string", 42, True, ["a", "b"]])
 def test_connection_config_from_dict_rejects_non_mapping(bad_value):
-    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
-
     with pytest.raises(InvalidConnectionConfigurationError) as exc_info:
         ConnectionConfig.from_dict(bad_value)
     assert "TOML table" in exc_info.value.message

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -415,6 +415,62 @@ def test_mask_sensitive_parameters_masks_all_known_sensitive_keys():
     assert params["password"] == "hunter2"
 
 
+@pytest.mark.parametrize("config_v2", [False, True])
+@pytest.mark.parametrize("extra_args", [[], ["--all"]])
+def test_connection_list_tolerates_non_table_entry(
+    runner, monkeypatch, config_v2, extra_args
+):
+    """`snow connection list` must not crash when config.toml contains a scalar
+    entry under [connections] (e.g. a stray `key = "value"` line). The bad
+    entry should be skipped, and valid entries should still be listed.
+    Covers the default path and ``--all`` (which exercises
+    ``AlternativeConfigProvider.get_all_connections`` under config v2).
+    """
+    if config_v2:
+        monkeypatch.setenv("SNOWFLAKE_CLI_CONFIG_V2_ENABLED", "1")
+        from snowflake.cli.api.config_provider import reset_config_provider
+
+        reset_config_provider()
+
+    with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
+        tmp_file.write(
+            dedent(
+                """\
+                [connections]
+                stray = "not-a-table"
+
+                [connections.good]
+                account = "acc"
+                user = "u"
+                """
+            )
+        )
+        tmp_file.flush()
+        os.chmod(tmp_file.name, 0o600)
+
+        # --format json keeps the payload machine-parseable (cli_console is
+        # auto-muted for structured output) and proves the bad entry is
+        # skipped, not crashing the command.
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
+            ["connection", "list", *extra_args, "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        names = {entry["connection_name"] for entry in payload}
+        assert "good" in names
+        assert "stray" not in names
+
+        # Default (table) format exercises the cli_console.warning path so the
+        # user actually sees what was dropped.
+        result_table = runner.invoke_with_config_file(
+            tmp_file.name,
+            ["connection", "list", *extra_args],
+        )
+        assert result_table.exit_code == 0, result_table.output
+        assert "Skipping connection 'stray'" in result_table.output
+
+
 @mock.patch.dict(
     os.environ,
     {


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes SNOW-3480430 / #2954.

`snow connection list` crashed with `AttributeError: 'String' object has no attribute 'items'` when `config.toml` had a scalar value directly under `[connections]`, e.g.:

```toml
[connections]
stray = "not-a-table"

[connections.good]
account = "acc"
user = "u"
```

`ConnectionConfig.from_dict` iterated the scalar with `.items()` unconditionally, so the whole command aborted and the user could not list any of their (otherwise valid) connections.

**Fix**

1. `ConnectionConfig.from_dict` now raises a clear `ClickException` when the input is not a mapping, so direct callers — and anyone writing config programmatically — get an actionable error (\"Connection configuration must be a TOML table with key/value pairs…\") instead of a raw `AttributeError`.
2. Both providers filter non-table entries under `[connections]` with a warning, so `snow connection list` keeps working and the user can see their good connections while being told which entry is malformed:
   - `LegacyConfigProvider.get_all_connections()` now filters via a shared `_is_connection_table` helper.
   - `AlternativeConfigProvider.get_all_connections()` (the `--all` / env-connections path) filters via the same helper.
   - `AlternativeConfigProvider._get_file_based_connections()` already silently dropped non-dicts; it now uses the same helper so the skip is logged consistently.

**Tests**

- `tests/test_config.py`:
  - `test_connection_config_from_dict_rejects_non_mapping` — parametrized over `str`, `int`, `bool`, `list` to confirm the `ClickException` message mentions \"TOML table\" and the offending type.
  - `test_connection_config_from_dict_accepts_empty_mapping` — empty table is still valid.
  - `test_connection_config_from_dict_preserves_known_and_other_settings` — happy path still routes unknown keys into `_other_settings`.
- `tests/test_connection.py::test_connection_list_tolerates_non_table_entry` — parametrized over legacy vs `SNOWFLAKE_CLI_CONFIG_V2_ENABLED=1`; writes a `config.toml` with a stray scalar under `[connections]` plus one good connection, invokes `snow connection list --format json`, and asserts the command exits 0, the good connection is listed, and the stray one is not.

Full `tests/test_config.py`, `tests/test_connection.py`, `tests/test_config_provider_integration.py`, and `tests/config_ng/` suites pass locally (402 passed, 15 skipped).

### Release notes

Entry added under *Unreleased version → Fixes and improvements*.