### PR TITLE
fix(nativeapp): escape py_file path in Snowpark processor callback template

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
+++ b/src/snowflake/cli/_plugins/nativeapp/codegen/snowpark/callback_source.py.jinja
@@ -169,7 +169,7 @@ try:
     import importlib
     with contextlib.redirect_stdout(None):
         with contextlib.redirect_stderr(None):
-            __snowflake_internal_spec = importlib.util.spec_from_file_location("<string>", r"{{py_file}}")
+            __snowflake_internal_spec = importlib.util.spec_from_file_location("<string>", {{py_file | tojson}})
             __snowflake_internal_module = importlib.util.module_from_spec(__snowflake_internal_spec)
             __snowflake_internal_spec.loader.exec_module(__snowflake_internal_module)
 except Exception as exc:  # Catch any error

--- a/tests/nativeapp/codegen/snowpark/test_python_processor.py
+++ b/tests/nativeapp/codegen/snowpark/test_python_processor.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import ast
 import copy
 import subprocess
 from pathlib import Path
@@ -27,6 +28,7 @@ from snowflake.cli._plugins.nativeapp.codegen.sandbox import (
     SandboxExecutionError,
 )
 from snowflake.cli._plugins.nativeapp.codegen.snowpark.python_processor import (
+    TEMPLATE_PATH,
     SnowparkAnnotationProcessor,
     _determine_virtual_env,
     _execute_in_sandbox,
@@ -38,6 +40,7 @@ from snowflake.cli._plugins.nativeapp.entities.application_package import (
     ApplicationPackageEntityModel,
 )
 from snowflake.cli.api.project.schemas.entities.common import ProcessorMapping
+from snowflake.cli.api.rendering.jinja import jinja_render_from_file
 
 from tests.nativeapp.utils import assert_dir_snapshot
 from tests.testing_utils.files_and_dirs import temp_local_dir
@@ -175,6 +178,47 @@ def test_execute_in_sandbox_all_possible_none_cases(mock_sandbox):
         )
         is None
     )
+
+
+# --------------------------------------------------------
+# --------- callback source template rendering ----------
+# --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "py_file",
+    [
+        '/tmp/evil"dir/my_file.py',
+        "/tmp/evil'dir/my_file.py",
+        "/tmp/evil\\dir/my_file.py",
+        '/tmp/evil"; import os; os.system("pwned")\n#/my_file.py',
+        "/tmp/normal/file.py",
+    ],
+)
+def test_callback_source_template_escapes_py_file(py_file):
+    """The rendered callback source must always produce valid Python where ``py_file`` is a
+    string literal — even when the path contains quotes, backslashes, or newlines.
+
+    Previously the template interpolated ``py_file`` into a raw-string literal
+    (``r"{{py_file}}"``), which allowed a crafted path to terminate the literal and inject
+    arbitrary Python. The ``tojson`` filter produces a properly escaped string literal.
+    """
+    rendered = jinja_render_from_file(
+        template_path=TEMPLATE_PATH, data={"py_file": py_file}
+    )
+
+    tree = ast.parse(rendered)
+    spec_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "spec_from_file_location"
+    ]
+    assert spec_calls, "spec_from_file_location call not found in rendered template"
+
+    path_arg = spec_calls[0].args[1]
+    assert isinstance(path_arg, ast.Constant) and path_arg.value == py_file
 
 
 # --------------------------------------------------------


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Ref: SNOW-3417033

**What changed.** The Snowpark annotation processor (`nativeapp codegen snowpark`) renders a small Python bootstrap script inside a sandboxed subprocess in order to introspect a user's Snowpark source file. The bootstrap template interpolated the absolute path of the target file into a raw-string literal:

```python
__snowflake_internal_spec = importlib.util.spec_from_file_location(
    \"<string>\", r\"{{py_file}}\"
)
```

A raw-string literal cannot escape `\"`, so any `py_file` containing a double quote terminated the literal early. In the benign case this produces a `SyntaxError` from the sandbox subprocess; in an adversarial case (a project whose directory name contains a crafted `\"; ... #` payload) it lets arbitrary Python be injected into the script that the processor then executes.

This PR replaces the raw-string interpolation with Jinja's built-in `tojson` filter, which emits a properly escaped JSON string literal — which is also a valid Python string literal — for any input:

```python
__snowflake_internal_spec = importlib.util.spec_from_file_location(
    \"<string>\", {{py_file | tojson}}
)
```

**Why `tojson` rather than a custom escape function.** `tojson` is shipped with Jinja, already applied elsewhere in this repo, and produces output that is unambiguously a JSON string literal. JSON string literals are a subset of Python string literals, so the rendered script is always syntactically valid Python regardless of what characters appear in the path.

**Tests.** A new parametrized test (`test_callback_source_template_escapes_py_file`) renders the template with a handful of hostile paths — embedded `\"`, `'`, `\\\\`, a full `\"; import os; os.system(...) #` payload, and a plain path — parses the rendered output with `ast.parse`, locates the `spec_from_file_location` call, and asserts that the path argument is an `ast.Constant` whose value equals the original input. This verifies both that the template still produces valid Python and that the path is preserved verbatim (not, e.g., turned into executable code).

**Scope note.** The linked Jira lists a broader, related attack surface: the entire user-authored source file is still executed inside the sandbox in order to collect extension-function annotations, which is code-injection-by-design for trusted project authors and not addressed here. This PR is deliberately scoped to the secondary vector in the template so it can land as a contained, verifiable change. Further hardening of the sandbox execution path is tracked on the Jira.

Opened as a draft — please review.