### PR TITLE
fix: [SNOW-3388311] stop duplicate LOGIN_HISTORY events when snow is rejected by an auth policy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Fixed duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) emitted when a `snow` command is rejected by an authentication policy. The internal connection cache now remembers a failed connect attempt and re-raises it on subsequent accesses within the same process, instead of re-dialing Snowflake once per access of the shared connection.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,7 +25,7 @@
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* Fixed duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) emitted when a `snow` command is rejected by an authentication policy. The internal connection cache now remembers a failed connect attempt and re-raises it on subsequent accesses within the same process, instead of re-dialing Snowflake once per access of the shared connection.
+* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/sql/repl.py
+++ b/src/snowflake/cli/_plugins/sql/repl.py
@@ -259,6 +259,10 @@ class Repl:
                 except Exception as e:
                     log.debug("error occurred: %s", e)
                     cli_console.warning(f"\nError occurred: {e}")
+                    # Connect failures are cached by OpenConnectionCache; drop
+                    # the cache so the next query can redial after the user
+                    # fixes config or a transient blip clears.
+                    get_cli_context_manager().connection_cache.clear_failures()
 
             except KeyboardInterrupt:  # a.k.a Ctrl-C
                 log.debug("user interrupted with Ctrl-C")
@@ -274,6 +278,7 @@ class Repl:
 
             except Exception as e:
                 cli_console.warning(f"\nError occurred: {e}")
+                get_cli_context_manager().connection_cache.clear_failures()
 
     def set_next_input(self, text: str) -> None:
         """Set the text that will be used as the next REPL input."""

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -216,6 +216,7 @@ class OpenConnectionCache:
 
     connections: dict[str, SnowflakeConnection]
     cleanup_futures: dict[str, asyncio.TimerHandle]
+    failures: dict[str, Exception]
 
     CONNECTION_CLEANUP_SEC: float = 10.0 * 60
     """Connections are closed this many seconds after the last time they are accessed."""
@@ -223,6 +224,7 @@ class OpenConnectionCache:
     def __init__(self):
         self.connections = {}
         self.cleanup_futures = {}
+        self.failures = {}
 
     def __getitem__(self, ctx):
         if not isinstance(ctx, ConnectionContext):
@@ -230,6 +232,14 @@ class OpenConnectionCache:
                 f"Expected key to be ConnectionContext but got {repr(ctx)}"
             )
         key = repr(ctx)
+        if key in self.failures:
+            # A prior attempt for this context already failed; re-raise rather
+            # than dialing again. Without this, every access of the CLI's
+            # global connection (pre-command telemetry, command body, error
+            # handler, post-command telemetry) would trigger an independent
+            # connect() call, producing duplicate LOGIN_HISTORY events on
+            # auth-policy rejection and similar deterministic failures.
+            raise self.failures[key]
         if not self._has_open_connection(key):
             self._insert(key, ctx)
         self._touch(key)
@@ -245,6 +255,11 @@ class OpenConnectionCache:
         for future in self.cleanup_futures.values():
             future.cancel()
         self.cleanup_futures.clear()
+        self.failures.clear()
+
+    def clear_failures(self):
+        """Forgets cached failed-connection attempts so they can be retried."""
+        self.failures.clear()
 
     def _has_open_connection(self, key: str):
         return key in self.connections
@@ -257,10 +272,11 @@ class OpenConnectionCache:
             # given ConnectionContext if get_env_value or get_connection_dict would
             # have returned different values (i.e. env / config have changed).
             self.connections[key] = ctx.build_connection()
-        except Exception:
+        except Exception as exc:
             logger.debug(
-                "ConnectionCache: failed to connect using %s; not caching.", key
+                "ConnectionCache: failed to connect using %s; caching failure.", key
             )
+            self.failures[key] = exc
             raise
 
     def _cancel_cleanup_future_if_exists(self, key: str):

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -17,6 +17,8 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.connections import ConnectionContext, OpenConnectionCache
+from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
+from snowflake.connector.errors import DatabaseError
 
 
 @pytest.fixture
@@ -124,7 +126,6 @@ def test_connection_cache_caches(
     )
 
 
-@mock.patch("snowflake.connector.connect")
 @mock.patch("snowflake.cli._app.snow_connector.command_info")
 def test_connection_cache_caches_failures(
     mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
@@ -134,9 +135,6 @@ def test_connection_cache_caches_failures(
     events (one per access of the CLI's global connection: pre-command
     telemetry, command body, error handler, post-command telemetry).
     """
-    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
-    from snowflake.connector.errors import DatabaseError
-
     mock_command_info.return_value = "application"
     mock_connect.side_effect = DatabaseError(
         msg="Failed to connect to DB: host:port. Sign-in disallowed by authentication policy",
@@ -161,18 +159,14 @@ def test_connection_cache_caches_failures(
     assert mock_connect.call_count == 1
 
 
-@mock.patch("snowflake.connector.connect")
 @mock.patch("snowflake.cli._app.snow_connector.command_info")
 def test_connection_cache_clear_failures_allows_retry(
     mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
 ):
-    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
-    from snowflake.connector.errors import DatabaseError
-
     mock_command_info.return_value = "application"
     mock_connect.side_effect = [
         DatabaseError(msg="boom", errno=250001),
-        mock.MagicMock(),
+        mock_connect.mocked_ctx,
     ]
 
     from snowflake.cli.api.config import config_init
@@ -191,18 +185,14 @@ def test_connection_cache_clear_failures_allows_retry(
     assert mock_connect.call_count == 2
 
 
-@mock.patch("snowflake.connector.connect")
 @mock.patch("snowflake.cli._app.snow_connector.command_info")
 def test_connection_cache_clear_also_forgets_failures(
     mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
 ):
-    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
-    from snowflake.connector.errors import DatabaseError
-
     mock_command_info.return_value = "application"
     mock_connect.side_effect = [
         DatabaseError(msg="boom", errno=250001),
-        mock.MagicMock(),
+        mock_connect.mocked_ctx,
     ]
 
     from snowflake.cli.api.config import config_init

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -122,3 +122,99 @@ def test_connection_cache_caches(
         password="dummy_password",
         application_name="snowcli",
     )
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+def test_connection_cache_caches_failures(
+    mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
+):
+    """Once a connect() call fails, subsequent accesses must re-raise without
+    re-dialing — otherwise auth-policy rejection logs duplicate LOGIN_HISTORY
+    events (one per access of the CLI's global connection: pre-command
+    telemetry, command body, error handler, post-command telemetry).
+    """
+    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
+    from snowflake.connector.errors import DatabaseError
+
+    mock_command_info.return_value = "application"
+    mock_connect.side_effect = DatabaseError(
+        msg="Failed to connect to DB: host:port. Sign-in disallowed by authentication policy",
+        errno=250001,
+    )
+
+    from snowflake.cli.api.config import config_init
+
+    config_init(test_snowcli_config)
+
+    ctx = ConnectionContext(connection_name="default")
+
+    cached_exc = None
+    for _ in range(3):
+        with pytest.raises(InvalidConnectionConfigurationError) as excinfo:
+            local_connection_cache[ctx]
+        if cached_exc is None:
+            cached_exc = excinfo.value
+        else:
+            assert excinfo.value is cached_exc
+
+    assert mock_connect.call_count == 1
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+def test_connection_cache_clear_failures_allows_retry(
+    mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
+):
+    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
+    from snowflake.connector.errors import DatabaseError
+
+    mock_command_info.return_value = "application"
+    mock_connect.side_effect = [
+        DatabaseError(msg="boom", errno=250001),
+        mock.MagicMock(),
+    ]
+
+    from snowflake.cli.api.config import config_init
+
+    config_init(test_snowcli_config)
+
+    ctx = ConnectionContext(connection_name="default")
+
+    with pytest.raises(InvalidConnectionConfigurationError):
+        local_connection_cache[ctx]
+    assert mock_connect.call_count == 1
+
+    local_connection_cache.clear_failures()
+
+    local_connection_cache[ctx]
+    assert mock_connect.call_count == 2
+
+
+@mock.patch("snowflake.connector.connect")
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+def test_connection_cache_clear_also_forgets_failures(
+    mock_command_info, mock_connect, local_connection_cache, test_snowcli_config
+):
+    from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
+    from snowflake.connector.errors import DatabaseError
+
+    mock_command_info.return_value = "application"
+    mock_connect.side_effect = [
+        DatabaseError(msg="boom", errno=250001),
+        mock.MagicMock(),
+    ]
+
+    from snowflake.cli.api.config import config_init
+
+    config_init(test_snowcli_config)
+
+    ctx = ConnectionContext(connection_name="default")
+
+    with pytest.raises(InvalidConnectionConfigurationError):
+        local_connection_cache[ctx]
+
+    local_connection_cache.clear()
+
+    local_connection_cache[ctx]
+    assert mock_connect.call_count == 2

--- a/tests/sql/test_repl.py
+++ b/tests/sql/test_repl.py
@@ -69,6 +69,24 @@ def test_exit_sequence(user_inputs, repl, os_agnostic_snapshot, capsys):
     os_agnostic_snapshot.assert_match(output)
 
 
+def test_repl_clears_cached_failure_after_query_error(repl):
+    """A transient connect failure mid-REPL must not poison the cache for
+    the remainder of the session — otherwise every subsequent query would
+    re-raise the cached exception until the user relaunches `snow sql`.
+    """
+    cache = get_cli_context_manager().connection_cache
+    with mock.patch.object(repl, "_initialize_connection"), mock.patch.object(
+        cache, "clear_failures"
+    ) as mock_clear_failures, mock.patch.object(
+        repl, "_execute", side_effect=Exception("transient connect blip")
+    ), mock.patch.object(
+        repl.session, "prompt", side_effect=iter(("select 1;", "exit", "y"))
+    ):
+        repl.run()
+
+    mock_clear_failures.assert_called_once()
+
+
 def test_repl_full_app(runner, os_agnostic_snapshot, mock_cursor):
     user_inputs = iter(("exit", "y"))
     mocked_cursor = [


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Resolves [SNOW-3388311](https://snowflakecomputing.atlassian.net/browse/SNOW-3388311).

A single `snow` invocation that is blocked by an authentication policy was emitting **3 `AUTHN_POLICY_AUTHN_ATTEMPT_REJECTED`** events plus an **`OVERFLOW_FAILURE_EVENTS_ELIDED`** into `LOGIN_HISTORY`, while SnowSQL emits only 1. This makes it hard for customers to correlate a policy rejection with an actual user action, and inflates the apparent attack surface in security dashboards.

#### Root cause

The duplicates are not driver retries — the Python connector only dials once per `connect()`. They come from the CLI accessing `get_cli_context().connection` from several code paths per command:

1. pre-command telemetry (`pre_execute`)
2. the command body itself
3. the global `exception_handler`
4. post-command telemetry flush (`post_execute` → `flush_telemetry`)

Every access goes through `OpenConnectionCache`. The cache cached *successful* connections but deliberately skipped caching failures (`logger.debug("... not caching")`), so each of the 4 accesses independently called `build_connection()` → `connect_to_snowflake()` → `snowflake.connector.connect()`. Each dial produces its own `AUTHN_POLICY_AUTHN_ATTEMPT_REJECTED` event; GS elides the 4th once the per-account/per-window cap is hit, adding `OVERFLOW_FAILURE_EVENTS_ELIDED`. Net: 3 rejected + 1 overflow = the customer-visible pattern.

(A couple of the accesses are wrapped in `@ignore_exceptions()` for telemetry, so the user never sees the extra failures — but GS still records them.)

#### Fix

Cache the exception on the first failure in `OpenConnectionCache._insert()` and short-circuit subsequent `__getitem__` calls for the same `ConnectionContext`:

- new `failures: dict[str, Exception]` alongside `connections`;
- `__getitem__` re-raises the cached exception instead of redialing;
- `_insert` stores the exception on failure before re-raising;
- new `clear_failures()` for callers that want to retry without tearing down cached *open* connections;
- existing `clear()` also wipes failures.

After the fix a rejected CLI invocation dials Snowflake exactly once — matching SnowSQL and the customer's expectation — regardless of how many internal accesses of the shared connection the command makes.

Scope notes:
- The cache is per-process, so this does **not** change cross-invocation retry behavior. Re-running `snow` still produces a new connect attempt (as intended).
- `snow sql` REPL is unaffected: `_initialize_connection` runs first at startup and `sys.exit`s on auth failure, so the REPL loop never sees a cached failure.
- I considered a narrower fix keyed on the specific error code (390202 → 250001), but the driver rewrites 390202 into a generic `ER_FAILED_TO_CONNECT_TO_DB` before the CLI sees it, so a narrow fix would require brittle message-string matching. Caching *all* deterministic failures per context is the right shape — any auth-time error would have emitted the same duplicates.

#### Tests

Added 3 unit tests in `tests/api/test_connections.py`:

- `test_connection_cache_caches_failures` — 3 accesses after an auth-policy-like `DatabaseError`, asserts only 1 underlying `connect()` call and that the same exception instance is re-raised each time.
- `test_connection_cache_clear_failures_allows_retry` — after `clear_failures()`, a subsequent access redials.
- `test_connection_cache_clear_also_forgets_failures` — the existing `clear()` also forgets failures.

Ran wider suites locally with no regressions:
- `tests/api/test_connections.py`: 8 passed.
- `tests/api/` + `tests/app/` + `tests/test_connection.py` + `tests/test_common_global_context.py`: 692 passed.
- `tests/sql/` + `tests/api/test_sql_execution.py`: 224 passed.

[SNOW-3388311]: https://snowflakecomputing.atlassian.net/browse/SNOW-3388311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


---
Supersedes #2923 — identical commits (same SHA: `2ce2a491`). Re-opened from an upstream branch because branch protection on `main` requires `*-trusted` status checks that only fire for PRs from the upstream repo, not forks. Previous review and approval history is on #2923.
