### PR TITLE
fix: guard get_account_identifier / spcs build-image against NULL org

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Upgraded `snowflake-connector-python` from 4.5.0 to 4.6.0.
 * `snow dcm list-deployments` and `snow dcm drop-deployment` now wrap the project name in `IDENTIFIER(...)`, matching every other DCM subcommand. Fully-qualified and quoted project names are now handled consistently.
 * Fixed `snow sql` table output rendering as a series of `|` characters when selecting many columns into a non-terminal destination (e.g. piped or redirected output).
+* `get_account_identifier()` and `snow spcs service build-image` now raise a clear, user-visible error when `CURRENT_ORGANIZATION_NAME()` / `CURRENT_ACCOUNT_NAME()` return no row or a NULL value, instead of a cryptic `TypeError: 'NoneType' object is not subscriptable` / `AttributeError: 'NoneType' object has no attribute 'lower'`.
 
 
 # v3.19.0

--- a/src/snowflake/cli/_plugins/connection/util.py
+++ b/src/snowflake/cli/_plugins/connection/util.py
@@ -228,9 +228,21 @@ def get_account_identifier(conn: SnowflakeConnection) -> AccountIdentifier:
         cursor_class=DictCursor,
     )
     result = cursor.fetchone()
+    if result is None:
+        raise ClickException(
+            "Could not determine account identifier: "
+            "CURRENT_ORGANIZATION_NAME() / CURRENT_ACCOUNT_NAME() returned no row."
+        )
+    org = result.get("ORG")
+    account = result.get("ACCT")
+    if not org or not account:
+        raise ClickException(
+            "Could not determine account identifier: "
+            f"CURRENT_ORGANIZATION_NAME()={org!r}, CURRENT_ACCOUNT_NAME()={account!r}."
+        )
     return AccountIdentifier(
-        organization_name=result["ORG"],
-        account_name=result["ACCT"],
+        organization_name=org,
+        account_name=account,
     )
 
 

--- a/src/snowflake/cli/_plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/services/manager.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import yaml
-from snowflake.cli._plugins.connection.util import get_account
+from snowflake.cli._plugins.connection.util import get_account_identifier
 from snowflake.cli._plugins.object.common import Tag
 from snowflake.cli._plugins.object.manager import ObjectManager
 from snowflake.cli._plugins.spcs.common import (
@@ -332,15 +332,13 @@ class ServiceManager(SqlExecutionMixin):
             external_access_integrations: List of EAI names
             async_mode: Whether to run the build asynchronously
         """
-        # Get organization name
-        # Using execute_string (same as get_account) for consistency
-        *_, org_cursor = self._conn.execute_string(
-            "SELECT CURRENT_ORGANIZATION_NAME()", cursor_class=DictCursor
-        )
-        org_name = org_cursor.fetchone()["CURRENT_ORGANIZATION_NAME()"].lower()
-
-        # Get account name using existing utility function
-        account_name = get_account(self._conn)
+        # Resolve org/account via the shared helper — one round-trip, with a
+        # clear error if CURRENT_ORGANIZATION_NAME/CURRENT_ACCOUNT_NAME return
+        # NULL or no row (rather than an opaque ``TypeError: 'NoneType' is not
+        # subscriptable``).
+        account_identifier = get_account_identifier(self._conn)
+        org_name = account_identifier.organization_name.lower()
+        account_name = account_identifier.account_name.lower()
 
         # Parse the image repository using FQN utility
         # This handles [db.][schema.]repo_name format automatically

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -2110,9 +2110,8 @@ def normalize_query(query):
 
 
 # Tests for build_image command
-@patch("snowflake.cli._plugins.connection.util.get_account")
 @patch(EXECUTE_QUERY)
-def test_build_image(mock_execute_query, mock_get_account):
+def test_build_image(mock_execute_query):
     """Test build_image with all parameters."""
     job_service_name = "test_build_job"
     compute_pool = "test_pool"
@@ -2123,16 +2122,17 @@ def test_build_image(mock_execute_query, mock_get_account):
     build_context_path = "build_contexts/test"
     external_access_integrations = ["eai1", "eai2"]
 
-    # Mock connection responses
+    # Mock the shared get_account_identifier round-trip (ORG + ACCT in one row).
     mock_org_cursor = Mock()
-    mock_org_cursor.fetchone.return_value = {"CURRENT_ORGANIZATION_NAME()": "TEST_ORG"}
+    mock_org_cursor.fetchone.return_value = {
+        "ORG": "TEST_ORG",
+        "ACCT": "TEST_ACCOUNT",
+    }
     mock_conn = Mock()
     mock_conn.execute_string.return_value = (None, mock_org_cursor)
     mock_conn.database = None
     mock_conn.schema = None
     mock_conn.account = "test_account"
-
-    mock_get_account.return_value = "test_account"
 
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
@@ -2200,8 +2200,7 @@ def test_build_image(mock_execute_query, mock_get_account):
     assert result == cursor
 
 
-@patch("snowflake.cli._plugins.connection.util.get_account")
-def test_build_image_repository_validation(mock_get_account):
+def test_build_image_repository_validation():
     """Test build_image validates image repository format.
 
     FQN parsing behavior:
@@ -2212,14 +2211,15 @@ def test_build_image_repository_validation(mock_get_account):
     Note: It's impossible to have database present without schema.
     """
     mock_org_cursor = Mock()
-    mock_org_cursor.fetchone.return_value = {"CURRENT_ORGANIZATION_NAME()": "TEST_ORG"}
+    mock_org_cursor.fetchone.return_value = {
+        "ORG": "TEST_ORG",
+        "ACCT": "TEST_ACCOUNT",
+    }
     mock_conn = Mock()
     mock_conn.execute_string.return_value = (None, mock_org_cursor)
     mock_conn.database = None
     mock_conn.schema = None
     mock_conn.account = "test_account"
-
-    mock_get_account.return_value = "test_account"
 
     manager = ServiceManager(connection=mock_conn)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -247,6 +247,34 @@ def test_get_account_identifier(mock_get_account):
 
 
 @pytest.mark.parametrize(
+    "fetchone_return",
+    [
+        None,
+        {"ORG": None, "ACCT": "my_account"},
+        {"ORG": "my_org", "ACCT": None},
+        {"ORG": "", "ACCT": "my_account"},
+        {"ORG": "my_org", "ACCT": ""},
+    ],
+)
+def test_get_account_identifier_missing_result_raises_click_exception(fetchone_return):
+    """``get_account_identifier`` must raise a user-visible ``ClickException``
+    when ``CURRENT_ORGANIZATION_NAME()`` / ``CURRENT_ACCOUNT_NAME()`` return
+    no row or a NULL value, instead of a cryptic ``TypeError`` / ``AttributeError``."""
+    from unittest.mock import MagicMock
+
+    from click.exceptions import ClickException
+    from snowflake.cli._plugins.connection.util import get_account_identifier
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = fetchone_return
+    mock_conn.execute_string.return_value = (None, mock_cursor)
+
+    with pytest.raises(ClickException, match="Could not determine account identifier"):
+        get_account_identifier(mock_conn)
+
+
+@pytest.mark.parametrize(
     "allowlist, expected",
     [
         (


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Both `get_account_identifier()` (in `connection/util.py`) and `snow spcs service build-image` (in `spcs/services/manager.py`) call `cursor.fetchone()` on the result of `SELECT CURRENT_ORGANIZATION_NAME() …` / `SELECT CURRENT_ACCOUNT_NAME() …` and then immediately subscript or `.lower()` the returned row — without checking whether `fetchone()` returned `None` or whether the column values are `NULL` / empty.

In practice this crashes the CLI with either:
- `TypeError: 'NoneType' object is not subscriptable` (when `fetchone()` returns `None`), or
- `AttributeError: 'NoneType' object has no attribute 'lower'` (when the column value is `NULL`)

…instead of a user-visible, actionable error. The existing call site in `dcm/commands.py` already wraps `get_account_identifier()` in a broad `try/except`, which suggests this has been flaky in the field.

**Changes**

1. `connection/util.py::get_account_identifier` — guard against `fetchone() is None` and against `NULL`/empty `ORG`/`ACCT` values. Raise a `ClickException` with a clear message in both cases.
2. `spcs/services/manager.py::build_image` — replace the ad-hoc `SELECT CURRENT_ORGANIZATION_NAME()` + separate `get_account(…)` call (two SQL round-trips, two independent failure modes) with a single call to the hardened `get_account_identifier(…)` helper. One round-trip, consistent error handling.
3. Tests:
   - New parametrised test `test_get_account_identifier_missing_result_raises_click_exception` covers: `fetchone() is None`, `ORG=None`, `ACCT=None`, `ORG=""`, `ACCT=""`.
   - Existing `test_build_image` / `test_build_image_repository_validation` updated to mock the new two-column `{"ORG": …, "ACCT": …}` shape and drop the obsolete `get_account` patch.
4. `RELEASE-NOTES.md` — entry under Unreleased / Fixes and improvements.

**Risk**

Low. Pure error-path hardening + a one-round-trip refactor of an existing call site. No behaviour change on the happy path. Full unit-test suites for `tests/test_utils.py`, `tests/spcs/`, `tests/connection/`, `tests/config_ng/` pass locally.