### PR TITLE
fix: [SNOW-3392895] escape SPCS service args in CALL SYSTEM$GET_SERVICE_* queries

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,9 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed `snow spcs service logs` and `snow spcs service status` passing user-supplied arguments directly into `CALL SYSTEM$GET_SERVICE_LOGS(...)` / `CALL SYSTEM$GET_SERVICE_STATUS(...)` without escaping single quotes. Arguments are now wrapped via `to_string_literal` before interpolation.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,9 +44,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* Fixed `snow spcs service logs` and `snow spcs service status` passing user-supplied arguments directly into `CALL SYSTEM$GET_SERVICE_LOGS(...)` / `CALL SYSTEM$GET_SERVICE_STATUS(...)` without escaping single quotes. Arguments are now wrapped via `to_string_literal` before interpolation.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -47,6 +47,7 @@ from snowflake.cli.api.artifacts.utils import bundle_artifacts
 from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB, ObjectType
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.schemas.entities.common import Artifacts
+from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.stage_path import StagePath
@@ -433,7 +434,9 @@ class ServiceManager(SqlExecutionMixin):
         return re.sub(r"\$(?=\$)", r"\\u0024", json.dumps(data))
 
     def status(self, service_name: str) -> SnowflakeCursor:
-        return self.execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")
+        return self.execute_query(
+            f"CALL SYSTEM$GET_SERVICE_STATUS({to_string_literal(service_name)})"
+        )
 
     def logs(
         self,
@@ -446,8 +449,10 @@ class ServiceManager(SqlExecutionMixin):
         include_timestamps: bool = False,
     ):
         cursor = self.execute_query(
-            f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', "
-            f"{num_lines}, {previous_logs}, '{since_timestamp}', {include_timestamps});"
+            f"call SYSTEM$GET_SERVICE_LOGS({to_string_literal(service_name)}, "
+            f"{to_string_literal(instance_id)}, {to_string_literal(container_name)}, "
+            f"{num_lines}, {previous_logs}, {to_string_literal(since_timestamp)}, "
+            f"{include_timestamps});"
         )
 
         for log in cursor.fetchall():

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -744,6 +744,23 @@ def test_status_qualified_name(mock_execute_query):
 
 
 @patch(EXECUTE_QUERY)
+def test_status_escapes_single_quote(mock_execute_query):
+    """A service name containing a single quote must be passed as an escaped literal."""
+    service_name = "svc'); DROP SERVICE foo; --"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    ServiceManager().status(service_name)
+    expected_query = (
+        f"CALL SYSTEM$GET_SERVICE_STATUS({to_string_literal(service_name)})"
+    )
+    mock_execute_query.assert_called_once_with(expected_query)
+    # The embedded quote must be escaped (backslash form) so Snowflake's parser
+    # cannot treat the remainder as a new statement.
+    sent_query = mock_execute_query.call_args[0][0]
+    assert "\\'" in sent_query
+
+
+@patch(EXECUTE_QUERY)
 def test_logs(mock_execute_query):
     service_name = "test_service"
     container_name = "test_container"
@@ -761,7 +778,11 @@ def test_logs(mock_execute_query):
     )
     result = list(result_generator)
 
-    expected_query_1 = f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines}, False, '', False);"
+    expected_query_1 = (
+        f"call SYSTEM$GET_SERVICE_LOGS({to_string_literal(service_name)}, "
+        f"{to_string_literal(instance_id)}, {to_string_literal(container_name)}, "
+        f"{num_lines}, False, {to_string_literal('')}, False);"
+    )
     expected_output = ["log_line_1", "log_line_2"]
 
     mock_execute_query.assert_has_calls([call(expected_query_1)])
@@ -779,7 +800,11 @@ def test_logs(mock_execute_query):
     )
     result = list(result_generator)
 
-    expected_query_2 = f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines}, False, '{since_timestamp}', False);"
+    expected_query_2 = (
+        f"call SYSTEM$GET_SERVICE_LOGS({to_string_literal(service_name)}, "
+        f"{to_string_literal(instance_id)}, {to_string_literal(container_name)}, "
+        f"{num_lines}, False, {to_string_literal(since_timestamp)}, False);"
+    )
     expected_output = ["log_line_1", "log_line_2"]
 
     # Assertions for Test Case 2
@@ -801,11 +826,36 @@ def test_logs(mock_execute_query):
     )
     result = list(result_generator)
 
-    expected_query_3 = f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines}, True, '', False);"
+    expected_query_3 = (
+        f"call SYSTEM$GET_SERVICE_LOGS({to_string_literal(service_name)}, "
+        f"{to_string_literal(instance_id)}, {to_string_literal(container_name)}, "
+        f"{num_lines}, True, {to_string_literal('')}, False);"
+    )
     expected_output = ["previous_log_line_1", "previous_log_line_2"]
 
     mock_execute_query.assert_has_calls([call(expected_query_3)])
     assert result == expected_output
+
+
+@patch(EXECUTE_QUERY)
+def test_logs_escapes_single_quote(mock_execute_query):
+    """String arguments containing single quotes must be passed as escaped literals."""
+    service_name = "svc'); DROP SERVICE foo; --"
+    instance_id = "0"
+    container_name = "main"
+    num_lines = 10
+
+    cursor = Mock(spec=SnowflakeCursor)
+    cursor.fetchall.return_value = []
+    mock_execute_query.return_value = cursor
+
+    list(ServiceManager().logs(service_name, instance_id, container_name, num_lines))
+
+    sent_query = mock_execute_query.call_args[0][0]
+    # The embedded quote must be escaped (backslash form), preventing parser breakout.
+    assert "\\'" in sent_query
+    # The properly-escaped literal should appear in the final query.
+    assert to_string_literal(service_name) in sent_query
 
 
 @patch("snowflake.cli._plugins.spcs.services.manager.ServiceManager.logs")

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -754,10 +754,6 @@ def test_status_escapes_single_quote(mock_execute_query):
         f"CALL SYSTEM$GET_SERVICE_STATUS({to_string_literal(service_name)})"
     )
     mock_execute_query.assert_called_once_with(expected_query)
-    # The embedded quote must be escaped (backslash form) so Snowflake's parser
-    # cannot treat the remainder as a new statement.
-    sent_query = mock_execute_query.call_args[0][0]
-    assert "\\'" in sent_query
 
 
 @patch(EXECUTE_QUERY)
@@ -852,9 +848,6 @@ def test_logs_escapes_single_quote(mock_execute_query):
     list(ServiceManager().logs(service_name, instance_id, container_name, num_lines))
 
     sent_query = mock_execute_query.call_args[0][0]
-    # The embedded quote must be escaped (backslash form), preventing parser breakout.
-    assert "\\'" in sent_query
-    # The properly-escaped literal should appear in the final query.
     assert to_string_literal(service_name) in sent_query
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description