### PR TITLE
Snowflake Apps: better error messages for common failures

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -73,16 +73,6 @@ SOURCE_DEFAULT = "default"
 SOURCE_MISSING = "missing"
 
 
-def _role_hint(details: str = "") -> str:
-    """Return a consistent privilege guidance hint for user-facing errors."""
-    role = getattr(get_cli_context().connection_context, "role", None)
-    role_fragment = f"role '{role}'" if role else "your current role"
-    base = f"Check grants for {role_fragment}, or retry with --role <ROLE>."
-    if details:
-        return f"{details} {base}"
-    return base
-
-
 def snowflake_app_setup(
     app_name: Optional[str],
     dry_run: bool,
@@ -353,9 +343,7 @@ def snowflake_app_open(
         except ProgrammingError as err:
             raise CliError(
                 f"Could not resolve endpoint URL for service {service_fqn.identifier}. "
-                + _role_hint(
-                    "This may indicate missing privileges on the target schema or application service."
-                )
+                "This may indicate missing privileges on the target schema or application service."
             ) from err
 
         if not url:
@@ -390,9 +378,7 @@ def snowflake_app_events(
         raise ClickException(
             f"Could not retrieve logs for '{service_fqn.identifier}'. "
             "Verify that the app is deployed and the service is running. "
-            + _role_hint(
-                "If the service exists, this can also happen when the active role cannot read application service logs."
-            )
+            "If the service exists, this can also happen when the active role cannot read application service logs."
         )
     return MessageResult(logs)
 
@@ -729,18 +715,14 @@ def snowflake_app_deploy(
                     raise CliError(
                         "Deployment failed while upgrading application service "
                         f"'{service_fqn.identifier}': {upgrade_error}. "
-                        + _role_hint(
-                            "Verify privileges for ALTER APPLICATION SERVICE and access to referenced objects."
-                        )
+                        "Verify privileges for ALTER APPLICATION SERVICE and access to referenced objects."
                     ) from upgrade_error
                 did_upgrade = True
             else:
                 raise CliError(
                     "Deployment failed while creating application service "
                     f"'{service_fqn.identifier}': {e}. "
-                    + _role_hint(
-                        "Verify privileges for CREATE APPLICATION SERVICE plus USAGE on configured compute pools, warehouse, and external access integrations."
-                    )
+                    "Verify privileges for CREATE APPLICATION SERVICE plus USAGE on configured compute pools, warehouse, and external access integrations."
                 ) from e
 
     def _svc_is_upgrading(d: dict) -> bool:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -73,6 +73,16 @@ SOURCE_DEFAULT = "default"
 SOURCE_MISSING = "missing"
 
 
+def _role_hint(details: str = "") -> str:
+    """Return a consistent privilege guidance hint for user-facing errors."""
+    role = getattr(get_cli_context().connection_context, "role", None)
+    role_fragment = f"role '{role}'" if role else "your current role"
+    base = f"Check grants for {role_fragment}, or retry with --role <ROLE>."
+    if details:
+        return f"{details} {base}"
+    return base
+
+
 def snowflake_app_setup(
     app_name: Optional[str],
     dry_run: bool,
@@ -338,7 +348,15 @@ def snowflake_app_open(
         )
 
         manager = SnowflakeAppManager()
-        url = manager.get_service_endpoint_url(service_fqn)
+        try:
+            url = manager.get_service_endpoint_url(service_fqn)
+        except ProgrammingError as err:
+            raise CliError(
+                f"Could not resolve endpoint URL for service {service_fqn.identifier}. "
+                + _role_hint(
+                    "This may indicate missing privileges on the target schema or application service."
+                )
+            ) from err
 
         if not url:
             raise CliError(
@@ -371,7 +389,10 @@ def snowflake_app_events(
     except ProgrammingError:
         raise ClickException(
             f"Could not retrieve logs for '{service_fqn.identifier}'. "
-            "Verify that the app is deployed and the service is running."
+            "Verify that the app is deployed and the service is running. "
+            + _role_hint(
+                "If the service exists, this can also happen when the active role cannot read application service logs."
+            )
         )
     return MessageResult(logs)
 
@@ -699,13 +720,28 @@ def snowflake_app_deploy(
                 cli_console.step(
                     f"Application service {app_name} already exists. Upgrading..."
                 )
-                manager.upgrade_app_service(
-                    service_fqn=service_fqn,
-                    version="LATEST",
-                )
+                try:
+                    manager.upgrade_app_service(
+                        service_fqn=service_fqn,
+                        version="LATEST",
+                    )
+                except ProgrammingError as upgrade_error:
+                    raise CliError(
+                        "Deployment failed while upgrading application service "
+                        f"'{service_fqn.identifier}': {upgrade_error}. "
+                        + _role_hint(
+                            "Verify privileges for ALTER APPLICATION SERVICE and access to referenced objects."
+                        )
+                    ) from upgrade_error
                 did_upgrade = True
             else:
-                raise
+                raise CliError(
+                    "Deployment failed while creating application service "
+                    f"'{service_fqn.identifier}': {e}. "
+                    + _role_hint(
+                        "Verify privileges for CREATE APPLICATION SERVICE plus USAGE on configured compute pools, warehouse, and external access integrations."
+                    )
+                ) from e
 
     def _svc_is_upgrading(d: dict) -> bool:
         return str(d.get("is_upgrading", "")).lower() in ("true", "1", "yes")

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2836,7 +2836,6 @@ class TestOpenCommand:
                 "Could not resolve endpoint URL for service DB.SCHEMA.MY_APP"
                 in result.output
             )
-            assert "--role <ROLE>" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands.typer.launch")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3287,7 +3286,6 @@ class TestEventsCommand:
             assert result.exit_code == 1
             assert "Could not retrieve logs" in result.output
             assert "Verify that the app is deployed" in result.output
-            assert "--role <ROLE>" in result.output
 
 
 # ── Deploy CLI command tests ──────────────────────────────────────────
@@ -3428,7 +3426,6 @@ class TestDeployCommand:
                 "Deployment failed while creating application service" in result.output
             )
             assert "Verify privileges for CREATE" in result.output
-            assert "--role <ROLE>" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2803,6 +2803,41 @@ class TestOpenCommand:
             assert result.exit_code == 1
             assert "No endpoint URL found" in result.output
 
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_open_permission_error_includes_role_guidance(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock(database="DB", schema="SCHEMA")
+        fqn.name = "MY_APP"
+        entity.fqn = fqn
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.get_service_endpoint_url.side_effect = ProgrammingError(
+            "not authorized"
+        )
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "open"])
+            assert result.exit_code == 1
+            assert (
+                "Could not resolve endpoint URL for service DB.SCHEMA.MY_APP"
+                in result.output
+            )
+            assert "--role <ROLE>" in result.output
+
     @patch("snowflake.cli._plugins.apps.commands.typer.launch")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     @patch("snowflake.cli._plugins.apps.commands.get_cli_context")
@@ -3252,6 +3287,7 @@ class TestEventsCommand:
             assert result.exit_code == 1
             assert "Could not retrieve logs" in result.output
             assert "Verify that the app is deployed" in result.output
+            assert "--role <ROLE>" in result.output
 
 
 # ── Deploy CLI command tests ──────────────────────────────────────────
@@ -3327,6 +3363,72 @@ class TestDeployCommand:
             mock_mgr.build_app_artifact_repo.assert_not_called()
             mock_mgr.artifact_repo_exists.assert_not_called()
             mock_mgr.create_app_service.assert_called_once()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_service_creation_error_includes_role_guidance(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        create_error = ProgrammingError("not authorized")
+        create_error.errno = 2043
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.create_app_service.side_effect = create_error
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            assert result.exit_code == 1
+            assert (
+                "Deployment failed while creating application service" in result.output
+            )
+            assert "Verify privileges for CREATE" in result.output
+            assert "--role <ROLE>" in result.output
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- Add actionable role/grant guidance for common Snowflake Apps auth failures.
- Improve `snow app open` error messaging when endpoint lookup fails due to privileges.
- Improve `snow app events` messaging for log-read permission failures.
- Surface clearer deploy failure hints for CREATE/ALTER APPLICATION SERVICE authorization errors.
