### PR TITLE
fix: [SNOW-3417278] contain read_file_content / procedure_from_js_file Jinja filters to project root

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,9 +44,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,7 +47,6 @@
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 * The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
-* The `read_file_content` and `procedure_from_js_file` Jinja filters used during SQL template rendering now require the referenced path to resolve inside the active project root, and read with the standard `DEFAULT_SIZE_LIMIT_MB` (128 MB) size limit instead of the previous `UNLIMITED` bypass. Templates that referenced files outside the project (including via `../` traversal or absolute paths to the user's home directory) will now fail fast with a clear `ClickException` rather than embedding the file's contents into the rendered SQL.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,10 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* The `read_file_content` and `procedure_from_js_file` Jinja filters used during SQL template rendering now require the referenced path to resolve inside the active project root, and read with the standard `DEFAULT_SIZE_LIMIT_MB` (128 MB) size limit instead of the previous `UNLIMITED` bypass. Templates that referenced files outside the project (including via `../` traversal or absolute paths to the user's home directory) will now fail fast with a clear `ClickException` rather than embedding the file's contents into the rendered SQL.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/rendering/jinja.py
+++ b/src/snowflake/cli/api/rendering/jinja.py
@@ -32,19 +32,20 @@ FUNCTION_KEY = "fn"
 def _resolve_within_project_root(file_name: str, filter_name: str) -> Path:
     """Resolve ``file_name`` and ensure it is contained within the project root.
 
-    When a project root is configured (i.e. the command is executed inside a
-    Snowflake CLI project), the resolved target must be a descendant of that
-    root. Otherwise, a :class:`ClickException` is raised to prevent arbitrary
-    file reads outside of the project's scope.
+    The resolved target must be a descendant of the active project root.
+    Outside a project (``MissingConfigurationError``), the containment check is
+    skipped — but note that ``snow sql -q`` always has a project root (CWD), so
+    in practice this fallback only applies to non-CLI render callers.
     """
     # Lazy import to avoid circular dependency with ``cli_global_context``.
     from snowflake.cli.api.cli_global_context import get_cli_context
+    from snowflake.cli.api.exceptions import MissingConfigurationError
 
     target = Path(file_name).expanduser().resolve()
 
     try:
         project_root: Optional[Path] = get_cli_context().project_root
-    except Exception:
+    except MissingConfigurationError:
         project_root = None
 
     if project_root is not None:

--- a/src/snowflake/cli/api/rendering/jinja.py
+++ b/src/snowflake/cli/api/rendering/jinja.py
@@ -32,30 +32,24 @@ FUNCTION_KEY = "fn"
 def _resolve_within_project_root(file_name: str, filter_name: str) -> Path:
     """Resolve ``file_name`` and ensure it is contained within the project root.
 
-    The resolved target must be a descendant of the active project root.
-    Outside a project (``MissingConfigurationError``), the containment check is
-    skipped — but note that ``snow sql -q`` always has a project root (CWD), so
-    in practice this fallback only applies to non-CLI render callers.
+    Relative paths are anchored to the project root (not CWD) before resolving,
+    matching the behaviour of the sibling helper in entities/utils.py.
     """
     # Lazy import to avoid circular dependency with ``cli_global_context``.
     from snowflake.cli.api.cli_global_context import get_cli_context
-    from snowflake.cli.api.exceptions import MissingConfigurationError
 
-    target = Path(file_name).expanduser().resolve()
-
+    root = Path(get_cli_context().project_root).resolve()
+    candidate = Path(file_name).expanduser()
+    if candidate.is_absolute():
+        target = candidate.resolve()
+    else:
+        target = (root / candidate).resolve()
     try:
-        project_root: Optional[Path] = get_cli_context().project_root
-    except MissingConfigurationError:
-        project_root = None
-
-    if project_root is not None:
-        root = Path(project_root).resolve()
-        try:
-            target.relative_to(root)
-        except ValueError:
-            raise ClickException(
-                f"{filter_name}: path '{file_name}' is outside the project root."
-            )
+        target.relative_to(root)
+    except ValueError:
+        raise ClickException(
+            f"{filter_name}: path '{file_name}' is outside the project root."
+        )
     return target
 
 

--- a/src/snowflake/cli/api/rendering/jinja.py
+++ b/src/snowflake/cli/api/rendering/jinja.py
@@ -20,19 +20,52 @@ from textwrap import dedent
 from typing import Any, Dict, Optional
 
 import jinja2
+from click import ClickException
 from jinja2 import Environment, StrictUndefined, loaders
-from snowflake.cli.api.secure_path import UNLIMITED, SecurePath
+from snowflake.cli.api.constants import DEFAULT_SIZE_LIMIT_MB
+from snowflake.cli.api.secure_path import SecurePath
 
 CONTEXT_KEY = "ctx"
 FUNCTION_KEY = "fn"
 
 
-def read_file_content(file_name: str):
-    return SecurePath(file_name).read_text(file_size_limit_mb=UNLIMITED)
+def _resolve_within_project_root(file_name: str, filter_name: str) -> Path:
+    """Resolve ``file_name`` and ensure it is contained within the project root.
+
+    When a project root is configured (i.e. the command is executed inside a
+    Snowflake CLI project), the resolved target must be a descendant of that
+    root. Otherwise, a :class:`ClickException` is raised to prevent arbitrary
+    file reads outside of the project's scope.
+    """
+    # Lazy import to avoid circular dependency with ``cli_global_context``.
+    from snowflake.cli.api.cli_global_context import get_cli_context
+
+    target = Path(file_name).expanduser().resolve()
+
+    try:
+        project_root: Optional[Path] = get_cli_context().project_root
+    except Exception:
+        project_root = None
+
+    if project_root is not None:
+        root = Path(project_root).resolve()
+        try:
+            target.relative_to(root)
+        except ValueError:
+            raise ClickException(
+                f"{filter_name}: path '{file_name}' is outside the project root."
+            )
+    return target
+
+
+def read_file_content(file_name: str) -> str:
+    target = _resolve_within_project_root(file_name, "read_file_content")
+    return SecurePath(target).read_text(file_size_limit_mb=DEFAULT_SIZE_LIMIT_MB)
 
 
 @jinja2.pass_environment  # type: ignore
 def procedure_from_js_file(env: jinja2.Environment, file_name: str):
+    target = _resolve_within_project_root(file_name, "procedure_from_js_file")
     template = env.from_string(
         dedent(
             """\
@@ -47,7 +80,7 @@ def procedure_from_js_file(env: jinja2.Environment, file_name: str):
         )
     )
     return template.render(
-        code=SecurePath(file_name).read_text(file_size_limit_mb=UNLIMITED)
+        code=SecurePath(target).read_text(file_size_limit_mb=DEFAULT_SIZE_LIMIT_MB)
     )
 
 

--- a/tests/api/test_rendering.py
+++ b/tests/api/test_rendering.py
@@ -219,7 +219,9 @@ def test_read_file_content_allows_relative_path_inside_project_root(
     jinja_cli_context.project_root = tmp_path
     target = tmp_path / "relative.txt"
     target.write_text("relative content")
-    monkeypatch.chdir(tmp_path)
+    # CWD deliberately differs from project root — relative path must be
+    # anchored to project_root, not CWD.
+    monkeypatch.chdir("/")
     assert _render("{{ 'relative.txt' | read_file_content }}") == "relative content"
 
 
@@ -295,35 +297,3 @@ def test_read_file_content_enforces_default_size_limit(tmp_path, jinja_cli_conte
         assert_size.side_effect = FileTooLargeError(target, 128)
         with pytest.raises(FileTooLargeError):
             _render(f"{{{{ '{target}' | read_file_content }}}}")
-
-
-def test_read_file_content_skips_containment_on_missing_configuration(tmp_path):
-    """When MissingConfigurationError is raised accessing project_root, the
-    containment check is skipped and the file is read without restriction.
-    Note: snow sql -q always provides a project_root (CWD), so this fallback
-    applies only to non-CLI render callers where no project context exists."""
-    from snowflake.cli.api.exceptions import MissingConfigurationError
-
-    with mock.patch(
-        "snowflake.cli.api.cli_global_context.get_cli_context"
-    ) as ctx, mock.patch(
-        "snowflake.cli.api.rendering.sql_templates.get_cli_context"
-    ) as sql_ctx:
-        sql_ctx().template_context = {
-            "ctx": {"env": ProjectEnvironment(default_env={}, override_env={})}
-        }
-        type(ctx.return_value).project_root = mock.PropertyMock(
-            side_effect=MissingConfigurationError("no project")
-        )
-
-        target = tmp_path / "file.txt"
-        target.write_text("standalone")
-        assert (
-            snowflake_sql_jinja_render(
-                f"{{{{ '{target}' | read_file_content }}}}",
-                template_syntax_config=SQLTemplateSyntaxConfig(
-                    enable_jinja_syntax=True
-                ),
-            )
-            == "standalone"
-        )

--- a/tests/api/test_rendering.py
+++ b/tests/api/test_rendering.py
@@ -180,3 +180,147 @@ def test_has_client_side_templates():
     assert not has_client_side_templates("<test>")
     assert not has_client_side_templates("{<est}")
     assert not has_client_side_templates("")
+
+
+# --- read_file_content / procedure_from_js_file containment tests -----------
+
+
+@pytest.fixture
+def jinja_cli_context():
+    """Patches get_cli_context wherever jinja.py imports it, for filter tests."""
+    with mock.patch(
+        "snowflake.cli.api.cli_global_context.get_cli_context"
+    ) as ctx, mock.patch(
+        "snowflake.cli.api.rendering.sql_templates.get_cli_context"
+    ) as sql_ctx:
+        sql_ctx().template_context = {
+            "ctx": {"env": ProjectEnvironment(default_env={}, override_env={})}
+        }
+        yield ctx()
+
+
+def _render(content: str) -> str:
+    return snowflake_sql_jinja_render(
+        content,
+        template_syntax_config=SQLTemplateSyntaxConfig(enable_jinja_syntax=True),
+    )
+
+
+def test_read_file_content_allows_file_inside_project_root(tmp_path, jinja_cli_context):
+    jinja_cli_context.project_root = tmp_path
+    target = tmp_path / "inside.txt"
+    target.write_text("hello from project")
+    assert _render(f"{{{{ '{target}' | read_file_content }}}}") == "hello from project"
+
+
+def test_read_file_content_allows_relative_path_inside_project_root(
+    tmp_path, jinja_cli_context, monkeypatch
+):
+    jinja_cli_context.project_root = tmp_path
+    target = tmp_path / "relative.txt"
+    target.write_text("relative content")
+    monkeypatch.chdir(tmp_path)
+    assert _render("{{ 'relative.txt' | read_file_content }}") == "relative content"
+
+
+def test_read_file_content_rejects_path_outside_project_root(
+    tmp_path, jinja_cli_context
+):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    jinja_cli_context.project_root = project_root
+
+    outside = tmp_path / "outside.secret"
+    outside.write_text("SECRET")
+
+    with pytest.raises(ClickException) as err:
+        _render(f"{{{{ '{outside}' | read_file_content }}}}")
+    assert "outside the project root" in err.value.message
+    assert "read_file_content" in err.value.message
+
+
+def test_read_file_content_rejects_parent_traversal(tmp_path, jinja_cli_context):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    jinja_cli_context.project_root = project_root
+
+    outside = tmp_path / "outside.secret"
+    outside.write_text("SECRET")
+
+    traversal = project_root / ".." / "outside.secret"
+    with pytest.raises(ClickException) as err:
+        _render(f"{{{{ '{traversal}' | read_file_content }}}}")
+    assert "outside the project root" in err.value.message
+
+
+def test_procedure_from_js_file_rejects_path_outside_project_root(
+    tmp_path, jinja_cli_context
+):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    jinja_cli_context.project_root = project_root
+
+    outside_js = tmp_path / "evil.js"
+    outside_js.write_text("return 42;")
+
+    with pytest.raises(ClickException) as err:
+        _render(f"{{{{ '{outside_js}' | procedure_from_js_file }}}}")
+    assert "outside the project root" in err.value.message
+    assert "procedure_from_js_file" in err.value.message
+
+
+def test_procedure_from_js_file_allows_file_inside_project_root(
+    tmp_path, jinja_cli_context
+):
+    jinja_cli_context.project_root = tmp_path
+    js = tmp_path / "proc.js"
+    js.write_text("return arguments[0];")
+    rendered = _render(f"{{{{ '{js}' | procedure_from_js_file }}}}")
+    assert "return arguments[0];" in rendered
+    assert "module.exports = exports;" in rendered
+
+
+def test_read_file_content_enforces_default_size_limit(tmp_path, jinja_cli_context):
+    """A file over DEFAULT_SIZE_LIMIT_MB (128 MB) must be rejected rather than
+    read unbounded (the UNLIMITED bypass is removed)."""
+    from snowflake.cli.api.exceptions import FileTooLargeError
+
+    jinja_cli_context.project_root = tmp_path
+    target = tmp_path / "big.txt"
+    target.write_text("x")
+
+    with mock.patch(
+        "snowflake.cli.api.secure_path.SecurePath._assert_file_size_limit"
+    ) as assert_size:
+        assert_size.side_effect = FileTooLargeError(target, 128)
+        with pytest.raises(FileTooLargeError):
+            _render(f"{{{{ '{target}' | read_file_content }}}}")
+
+
+def test_read_file_content_without_project_root_is_permissive(tmp_path):
+    """If there is no active project (get_cli_context().project_root raises),
+    the filter falls back to reading the file without containment — this matches
+    the behaviour of ad-hoc ``snow sql -q`` invocations outside a project."""
+    with mock.patch(
+        "snowflake.cli.api.cli_global_context.get_cli_context"
+    ) as ctx, mock.patch(
+        "snowflake.cli.api.rendering.sql_templates.get_cli_context"
+    ) as sql_ctx:
+        sql_ctx().template_context = {
+            "ctx": {"env": ProjectEnvironment(default_env={}, override_env={})}
+        }
+        type(ctx.return_value).project_root = mock.PropertyMock(
+            side_effect=RuntimeError("no project")
+        )
+
+        target = tmp_path / "file.txt"
+        target.write_text("standalone")
+        assert (
+            snowflake_sql_jinja_render(
+                f"{{{{ '{target}' | read_file_content }}}}",
+                template_syntax_config=SQLTemplateSyntaxConfig(
+                    enable_jinja_syntax=True
+                ),
+            )
+            == "standalone"
+        )

--- a/tests/api/test_rendering.py
+++ b/tests/api/test_rendering.py
@@ -210,7 +210,10 @@ def test_read_file_content_allows_file_inside_project_root(tmp_path, jinja_cli_c
     jinja_cli_context.project_root = tmp_path
     target = tmp_path / "inside.txt"
     target.write_text("hello from project")
-    assert _render(f"{{{{ '{target}' | read_file_content }}}}") == "hello from project"
+    assert (
+        _render(f"{{{{ '{target.as_posix()}' | read_file_content }}}}")
+        == "hello from project"
+    )
 
 
 def test_read_file_content_allows_relative_path_inside_project_root(
@@ -236,7 +239,7 @@ def test_read_file_content_rejects_path_outside_project_root(
     outside.write_text("SECRET")
 
     with pytest.raises(ClickException) as err:
-        _render(f"{{{{ '{outside}' | read_file_content }}}}")
+        _render(f"{{{{ '{outside.as_posix()}' | read_file_content }}}}")
     assert "outside the project root" in err.value.message
     assert "read_file_content" in err.value.message
 
@@ -251,7 +254,7 @@ def test_read_file_content_rejects_parent_traversal(tmp_path, jinja_cli_context)
 
     traversal = project_root / ".." / "outside.secret"
     with pytest.raises(ClickException) as err:
-        _render(f"{{{{ '{traversal}' | read_file_content }}}}")
+        _render(f"{{{{ '{traversal.as_posix()}' | read_file_content }}}}")
     assert "outside the project root" in err.value.message
 
 
@@ -266,7 +269,7 @@ def test_procedure_from_js_file_rejects_path_outside_project_root(
     outside_js.write_text("return 42;")
 
     with pytest.raises(ClickException) as err:
-        _render(f"{{{{ '{outside_js}' | procedure_from_js_file }}}}")
+        _render(f"{{{{ '{outside_js.as_posix()}' | procedure_from_js_file }}}}")
     assert "outside the project root" in err.value.message
     assert "procedure_from_js_file" in err.value.message
 
@@ -277,7 +280,7 @@ def test_procedure_from_js_file_allows_file_inside_project_root(
     jinja_cli_context.project_root = tmp_path
     js = tmp_path / "proc.js"
     js.write_text("return arguments[0];")
-    rendered = _render(f"{{{{ '{js}' | procedure_from_js_file }}}}")
+    rendered = _render(f"{{{{ '{js.as_posix()}' | procedure_from_js_file }}}}")
     assert "return arguments[0];" in rendered
     assert "module.exports = exports;" in rendered
 
@@ -296,4 +299,4 @@ def test_read_file_content_enforces_default_size_limit(tmp_path, jinja_cli_conte
     ) as assert_size:
         assert_size.side_effect = FileTooLargeError(target, 128)
         with pytest.raises(FileTooLargeError):
-            _render(f"{{{{ '{target}' | read_file_content }}}}")
+            _render(f"{{{{ '{target.as_posix()}' | read_file_content }}}}")

--- a/tests/api/test_rendering.py
+++ b/tests/api/test_rendering.py
@@ -297,10 +297,13 @@ def test_read_file_content_enforces_default_size_limit(tmp_path, jinja_cli_conte
             _render(f"{{{{ '{target}' | read_file_content }}}}")
 
 
-def test_read_file_content_without_project_root_is_permissive(tmp_path):
-    """If there is no active project (get_cli_context().project_root raises),
-    the filter falls back to reading the file without containment — this matches
-    the behaviour of ad-hoc ``snow sql -q`` invocations outside a project."""
+def test_read_file_content_skips_containment_on_missing_configuration(tmp_path):
+    """When MissingConfigurationError is raised accessing project_root, the
+    containment check is skipped and the file is read without restriction.
+    Note: snow sql -q always provides a project_root (CWD), so this fallback
+    applies only to non-CLI render callers where no project context exists."""
+    from snowflake.cli.api.exceptions import MissingConfigurationError
+
     with mock.patch(
         "snowflake.cli.api.cli_global_context.get_cli_context"
     ) as ctx, mock.patch(
@@ -310,7 +313,7 @@ def test_read_file_content_without_project_root_is_permissive(tmp_path):
             "ctx": {"env": ProjectEnvironment(default_env={}, override_env={})}
         }
         type(ctx.return_value).project_root = mock.PropertyMock(
-            side_effect=RuntimeError("no project")
+            side_effect=MissingConfigurationError("no project")
         )
 
         target = tmp_path / "file.txt"


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description