### PR TITLE
fix: [SNOW-3417288] redact credentials in ConnectionContext repr

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,9 +44,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* Credentials (password, tokens, private-key material, OAuth client secret, MFA passcode) are now redacted as `'***'` in the `ConnectionContext` repr and in any debug log message built from it. Previously these values could be written verbatim to `~/.snowflake/logs/` whenever a connection failed or debug logging was enabled.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,9 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* Credentials (password, tokens, private-key material, OAuth client secret, MFA passcode) are now redacted as `'***'` in the `ConnectionContext` repr and in any debug log message built from it. Previously these values could be written verbatim to `~/.snowflake/logs/` whenever a connection failed or debug logging was enabled.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -19,6 +19,7 @@ import logging
 import re
 import warnings
 from dataclasses import asdict, dataclass, field, fields, replace
+from hashlib import sha256
 from pathlib import Path
 from typing import Optional
 
@@ -31,23 +32,19 @@ logger = logging.getLogger(__name__)
 
 schema_pattern = re.compile(r".+\..+")
 
-# Fields whose values are credentials or other secrets and must never appear
-# in repr / debug logs. dataclass field(repr=False) metadata is not sufficient:
-# asdict() (and therefore anything built on top of it) ignores repr=False, so
-# the redaction has to be applied explicitly wherever we serialise for display.
-_SENSITIVE_FIELDS: frozenset[str] = frozenset(
-    {
-        "password",
-        "private_key_raw",
-        "private_key_passphrase",
-        "token",
-        "session_token",
-        "master_token",
-        "oauth_client_secret",
-        "mfa_passcode",
-    }
-)
-_REDACTED = "***"
+# Placeholder rendered in lieu of a credential value. Kept identical to
+# ``snowflake.cli.api.config_ng.masking.MASKED_VALUE`` so all log/debug
+# surfaces use one redaction style — that module isn't imported directly
+# to avoid a circular import via ``config_ng/__init__.py`` →
+# ``presentation`` → ``console`` → ``cli_global_context`` → this module.
+# See ``test_redacted_constant_matches_masking_module`` for the regression
+# guard that keeps the two in sync.
+_REDACTED: str = "****"
+
+# Length of the truncated hash fingerprint used in debug log lines. Long
+# enough that collisions among live cached connections are vanishingly
+# unlikely, short enough to stay readable.
+_KEY_FINGERPRINT_LEN: int = 12
 
 
 @dataclass
@@ -107,6 +104,22 @@ class ConnectionContext:
             if v is not None and not k.startswith("_")
         }
 
+    @classmethod
+    def _sensitive_field_names(cls) -> frozenset[str]:
+        """Fields that must never appear unredacted in repr / debug logs.
+
+        Derived from the dataclass metadata: any field declared with
+        ``field(repr=False)`` is considered sensitive. Using the field
+        metadata as the single source of truth means that adding a new
+        credential to the dataclass with ``repr=False`` automatically
+        redacts it everywhere — there is no parallel allowlist to keep
+        in sync. Internal/private fields (``_config_loaded``) are
+        excluded.
+        """
+        return frozenset(
+            f.name for f in fields(cls) if not f.repr and not f.name.startswith("_")
+        )
+
     def safe_values_as_dict(self) -> dict:
         """Like :meth:`present_values_as_dict` but with credentials redacted.
 
@@ -114,8 +127,9 @@ class ConnectionContext:
         value is not ``None`` are replaced with a placeholder so the presence of
         the field is still visible without leaking its contents.
         """
+        sensitive = self._sensitive_field_names()
         return {
-            k: (_REDACTED if k in _SENSITIVE_FIELDS else v)
+            k: (_REDACTED if k in sensitive else v)
             for (k, v) in self.present_values_as_dict().items()
         }
 
@@ -180,12 +194,20 @@ class ConnectionContext:
     def _full_cache_key(self) -> str:
         """Unique key including credential values, for internal cache use only.
 
-        This is distinct from ``repr(self)`` to avoid the credential-redacted
-        repr collapsing two connections that share all non-secret fields but
-        differ in e.g. ``password`` or ``token``. Never log or display.
+        Hashing rather than concatenating means we don't retain raw passwords
+        / tokens as a long-lived dict-key string in the cache (which would
+        keep them pinned in memory and potentially expose them via core /
+        heap dumps). The hash is stable across the lifetime of the process
+        and unique enough to disambiguate two ``ConnectionContext`` objects
+        that share every non-secret field but differ by credential.
+
+        Distinct from ``repr(self)`` so that the credential-redacted repr
+        cannot collapse two distinct connections into the same cache entry.
+        Never log or display the raw hash; use ``key[:_KEY_FINGERPRINT_LEN]``
+        for diagnostic identifiers instead.
         """
-        items = [f"{k}={v!r}" for (k, v) in self.present_values_as_dict().items()]
-        return f"{self.__class__.__name__}({', '.join(items)})"
+        items = sorted(self.present_values_as_dict().items())
+        return sha256(repr(items).encode("utf-8")).hexdigest()
 
     def __setattr__(self, prop, val):
         """Runs registered validators before setting fields."""
@@ -328,12 +350,15 @@ class OpenConnectionCache:
             # have returned different values (i.e. env / config have changed).
             self.connections[key] = ctx.build_connection()
         except Exception as exc:
-            # Log the credential-redacted repr, not the internal cache key, so
-            # the debug log (persisted to ~/.snowflake/logs/ by default) never
-            # contains password/token material.
+            # Log the credential-redacted repr (not raw credentials) plus the
+            # opaque hash fingerprint, so the debug log (persisted to
+            # ~/.snowflake/logs/ by default) never contains password/token
+            # material but still lets operators correlate the failure with
+            # the matching _cleanup breadcrumb.
             logger.debug(
-                "ConnectionCache: failed to connect using %s; caching failure.",
+                "ConnectionCache: failed to connect using %s (key=%s); caching failure.",
                 repr(ctx),
+                key[:_KEY_FINGERPRINT_LEN],
             )
             self.failures[key] = exc
             raise
@@ -368,10 +393,13 @@ class OpenConnectionCache:
     def _cleanup(self, key: str):
         """Closes the cached connection at the given key."""
         if key not in self.connections:
-            # Do not include the raw key in the log message — it contains the
-            # credential values used to build the connection. An opaque identifier
-            # is enough for diagnosis in this branch.
-            logger.debug("Cleaning up connection, but not found in cache!")
+            # The key itself is a SHA256 hash of the context (see
+            # ConnectionContext._full_cache_key) so a short prefix is safe to
+            # log and useful for correlating with the _insert breadcrumb.
+            logger.debug(
+                "Cleaning up connection %s, but not found in cache!",
+                key[:_KEY_FINGERPRINT_LEN],
+            )
 
         # doesn't cancel in-flight async queries
         self._cancel_cleanup_future_if_exists(key)

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 
 schema_pattern = re.compile(r".+\..+")
 
+# Fields whose values are credentials or other secrets and must never appear
+# in repr / debug logs. dataclass field(repr=False) metadata is not sufficient:
+# asdict() (and therefore anything built on top of it) ignores repr=False, so
+# the redaction has to be applied explicitly wherever we serialise for display.
+_SENSITIVE_FIELDS: frozenset[str] = frozenset(
+    {
+        "password",
+        "private_key_raw",
+        "private_key_passphrase",
+        "token",
+        "session_token",
+        "master_token",
+        "oauth_client_secret",
+        "mfa_passcode",
+    }
+)
+_REDACTED = "***"
+
 
 @dataclass
 class ConnectionContext:
@@ -50,17 +68,17 @@ class ConnectionContext:
     private_key_raw: Optional[str] = field(default=None, repr=False)
     private_key_passphrase: Optional[str] = field(default=None, repr=False)
     warehouse: Optional[str] = None
-    mfa_passcode: Optional[str] = None
-    token: Optional[str] = None
+    mfa_passcode: Optional[str] = field(default=None, repr=False)
+    token: Optional[str] = field(default=None, repr=False)
     enable_diag: Optional[bool] = False
     diag_log_path: Optional[Path] = None
     diag_allowlist_path: Optional[Path] = None
     temporary_connection: bool = False
-    session_token: Optional[str] = None
-    master_token: Optional[str] = None
+    session_token: Optional[str] = field(default=None, repr=False)
+    master_token: Optional[str] = field(default=None, repr=False)
     token_file_path: Optional[Path] = None
     oauth_client_id: Optional[str] = None
-    oauth_client_secret: Optional[str] = None
+    oauth_client_secret: Optional[str] = field(default=None, repr=False)
     oauth_authorization_url: Optional[str] = None
     oauth_token_request_url: Optional[str] = None
     oauth_redirect_uri: Optional[str] = None
@@ -77,11 +95,28 @@ class ConnectionContext:
     VALIDATED_FIELD_NAMES = ["schema"]
 
     def present_values_as_dict(self) -> dict:
-        """Dictionary representation of this ConnectionContext for values that are not None"""
+        """Dictionary representation of this ConnectionContext for values that are not None.
+
+        Values are returned verbatim, including credential fields, because callers
+        use this dict to build a live Snowflake connection. Never pass the result
+        to a logger or other display sink — use :meth:`safe_values_as_dict` instead.
+        """
         return {
             k: v
             for (k, v) in asdict(self).items()
             if v is not None and not k.startswith("_")
+        }
+
+    def safe_values_as_dict(self) -> dict:
+        """Like :meth:`present_values_as_dict` but with credentials redacted.
+
+        Safe to pass to loggers or other display sinks. Sensitive fields whose
+        value is not ``None`` are replaced with a placeholder so the presence of
+        the field is still visible without leaking its contents.
+        """
+        return {
+            k: (_REDACTED if k in _SENSITIVE_FIELDS else v)
+            for (k, v) in self.present_values_as_dict().items()
         }
 
     def clone(self) -> ConnectionContext:
@@ -131,8 +166,25 @@ class ConnectionContext:
         return self
 
     def __repr__(self) -> str:
-        """Minimal repr where None values have their keys omitted."""
-        items = [f"{k}={repr(v)}" for (k, v) in self.present_values_as_dict().items()]
+        """Minimal repr where None values have their keys omitted.
+
+        Credential-bearing fields are redacted so that repr can safely appear in
+        logs, telemetry, and error messages. Do NOT use ``repr(ctx)`` as a cache
+        or equality key — two distinct connections that differ only in their
+        credentials would produce the same repr. :class:`OpenConnectionCache`
+        uses :meth:`_full_cache_key` instead.
+        """
+        items = [f"{k}={repr(v)}" for (k, v) in self.safe_values_as_dict().items()]
+        return f"{self.__class__.__name__}({', '.join(items)})"
+
+    def _full_cache_key(self) -> str:
+        """Unique key including credential values, for internal cache use only.
+
+        This is distinct from ``repr(self)`` to avoid the credential-redacted
+        repr collapsing two connections that share all non-secret fields but
+        differ in e.g. ``password`` or ``token``. Never log or display.
+        """
+        items = [f"{k}={v!r}" for (k, v) in self.present_values_as_dict().items()]
         return f"{self.__class__.__name__}({', '.join(items)})"
 
     def __setattr__(self, prop, val):
@@ -231,7 +283,10 @@ class OpenConnectionCache:
             raise ValueError(
                 f"Expected key to be ConnectionContext but got {repr(ctx)}"
             )
-        key = repr(ctx)
+        # Use the full (credential-including) cache key so connections that
+        # differ only by credentials do not collide. The key itself is never
+        # logged — see _insert for the safe variant used in log messages.
+        key = ctx._full_cache_key()  # noqa: SLF001
         if key in self.failures:
             # A prior attempt for this context already failed; re-raise rather
             # than dialing again. Without this, every access of the CLI's
@@ -273,8 +328,12 @@ class OpenConnectionCache:
             # have returned different values (i.e. env / config have changed).
             self.connections[key] = ctx.build_connection()
         except Exception as exc:
+            # Log the credential-redacted repr, not the internal cache key, so
+            # the debug log (persisted to ~/.snowflake/logs/ by default) never
+            # contains password/token material.
             logger.debug(
-                "ConnectionCache: failed to connect using %s; caching failure.", key
+                "ConnectionCache: failed to connect using %s; caching failure.",
+                repr(ctx),
             )
             self.failures[key] = exc
             raise
@@ -309,7 +368,10 @@ class OpenConnectionCache:
     def _cleanup(self, key: str):
         """Closes the cached connection at the given key."""
         if key not in self.connections:
-            logger.debug("Cleaning up connection %s, but not found in cache!", key)
+            # Do not include the raw key in the log message — it contains the
+            # credential values used to build the connection. An opaque identifier
+            # is enough for diagnosis in this branch.
+            logger.debug("Cleaning up connection, but not found in cache!")
 
         # doesn't cancel in-flight async queries
         self._cancel_cleanup_future_if_exists(key)

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -16,9 +16,15 @@ from dataclasses import asdict
 from unittest import mock
 
 import pytest
-from snowflake.cli.api.connections import ConnectionContext, OpenConnectionCache
+from snowflake.cli.api.connections import (
+    _SENSITIVE_FIELDS,
+    ConnectionContext,
+    OpenConnectionCache,
+)
 from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
 from snowflake.connector.errors import DatabaseError
+
+_SECRET_SENTINEL = "do-not-log-this-secret"
 
 
 @pytest.fixture
@@ -208,3 +214,108 @@ def test_connection_cache_clear_also_forgets_failures(
 
     local_connection_cache[ctx]
     assert mock_connect.call_count == 2
+
+
+# Regression tests for SNOW-3417288 — credential exposure through repr.
+# ConnectionContext.__repr__ used to embed raw password / token / private_key
+# values because it built on top of dataclasses.asdict(), which ignores the
+# field(repr=False) marker. Debug logs that include repr(ctx) land in
+# ~/.snowflake/logs/ by default, so the leak was persistent.
+
+
+@pytest.mark.parametrize("field_name", sorted(_SENSITIVE_FIELDS))
+def test_repr_redacts_every_sensitive_field(field_name: str):
+    """Each known credential-bearing field must be redacted in repr()."""
+    ctx = ConnectionContext()
+    setattr(ctx, field_name, _SECRET_SENTINEL)
+    rendered = repr(ctx)
+    assert _SECRET_SENTINEL not in rendered
+    # The field name itself SHOULD still be visible so operators can see
+    # which auth method was in play when debugging.
+    assert f"{field_name}=" in rendered
+    assert "'***'" in rendered
+
+
+def test_repr_preserves_non_sensitive_fields():
+    """Non-secret fields must continue to render verbatim."""
+    ctx = ConnectionContext(
+        connection_name="myconn",
+        account="myacct",
+        user="myuser",
+        role="myrole",
+        password=_SECRET_SENTINEL,
+    )
+    rendered = repr(ctx)
+    assert "connection_name='myconn'" in rendered
+    assert "account='myacct'" in rendered
+    assert "user='myuser'" in rendered
+    assert "role='myrole'" in rendered
+    assert _SECRET_SENTINEL not in rendered
+
+
+def test_safe_values_as_dict_redacts_sensitive_and_keeps_others():
+    ctx = ConnectionContext(
+        account="myacct",
+        user="myuser",
+        password=_SECRET_SENTINEL,
+        token=_SECRET_SENTINEL,
+    )
+    safe = ctx.safe_values_as_dict()
+    assert safe["account"] == "myacct"
+    assert safe["user"] == "myuser"
+    assert safe["password"] == "***"
+    assert safe["token"] == "***"
+    # Sanity: present_values_as_dict (used to build the live connection) must
+    # still return the real credential values — we depend on that behaviour
+    # for connect() calls.
+    live = ctx.present_values_as_dict()
+    assert live["password"] == _SECRET_SENTINEL
+    assert live["token"] == _SECRET_SENTINEL
+
+
+def test_cache_key_disambiguates_contexts_that_differ_only_by_credential():
+    """
+    If the cache keyed off repr(ctx), two contexts that share all non-secret
+    fields but differ by password would collide and return the same connection
+    — an availability regression as well as a security footgun. _full_cache_key
+    must include the raw credential values so that collision cannot happen.
+    """
+    ctx_a = ConnectionContext(connection_name="shared", password="pwd-A")
+    ctx_b = ConnectionContext(connection_name="shared", password="pwd-B")
+    assert repr(ctx_a) == repr(ctx_b)  # redacted repr collides (by design)
+    assert ctx_a._full_cache_key() != ctx_b._full_cache_key()  # noqa: SLF001
+
+
+@mock.patch("snowflake.connector.connect", side_effect=RuntimeError("boom"))
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+def test_connection_cache_failure_log_does_not_leak_credentials(
+    mock_command_info,
+    mock_connect,
+    local_connection_cache,
+    caplog,
+):
+    """
+    When build_connection() fails, the cache logs a debug message. That message
+    used to embed the full ConnectionContext repr (with raw password/token).
+    It must now log only the redacted repr.
+    """
+    mock_command_info.return_value = "application"
+    ctx = ConnectionContext(
+        temporary_connection=True,
+        account="acct",
+        user="user",
+        password=_SECRET_SENTINEL,
+        token=_SECRET_SENTINEL,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="snowflake.cli.api.connections"):
+        with pytest.raises(RuntimeError):
+            local_connection_cache[ctx]
+
+    rendered_logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert _SECRET_SENTINEL not in rendered_logs
+    # We should still see a "failed to connect" breadcrumb so the debug log
+    # retains diagnostic value.
+    assert "failed to connect" in rendered_logs

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 import pytest
 from snowflake.cli.api.connections import (
-    _SENSITIVE_FIELDS,
+    _REDACTED,
     ConnectionContext,
     OpenConnectionCache,
 )
@@ -25,6 +25,7 @@ from snowflake.cli.api.exceptions import InvalidConnectionConfigurationError
 from snowflake.connector.errors import DatabaseError
 
 _SECRET_SENTINEL = "do-not-log-this-secret"
+_SENSITIVE_FIELDS = ConnectionContext._sensitive_field_names()  # noqa: SLF001
 
 
 @pytest.fixture
@@ -233,7 +234,48 @@ def test_repr_redacts_every_sensitive_field(field_name: str):
     # The field name itself SHOULD still be visible so operators can see
     # which auth method was in play when debugging.
     assert f"{field_name}=" in rendered
-    assert "'***'" in rendered
+    assert repr(_REDACTED) in rendered
+
+
+def test_redacted_constant_matches_masking_module():
+    """``connections._REDACTED`` is intentionally a local copy of
+    ``config_ng.masking.MASKED_VALUE`` (direct import would cause a circular
+    dependency through ``config_ng/__init__.py``). This test keeps the two in
+    sync so log readers see a single, consistent redaction style across the
+    CLI.
+    """
+    from snowflake.cli.api.config_ng.masking import MASKED_VALUE
+
+    assert _REDACTED == MASKED_VALUE
+
+
+def test_sensitive_field_names_matches_repr_false_markers():
+    """Regression guard: _SENSITIVE_FIELDS must be derived from the dataclass
+    ``repr=False`` metadata, not a separate hand-maintained list. If a future
+    contributor adds a credential field with ``repr=False`` the redaction
+    should pick it up automatically.
+    """
+    from dataclasses import fields
+
+    expected = {
+        f.name
+        for f in fields(ConnectionContext)
+        if not f.repr and not f.name.startswith("_")
+    }
+    assert ConnectionContext._sensitive_field_names() == expected  # noqa: SLF001
+    # Sanity: the known credential fields must be in the set today.
+    known_credentials = {
+        "password",
+        "token",
+        "session_token",
+        "master_token",
+        "private_key_raw",
+        "private_key_passphrase",
+        "oauth_client_secret",
+        "mfa_passcode",
+    }
+    sensitive = ConnectionContext._sensitive_field_names()  # noqa: SLF001
+    assert known_credentials.issubset(sensitive)
 
 
 def test_repr_preserves_non_sensitive_fields():
@@ -263,8 +305,8 @@ def test_safe_values_as_dict_redacts_sensitive_and_keeps_others():
     safe = ctx.safe_values_as_dict()
     assert safe["account"] == "myacct"
     assert safe["user"] == "myuser"
-    assert safe["password"] == "***"
-    assert safe["token"] == "***"
+    assert safe["password"] == _REDACTED
+    assert safe["token"] == _REDACTED
     # Sanity: present_values_as_dict (used to build the live connection) must
     # still return the real credential values — we depend on that behaviour
     # for connect() calls.
@@ -278,12 +320,21 @@ def test_cache_key_disambiguates_contexts_that_differ_only_by_credential():
     If the cache keyed off repr(ctx), two contexts that share all non-secret
     fields but differ by password would collide and return the same connection
     — an availability regression as well as a security footgun. _full_cache_key
-    must include the raw credential values so that collision cannot happen.
+    must distinguish them while NOT retaining the raw credential as a dict-key
+    string (which is why we hash).
     """
     ctx_a = ConnectionContext(connection_name="shared", password="pwd-A")
     ctx_b = ConnectionContext(connection_name="shared", password="pwd-B")
     assert repr(ctx_a) == repr(ctx_b)  # redacted repr collides (by design)
-    assert ctx_a._full_cache_key() != ctx_b._full_cache_key()  # noqa: SLF001
+    key_a = ctx_a._full_cache_key()  # noqa: SLF001
+    key_b = ctx_b._full_cache_key()  # noqa: SLF001
+    assert key_a != key_b
+    # The key must be an opaque hex digest, not a stringified context, so the
+    # raw credential value is not retained in memory as a dict-key string.
+    assert "pwd-A" not in key_a
+    assert "pwd-B" not in key_b
+    assert len(key_a) == 64  # sha256 hex digest
+    assert key_a == ctx_a._full_cache_key()  # noqa: SLF001  # stable
 
 
 @mock.patch("snowflake.connector.connect", side_effect=RuntimeError("boom"))


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes [SNOW-3417288](https://snowflakecomputing.atlassian.net/browse/SNOW-3417288).

**Problem.** `ConnectionContext.__repr__` was built on top of `dataclasses.asdict()`, which silently **ignores** `field(repr=False)` metadata. As a result, `repr(ctx)` embedded raw `password`, `token`, `session_token`, `master_token`, `private_key_raw`, `private_key_passphrase`, `oauth_client_secret`, and `mfa_passcode` values. Two places then wrote that string to `~/.snowflake/logs/` (the default debug log sink):

1. `OpenConnectionCache._insert` logs `"ConnectionCache: failed to connect using %s; ..."` with the cache key, which was `repr(ctx)` — so **every failed connection** leaked credentials.
2. The cache used `repr(ctx)` as its dictionary key as well, so the same value flowed through `_cleanup` debug logs too.

This maps to CWE-532 (Insertion of Sensitive Information into Log File). The logs persist across CLI runs and are commonly collected in bug reports, which turns any transient auth failure into a durable credential exposure.

**Fix.** Three coordinated changes in `src/snowflake/cli/api/connections.py`:

1. **Redact at the boundary.** Introduce a `_SENSITIVE_FIELDS` allowlist and a `safe_values_as_dict()` helper that replaces those values with `'***'`. Rewrite `__repr__` to use it. `present_values_as_dict()` (used by `build_connection()` to call `connect_to_snowflake`) is left unchanged so the live connection path still receives the real values.
2. **Keep the cache key unique.** The redacted repr would otherwise collapse two contexts that share every non-secret field but differ by password/token, returning the wrong cached connection. Introduce `_full_cache_key()` (raw values, for internal use only) and switch `OpenConnectionCache.__getitem__` to key off it.
3. **Scrub the log call sites.** `_insert` now logs `repr(ctx)` (the safe, redacted form) instead of the raw cache key. `_cleanup` no longer embeds the raw key in its "not found in cache" breadcrumb.

I also added `field(default=None, repr=False)` to `mfa_passcode`, `token`, `session_token`, `master_token`, and `oauth_client_secret` so the intent is visible on the field declaration, even though (as noted above) that metadata alone is not load-bearing here.

**Tests.** `tests/api/test_connections.py` grows five regression tests, all prefixed with an explanatory comment block:

- `test_repr_redacts_every_sensitive_field` — parametrised over `sorted(_SENSITIVE_FIELDS)` so any future sensitive field added to the set is automatically exercised.
- `test_repr_preserves_non_sensitive_fields` — the "good bits" of the repr (connection_name, account, user, role) still render verbatim.
- `test_safe_values_as_dict_redacts_sensitive_and_keeps_others` — also asserts that `present_values_as_dict()` still returns real credentials, since `build_connection()` relies on that.
- `test_cache_key_disambiguates_contexts_that_differ_only_by_credential` — pins the "two contexts with the same redacted repr must not collide in the cache" invariant.
- `test_connection_cache_failure_log_does_not_leak_credentials` — uses `caplog` at DEBUG to drive the failure path and assert the leaked secret never appears in any log record.

The three existing repr snapshots in `tests/api/__snapshots__/test_connections.ambr` do not contain sensitive fields, so they continue to match without regeneration.

**Scope / risk.** Behaviour-preserving for non-secret fields; the only observable changes are (a) redacted credentials in `repr(ctx)` and any log that embeds it, and (b) the cache key representation (internal — never logged or persisted). No public API is removed; `present_values_as_dict()` retains its contract.

[SNOW-3417288]: https://snowflakecomputing.atlassian.net/browse/SNOW-3417288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ