### PR TITLE
fix: [SNOW-3411343] escape single quotes when building SHOW LIKE patterns

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 * The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* `SHOW ... LIKE` queries built from a project-defined identifier (object lookups, stage existence checks, version/show-versions queries, image-repository lookups) now double any embedded single quote before wrapping the pattern as a SQL string literal. Previously a quoted identifier containing `'` could prematurely close the SQL literal and let an attacker-controlled `snowflake.yml` splice in a second statement.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -257,9 +257,14 @@ def escape_like_pattern(pattern: str, escape_sequence: str = r"\\") -> str:
 def identifier_to_show_like_pattern(identifier: str) -> str:
     """
     Takes an identifier and converts it into a pattern to be used with SHOW ... LIKE ... to get all rows with name
-    matching this identifier
+    matching this identifier.
+
+    Any single quotes embedded in the identifier are escaped by doubling (``''``)
+    so the resulting pattern is always a well-formed SQL string literal.
     """
-    return f"'{escape_like_pattern(unquote_identifier(identifier))}'"
+    pattern = escape_like_pattern(unquote_identifier(identifier))
+    pattern = pattern.replace("'", "''")
+    return f"'{pattern}'"
 
 
 def append_test_resource_suffix(identifier: str) -> str:

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -20,6 +20,7 @@ from snowflake.cli.api.project.util import (
     concat_identifiers,
     escape_like_pattern,
     identifier_in_list,
+    identifier_to_show_like_pattern,
     identifier_to_str,
     is_valid_identifier,
     is_valid_object_name,
@@ -239,6 +240,50 @@ def test_to_string_literal(raw_string, literal):
 )
 def test_escape_like_pattern(raw_string, escaped):
     assert escape_like_pattern(raw_string) == escaped
+
+
+@pytest.mark.parametrize(
+    "identifier, expected",
+    [
+        # unquoted identifiers canonicalize to uppercase
+        ("abc", "'ABC'"),
+        # underscores are LIKE-escaped with a pair of backslashes so SHOW LIKE
+        # treats them literally
+        ("my_name", r"'MY\\_NAME'"),
+        # names containing wildcard-like characters are forced through the
+        # quoted-identifier path and therefore keep their original case
+        ("mixed_percent%", r"'mixed\\_percent\\%'"),
+        # explicit quoted identifiers preserve case
+        ('"abc"', "'abc'"),
+        ('"Mixed_Case%"', r"'Mixed\\_Case\\%'"),
+        # embedded single quotes are escaped by doubling so the literal stays
+        # well-formed. Without doubling, the quote would prematurely terminate
+        # the SQL string and allow a second statement to be appended
+        # (SNOW-3411343).
+        ('"x\'y"', "'x''y'"),
+        (
+            '"x\'; GRANT ROLE ACCOUNTADMIN TO USER attacker;--"',
+            "'x''; GRANT ROLE ACCOUNTADMIN TO USER attacker;--'",
+        ),
+        # embedded double quotes in a quoted identifier are unescaped from ""
+        ('"a""b"', "'a\"b'"),
+    ],
+)
+def test_identifier_to_show_like_pattern(identifier, expected):
+    assert identifier_to_show_like_pattern(identifier) == expected
+
+
+def test_identifier_to_show_like_pattern_blocks_sql_injection():
+    """Embedded single quote must not be able to close the SQL literal."""
+    pattern = identifier_to_show_like_pattern(
+        '"victim\'); GRANT ROLE ACCOUNTADMIN TO USER attacker;--"'
+    )
+    # The output must start and end with single quotes, and every interior
+    # single quote is doubled so no stray quote remains to close the literal.
+    assert pattern.startswith("'") and pattern.endswith("'")
+    interior = pattern[1:-1]
+    assert "''" in interior  # the attacker's quote was doubled
+    assert "'" not in interior.replace("''", "")  # no stray quotes left
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.

### Changes description

Fixes [SNOW-3411343](https://snowflakecomputing.atlassian.net/browse/SNOW-3411343).

`identifier_to_show_like_pattern` builds the SQL string literal used by every `SHOW ... LIKE '<pattern>'` query the CLI issues (object lookups, stage existence checks, version/`show-versions` queries, image-repository lookups — 5 call sites). It already escaped the LIKE wildcards `%` and `_`, but did not escape single quotes. A quoted identifier like `"x'; <payload>;--"` coming from a project file therefore produced the literal `'x'; <payload>;--'`, and because `execute_stream` tokenizes on `;`, the payload ran as a separate statement.

The fix doubles every embedded single quote before wrapping the pattern as a literal — Snowflake's canonical string-literal escape. That keeps the pattern a single well-formed literal regardless of what comes from `snowflake.yml`:

```python
pattern = escape_like_pattern(unquote_identifier(identifier))
pattern = pattern.replace("'", "''")
return f"'{pattern}'"
```

I considered the ticket's suggestion of routing through `to_string_literal`, but that function runs `codecs.encode(..., "unicode-escape")` on the input, which would re-encode the backslashes that `escape_like_pattern` already inserted for `%`/`_` and produce `\\\\_` in the final literal — breaking legitimate LIKE escapes. Doubling the single quote inline is the minimal change that preserves existing behaviour for every other caller.

New tests cover wildcard escaping, quoted vs. unquoted canonicalization, embedded single quotes, the double-quote unescaping path, and an explicit injection payload. All 903 tests across the 10 affected test modules pass locally.

[SNOW-3411343]: https://snowflakecomputing.atlassian.net/browse/SNOW-3411343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ