### PR TITLE
Snowflake Apps: fix service SQL identifier handling

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -728,7 +728,7 @@ def snowflake_app_deploy(
                 ),
                 timeout_message=(
                     f"Upgrade timed out. Check logs:\n"
-                    f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
+                    f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
                 ),
             )
         else:

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -717,8 +717,10 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
     def get_service_logs(self, service_fqn: FQN, last: int = 500) -> str:
         """Fetch recent log output from an application service."""
+        from snowflake.cli.api.project.util import to_string_literal
+
         cursor = self.execute_query(
-            f"CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}', {last})"
+            f"CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS({to_string_literal(service_fqn.identifier)}, {last})"
         )
         row = cursor.fetchone()
         return row[0] if row else ""
@@ -1001,7 +1003,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         Returns an empty dict when the DESCRIBE returns no rows.
         """
         cursor = self.execute_query(
-            f"DESCRIBE APPLICATION SERVICE {service_fqn.identifier}",
+            f"DESCRIBE APPLICATION SERVICE {service_fqn.sql_identifier}",
             cursor_class=DictCursor,
         )
         row = cursor.fetchone()

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1034,7 +1034,7 @@ class TestSnowflakeAppManager:
         assert desc["url"] == "my-app.snowflakecomputing.app"
         assert desc["is_upgrading"] == "false"
         query = mock_execute.call_args[0][0]
-        assert "DESCRIBE APPLICATION SERVICE DB.SCHEMA.my_app" in query
+        assert "DESCRIBE APPLICATION SERVICE IDENTIFIER('DB.SCHEMA.my_app')" in query
 
     @patch(EXECUTE_QUERY)
     def test_describe_app_service_empty(self, mock_execute):
@@ -1275,7 +1275,8 @@ class TestSnowflakeAppManager:
         assert url == "https://my-endpoint.snowflakecomputing.app"
         mock_execute.assert_called_once()
         assert (
-            mock_execute.call_args[0][0] == "DESCRIBE APPLICATION SERVICE DB.SCHEMA.SVC"
+            mock_execute.call_args[0][0]
+            == "DESCRIBE APPLICATION SERVICE IDENTIFIER('DB.SCHEMA.SVC')"
         )
 
     @patch(EXECUTE_QUERY)
@@ -1302,7 +1303,8 @@ class TestSnowflakeAppManager:
         assert url is None
         mock_execute.assert_called_once()
         assert (
-            "DESCRIBE APPLICATION SERVICE DB.SCHEMA.SVC" in mock_execute.call_args[0][0]
+            "DESCRIBE APPLICATION SERVICE IDENTIFIER('DB.SCHEMA.SVC')"
+            in mock_execute.call_args[0][0]
         )
 
     @patch(EXECUTE_QUERY)
@@ -3969,6 +3971,82 @@ class TestDeployCommand:
         mock_mgr.create_app_service.assert_called_once()
         mock_mgr.build_app_artifact_repo.assert_not_called()
         mock_mgr.stage_exists.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_upgrade_timeout_hint_uses_fully_qualified_service_name(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        already_exists_error = ProgrammingError("already exists")
+        already_exists_error.errno = 2002
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.create_app_service.side_effect = already_exists_error
+        mock_mgr.resolve_application_service_url_from_describe.return_value = (
+            "https://my-app.snowflakecomputing.app"
+        )
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            assert result.exit_code == 0, result.output
+
+        mock_mgr.upgrade_app_service.assert_called_once_with(
+            service_fqn=FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP"),
+            version="LATEST",
+        )
+        _, poll_kwargs = mock_poll.call_args
+        assert (
+            "CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
+            in poll_kwargs["timeout_message"]
+        )
 
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
     @patch("snowflake.cli._plugins.apps.commands.perform_bundle")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- Use SQL-safe identifier form for `DESCRIBE APPLICATION SERVICE` lookups.
- Use SQL-safe quoting for application service log retrieval calls.
- Update upgrade-timeout guidance to reference the fully-qualified service name.
- Add regression coverage for the fully-qualified timeout hint.
