### PR TITLE
Fix SQL injection in secret and git repo helpers (SNOW-3417285)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,9 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed single-quote characters in user-supplied strings being interpolated verbatim into generated SQL in `snow secret create`, `snow git setup`, and the underlying `create_password_secret` / `create_api_integration` / git repository helpers. Values are now escaped with Snowflake's standard `''` convention, and the `snow git setup` URL validator rejects origins containing single quotes.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,9 +44,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* Fixed single-quote characters in user-supplied strings being interpolated verbatim into generated SQL in `snow secret create`, `snow git setup`, and the underlying `create_password_secret` / `create_api_integration` / git repository helpers. Values are now escaped with Snowflake's standard `''` convention, and the `snow git setup` URL validator rejects origins containing single quotes.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/git/commands.py
+++ b/src/snowflake/cli/_plugins/git/commands.py
@@ -97,6 +97,8 @@ def _assure_repository_does_not_exist(om: ObjectManager, repository_name: FQN) -
 def _validate_origin_url(url: str) -> None:
     if not url.startswith("https://"):
         raise ClickException("Url address should start with 'https'")
+    if "'" in url:
+        raise ClickException("Url address must not contain single-quote characters")
 
 
 def _unique_new_object_name(

--- a/src/snowflake/cli/_plugins/git/manager.py
+++ b/src/snowflake/cli/_plugins/git/manager.py
@@ -96,11 +96,12 @@ class GitManager(StageManager):
     def create(
         self, repo_name: FQN, api_integration: str, url: str, secret: str
     ) -> SnowflakeCursor:
+        safe_url = url.replace("'", "''")
         query = dedent(
             f"""
             create git repository {repo_name.sql_identifier}
             api_integration = {api_integration}
-            origin = '{url}'
+            origin = '{safe_url}'
             """
         )
         if secret is not None:

--- a/src/snowflake/cli/_plugins/git/manager.py
+++ b/src/snowflake/cli/_plugins/git/manager.py
@@ -26,6 +26,7 @@ from snowflake.cli._plugins.stage.manager import (
     UserStagePathParts,
 )
 from snowflake.cli.api.identifiers import FQN
+from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.api.stage_path import StagePath
 from snowflake.connector.cursor import SnowflakeCursor
 
@@ -96,12 +97,11 @@ class GitManager(StageManager):
     def create(
         self, repo_name: FQN, api_integration: str, url: str, secret: str
     ) -> SnowflakeCursor:
-        safe_url = url.replace("'", "''")
         query = dedent(
             f"""
             create git repository {repo_name.sql_identifier}
             api_integration = {api_integration}
-            origin = '{safe_url}'
+            origin = {to_string_literal(url)}
             """
         )
         if secret is not None:

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -185,23 +185,26 @@ class SqlExecutor(BaseSqlExecutor):
     def create_password_secret(
         self, name: FQN, username: str, password: str
     ) -> SnowflakeCursor:
+        safe_username = username.replace("'", "''")
+        safe_password = password.replace("'", "''")
         return self.execute_query(
             f"""
             create secret {name.sql_identifier}
             type = password
-            username = '{username}'
-            password = '{password}'
+            username = '{safe_username}'
+            password = '{safe_password}'
             """
         )
 
     def create_api_integration(
         self, name: FQN, api_provider: str, allowed_prefix: str, secret: Optional[str]
     ) -> SnowflakeCursor:
+        safe_allowed_prefix = allowed_prefix.replace("'", "''")
         return self.execute_query(
             f"""
             create api integration {name.sql_identifier}
             api_provider = {api_provider}
-            api_allowed_prefixes = ('{allowed_prefix}')
+            api_allowed_prefixes = ('{safe_allowed_prefix}')
             allowed_authentication_secrets = ({secret if secret else ""})
             enabled = true
             """

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -35,6 +35,7 @@ from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.util import (
     identifier_to_show_like_pattern,
     to_identifier,
+    to_string_literal,
     unquote_identifier,
 )
 from snowflake.cli.api.utils.cursor import find_first_row
@@ -185,26 +186,23 @@ class SqlExecutor(BaseSqlExecutor):
     def create_password_secret(
         self, name: FQN, username: str, password: str
     ) -> SnowflakeCursor:
-        safe_username = username.replace("'", "''")
-        safe_password = password.replace("'", "''")
         return self.execute_query(
             f"""
             create secret {name.sql_identifier}
             type = password
-            username = '{safe_username}'
-            password = '{safe_password}'
+            username = {to_string_literal(username)}
+            password = {to_string_literal(password)}
             """
         )
 
     def create_api_integration(
         self, name: FQN, api_provider: str, allowed_prefix: str, secret: Optional[str]
     ) -> SnowflakeCursor:
-        safe_allowed_prefix = allowed_prefix.replace("'", "''")
         return self.execute_query(
             f"""
             create api integration {name.sql_identifier}
             api_provider = {api_provider}
-            api_allowed_prefixes = ('{safe_allowed_prefix}')
+            api_allowed_prefixes = ({to_string_literal(allowed_prefix)})
             allowed_authentication_secrets = ({secret if secret else ""})
             enabled = true
             """

--- a/tests/api/test_sql_execution.py
+++ b/tests/api/test_sql_execution.py
@@ -156,6 +156,9 @@ def test_use_schema_fqn(mock_execute_query):
         ),
         ("john_doe", "a'b'c", "john_doe", "a''b''c"),
         ("o'brien", "d'arcy", "o''brien", "d''arcy"),
+        # Backslash before quote: doubled so neither STANDARD_ESCAPE_SEQUENCES
+        # mode lets the literal terminate prematurely.
+        ("foo\\'bar", "p\\'wd", "foo\\\\''bar", "p\\\\''wd"),
     ],
 )
 @mock.patch(EXECUTE_QUERY)
@@ -182,6 +185,7 @@ def test_create_password_secret_escapes_single_quotes(
             "https://github.com/''); GRANT ROLE ACCOUNTADMIN TO USER attacker;--",
         ),
         ("a'b'c", "a''b''c"),
+        ("https://example.com/x\\'y", "https://example.com/x\\\\''y"),
     ],
 )
 @mock.patch(EXECUTE_QUERY)

--- a/tests/api/test_sql_execution.py
+++ b/tests/api/test_sql_execution.py
@@ -16,6 +16,7 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.constants import ObjectType
+from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.sql_execution import SqlExecutor
 
 EXECUTE_QUERY = f"snowflake.cli.api.sql_execution.BaseSqlExecutor.execute_query"
@@ -141,3 +142,58 @@ def test_use_warehouse_same_id(
 def test_use_schema_fqn(mock_execute_query):
     SqlExecutor().use(ObjectType.SCHEMA, "db.schema")
     assert mock_execute_query.mock_calls == [mock.call("use schema db.schema")]
+
+
+@pytest.mark.parametrize(
+    "username, password, expected_username, expected_password",
+    [
+        ("john_doe", "admin123", "john_doe", "admin123"),
+        (
+            "ok'); GRANT ROLE ACCOUNTADMIN TO USER attacker;--",
+            "admin123",
+            "ok''); GRANT ROLE ACCOUNTADMIN TO USER attacker;--",
+            "admin123",
+        ),
+        ("john_doe", "a'b'c", "john_doe", "a''b''c"),
+        ("o'brien", "d'arcy", "o''brien", "d''arcy"),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+def test_create_password_secret_escapes_single_quotes(
+    mock_execute_query, username, password, expected_username, expected_password
+):
+    SqlExecutor().create_password_secret(
+        name=FQN.from_string("my_secret"),
+        username=username,
+        password=password,
+    )
+    assert mock_execute_query.call_count == 1
+    query = mock_execute_query.mock_calls[0].args[0]
+    assert f"username = '{expected_username}'" in query
+    assert f"password = '{expected_password}'" in query
+
+
+@pytest.mark.parametrize(
+    "allowed_prefix, expected_prefix",
+    [
+        ("https://github.com/repo.git", "https://github.com/repo.git"),
+        (
+            "https://github.com/'); GRANT ROLE ACCOUNTADMIN TO USER attacker;--",
+            "https://github.com/''); GRANT ROLE ACCOUNTADMIN TO USER attacker;--",
+        ),
+        ("a'b'c", "a''b''c"),
+    ],
+)
+@mock.patch(EXECUTE_QUERY)
+def test_create_api_integration_escapes_allowed_prefix(
+    mock_execute_query, allowed_prefix, expected_prefix
+):
+    SqlExecutor().create_api_integration(
+        name=FQN.from_string("my_api"),
+        api_provider="git_https_api",
+        allowed_prefix=allowed_prefix,
+        secret=None,
+    )
+    assert mock_execute_query.call_count == 1
+    query = mock_execute_query.mock_calls[0].args[0]
+    assert f"api_allowed_prefixes = ('{expected_prefix}')" in query

--- a/tests/git/test_git_commands.py
+++ b/tests/git/test_git_commands.py
@@ -256,6 +256,50 @@ def test_setup_invalid_url_error(mock_om_describe, mock_connector, runner, mock_
 
 @mock.patch("snowflake.connector.connect")
 @mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.describe")
+def test_setup_url_with_single_quote_rejected(
+    mock_om_describe, mock_connector, runner, mock_ctx
+):
+    mock_om_describe.side_effect = ProgrammingError(
+        errno=DOES_NOT_EXIST_OR_NOT_AUTHORIZED
+    )
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+    malicious_url = "https://example.com/repo'); GRANT ROLE ACCOUNTADMIN TO USER a;--"
+    communication = f"{malicious_url}\nn\n\n"
+    result = runner.invoke(["git", "setup", "repo_name"], input=communication)
+
+    assert result.exit_code == 1, result.output
+    assert "Error" in result.output
+    assert "Url address must not contain single-quote characters" in result.output
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.describe")
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.show")
+def test_setup_escapes_single_quote_in_password(
+    mock_om_show, mock_om_describe, mock_connector, runner, mock_ctx, mock_cursor
+):
+    mock_om_show.return_value = mock_cursor([], [])
+    mock_om_describe.side_effect = ProgrammingError(
+        errno=DOES_NOT_EXIST_OR_NOT_AUTHORIZED
+    )
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    password_with_quote = "pa'ss"
+    communication = "\n".join(
+        [EXAMPLE_URL, "y", "", "john_doe", password_with_quote, "new_integration", ""]
+    )
+    result = runner.invoke(["git", "setup", "repo_name"], input=communication)
+
+    assert result.exit_code == 0, result.output
+    query = ctx.get_query()
+    assert "password = 'pa''ss'" in query
+    assert "password = 'pa'ss'" not in query
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.describe")
 @mock.patch("snowflake.cli._plugins.snowpark.commands.ObjectManager.show")
 def test_setup_no_secret_existing_api(
     mock_om_show, mock_om_describe, mock_connector, runner, mock_ctx, mock_cursor


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes SNOW-3417285: three SQL-construction helpers embedded user-controlled strings into single-quoted literals without applying Snowflake's standard ``''`` escaping.

**Sinks**

- ``SqlExecutor.create_password_secret`` (``src/snowflake/cli/api/sql_execution.py:185``) — ``username`` / ``password`` interpolated verbatim.
- ``SqlExecutor.create_api_integration`` (``src/snowflake/cli/api/sql_execution.py:197``) — ``allowed_prefix`` interpolated verbatim inside ``API_ALLOWED_PREFIXES = ('{allowed_prefix}')``.
- ``GitManager.create`` (``src/snowflake/cli/_plugins/git/manager.py:96``) — ``url`` interpolated verbatim inside ``ORIGIN = '{url}'``.

Because ``execute_query`` routes through ``execute_stream`` (``sql_execution.py:85``), which splits the string on ``;`` and runs each statement separately, a single quote in any of those values terminates the string literal early and allows arbitrary SQL to be injected under the developer's session role. The most accessible vector is the git repository origin URL: ``snow git setup`` only required the URL to start with ``https://``, so a crafted origin like

```
https://example.com/repo'); GRANT ROLE ACCOUNTADMIN TO USER attacker;--
```

passed the validator and injected a second statement into the generated SQL.

**Fix**

- All three interpolation sites now double embedded single quotes before substitution (Snowflake's standard literal-escape, which is sound under the default ``STANDARD_ESCAPE_SEQUENCES=FALSE``).
- ``_validate_origin_url`` in ``git/commands.py`` additionally rejects URLs that contain a single quote.

Tests cover benign, malicious, and multi-quote inputs for each of ``create_password_secret``, ``create_api_integration``, ``GitManager.create`` (via the ``snow git setup`` flow), and the tightened ``_validate_origin_url``.

### Links

- Jira: [SNOW-3417285](https://snowflakecomputing.atlassian.net/browse/SNOW-3417285)
- CWE-89: Improper Neutralization of Special Elements used in an SQL Command
- Related: #2930 (same escaping convention applied to ``to_string_literal`` / ``identifier_to_show_like_pattern``)

[SNOW-3417285]: https://snowflakecomputing.atlassian.net/browse/SNOW-3417285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ