### PR TITLE
SNOW-3417304: escape single quotes in SHOW ... LIKE patterns

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,10 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
+* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
+* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* `--like` values passed to `snow object list` and `snow spcs image-repository list-images` are now escaped before being inlined into the generated `SHOW ... LIKE '...'` statement. Previously, a single quote in the pattern would terminate the literal and cause the rest of the argument to be parsed as SQL, so `--like "foo'; drop table users; --"` could execute arbitrary statements in the caller's own session.
 
 
 # v3.17.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,10 +44,6 @@
 
 ## Fixes and improvements
 * Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
-* Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
-* Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
-* The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
-* `--like` values passed to `snow object list` and `snow spcs image-repository list-images` are now escaped before being inlined into the generated `SHOW ... LIKE '...'` statement. Previously, a single quote in the pattern would terminate the literal and cause the rest of the argument to be parsed as SQL, so `--like "foo'; drop table users; --"` could execute arbitrary statements in the caller's own session.
 
 
 # v3.17.0

--- a/src/snowflake/cli/_plugins/git/manager.py
+++ b/src/snowflake/cli/_plugins/git/manager.py
@@ -26,6 +26,7 @@ from snowflake.cli._plugins.stage.manager import (
     UserStagePathParts,
 )
 from snowflake.cli.api.identifiers import FQN
+from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.api.stage_path import StagePath
 from snowflake.connector.cursor import SnowflakeCursor
 
@@ -85,10 +86,14 @@ class GitManager(StageManager):
         return StagePath.from_git_str(stage_path)
 
     def show_branches(self, repo_name: str, like: str) -> SnowflakeCursor:
-        return self.execute_query(f"show git branches like '{like}' in {repo_name}")
+        return self.execute_query(
+            f"show git branches like {to_string_literal(like)} in {repo_name}"
+        )
 
     def show_tags(self, repo_name: str, like: str) -> SnowflakeCursor:
-        return self.execute_query(f"show git tags like '{like}' in {repo_name}")
+        return self.execute_query(
+            f"show git tags like {to_string_literal(like)} in {repo_name}"
+        )
 
     def fetch(self, fqn: FQN) -> SnowflakeCursor:
         return self.execute_query(f"alter git repository {fqn} fetch")

--- a/src/snowflake/cli/_plugins/object/manager.py
+++ b/src/snowflake/cli/_plugins/object/manager.py
@@ -22,6 +22,7 @@ from snowflake.cli.api.constants import (
     ObjectNames,
 )
 from snowflake.cli.api.identifiers import FQN
+from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.api.rest_api import RestApi
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector import ProgrammingError
@@ -58,8 +59,7 @@ class ObjectManager(SqlExecutionMixin):
         query = " ".join(query_parts)
 
         if like:
-            escaped_like = like.replace("'", "''")
-            query += f" like '{escaped_like}'"
+            query += f" like {to_string_literal(like)}"
         if scope[0] is not None:
             scope_type = scope[0].replace("-", " ")
             if scope[1] is not None:

--- a/src/snowflake/cli/_plugins/object/manager.py
+++ b/src/snowflake/cli/_plugins/object/manager.py
@@ -58,7 +58,8 @@ class ObjectManager(SqlExecutionMixin):
         query = " ".join(query_parts)
 
         if like:
-            query += f" like '{like}'"
+            escaped_like = like.replace("'", "''")
+            query += f" like '{escaped_like}'"
         if scope[0] is not None:
             scope_type = scope[0].replace("-", " ")
             if scope[1] is not None:

--- a/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
@@ -85,7 +85,8 @@ class ImageRepositoryManager(SqlExecutionMixin):
 
     def list_images(self, repo_name: str, like_option: str) -> SnowflakeCursor:
         if like_option:
-            query = f"show images like '{like_option}' in image repository {repo_name}"
+            escaped_like = like_option.replace("'", "''")
+            query = f"show images like '{escaped_like}' in image repository {repo_name}"
         else:
             query = f"show images in image repository {repo_name}"
         return self.execute_query(query)

--- a/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/_plugins/spcs/image_repository/manager.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 from snowflake.cli._plugins.spcs.common import handle_object_already_exists
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.identifiers import FQN
+from snowflake.cli.api.project.util import to_string_literal
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.errors import ProgrammingError
@@ -85,8 +86,10 @@ class ImageRepositoryManager(SqlExecutionMixin):
 
     def list_images(self, repo_name: str, like_option: str) -> SnowflakeCursor:
         if like_option:
-            escaped_like = like_option.replace("'", "''")
-            query = f"show images like '{escaped_like}' in image repository {repo_name}"
+            query = (
+                f"show images like {to_string_literal(like_option)} "
+                f"in image repository {repo_name}"
+            )
         else:
             query = f"show images in image repository {repo_name}"
         return self.execute_query(query)

--- a/tests/git/test_git_commands.py
+++ b/tests/git/test_git_commands.py
@@ -118,6 +118,47 @@ def test_list_tags_like(mock_connector, runner, mock_ctx):
     assert ctx.get_query() == "show git tags like 'PATTERN' in repo_name"
 
 
+@pytest.mark.parametrize(
+    "subcommand, sql_verb",
+    [("list-branches", "branches"), ("list-tags", "tags")],
+)
+@pytest.mark.parametrize(
+    "like_pattern, expected_literal",
+    [
+        # Plain single quote injection: ''-doubling keeps the payload as data.
+        (
+            "foo'; drop table users; --",
+            "'foo''; drop table users; --'",
+        ),
+        # Backslash-before-quote payload: the connector's client-side
+        # split_statements treats \' as an escape pair, so plain ''-doubling
+        # alone would still let ;DROP TABLE be sliced off as a separate
+        # statement. to_string_literal also doubles the leading backslash.
+        (
+            "x\\';DROP TABLE t;--",
+            "'x\\\\'';DROP TABLE t;--'",
+        ),
+    ],
+)
+@mock.patch("snowflake.connector.connect")
+def test_git_list_like_escapes_string_literal(
+    mock_connector,
+    runner,
+    mock_ctx,
+    subcommand,
+    sql_verb,
+    like_pattern,
+    expected_literal,
+):
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+    result = runner.invoke(["git", subcommand, "repo_name", "--like", like_pattern])
+
+    assert result.exit_code == 0, result.output
+    expected_query = f"show git {sql_verb} like {expected_literal} in repo_name"
+    assert ctx.get_query() == expected_query
+
+
 @mock.patch("snowflake.connector.connect")
 def test_list_files(mock_connector, runner, mock_ctx):
     ctx = mock_ctx()

--- a/tests/object/test_object.py
+++ b/tests/object/test_object.py
@@ -342,20 +342,39 @@ def test_show_with_all_options_combined(mock_execute_query, mock_cursor):
     mock_execute_query.assert_called_once_with(expected_query)
 
 
+@pytest.mark.parametrize(
+    "like_pattern, expected_query",
+    [
+        (
+            "foo'; drop table users; --",
+            "show tables like 'foo''; drop table users; --'",
+        ),
+        # Backslash-before-quote payload: the connector's client-side
+        # split_statements treats \' as an escape pair, so plain ''-doubling
+        # would still let ;DROP TABLE be sliced off as a second statement.
+        # to_string_literal also doubles the leading backslash, keeping the
+        # whole payload inside a single literal.
+        (
+            "x\\';DROP TABLE t;--",
+            "show tables like 'x\\\\'';DROP TABLE t;--'",
+        ),
+        # % and _ remain wildcards (LIKE pattern semantics preserved).
+        ("foo%bar_baz", "show tables like 'foo%bar_baz'"),
+    ],
+)
 @mock.patch("snowflake.cli._plugins.object.manager.ObjectManager.execute_query")
-def test_show_like_escapes_single_quotes(mock_execute_query, mock_cursor):
-    """A single quote in --like must be escaped so it cannot terminate the
-    LIKE literal and inject additional SQL statements."""
+def test_show_like_escapes_string_literal(
+    mock_execute_query, mock_cursor, like_pattern, expected_query
+):
+    """A single quote (or backslash-quote) in --like must be escaped so it
+    cannot terminate the LIKE literal and inject additional SQL statements,
+    while LIKE wildcards (% and _) are left untouched."""
     from snowflake.cli._plugins.object.manager import ObjectManager
 
     mock_execute_query.return_value = mock_cursor(["row"], [])
 
-    ObjectManager().show(
-        object_type="table",
-        like="foo'; drop table users; --",
-    )
+    ObjectManager().show(object_type="table", like=like_pattern)
 
-    expected_query = "show tables like 'foo''; drop table users; --'"
     mock_execute_query.assert_called_once_with(expected_query)
 
 

--- a/tests/object/test_object.py
+++ b/tests/object/test_object.py
@@ -342,6 +342,23 @@ def test_show_with_all_options_combined(mock_execute_query, mock_cursor):
     mock_execute_query.assert_called_once_with(expected_query)
 
 
+@mock.patch("snowflake.cli._plugins.object.manager.ObjectManager.execute_query")
+def test_show_like_escapes_single_quotes(mock_execute_query, mock_cursor):
+    """A single quote in --like must be escaped so it cannot terminate the
+    LIKE literal and inject additional SQL statements."""
+    from snowflake.cli._plugins.object.manager import ObjectManager
+
+    mock_execute_query.return_value = mock_cursor(["row"], [])
+
+    ObjectManager().show(
+        object_type="table",
+        like="foo'; drop table users; --",
+    )
+
+    expected_query = "show tables like 'foo''; drop table users; --'"
+    mock_execute_query.assert_called_once_with(expected_query)
+
+
 @mock.patch("snowflake.connector")
 @pytest.mark.parametrize(
     "object_type, object_name",

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -367,18 +367,30 @@ def test_list_images_with_like(mock_execute_query):
     assert result == cursor
 
 
+@pytest.mark.parametrize(
+    "like_pattern, expected_literal",
+    [
+        ("foo'; drop table users; --", "'foo''; drop table users; --'"),
+        # Backslash-before-quote bypass: the connector's split_statements
+        # treats \' as an escape pair, so plain ''-doubling would still let
+        # the trailing DROP TABLE be sliced off as a second statement.
+        ("x\\';DROP TABLE t;--", "'x\\\\'';DROP TABLE t;--'"),
+        # % / _ wildcards are preserved (LIKE pattern semantics intact).
+        ("echo%_v2", "'echo%_v2'"),
+    ],
+)
 @patch(
     "snowflake.cli._plugins.spcs.image_repository.commands.ImageRepositoryManager.execute_query"
 )
-def test_list_images_like_escapes_single_quotes(mock_execute_query):
+def test_list_images_like_escapes_string_literal(
+    mock_execute_query, like_pattern, expected_literal
+):
     repo_name = "test_repo"
-    like = "foo'; drop table users; --"
     cursor = Mock(spec=SnowflakeCursor)
     mock_execute_query.return_value = cursor
-    ImageRepositoryManager().list_images(repo_name, like)
+    ImageRepositoryManager().list_images(repo_name, like_pattern)
     expected_query = (
-        "show images like 'foo''; drop table users; --' "
-        "in image repository test_repo"
+        f"show images like {expected_literal} in image repository test_repo"
     )
     mock_execute_query.assert_called_once_with(expected_query)
 

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -367,6 +367,22 @@ def test_list_images_with_like(mock_execute_query):
     assert result == cursor
 
 
+@patch(
+    "snowflake.cli._plugins.spcs.image_repository.commands.ImageRepositoryManager.execute_query"
+)
+def test_list_images_like_escapes_single_quotes(mock_execute_query):
+    repo_name = "test_repo"
+    like = "foo'; drop table users; --"
+    cursor = Mock(spec=SnowflakeCursor)
+    mock_execute_query.return_value = cursor
+    ImageRepositoryManager().list_images(repo_name, like)
+    expected_query = (
+        "show images like 'foo''; drop table users; --' "
+        "in image repository test_repo"
+    )
+    mock_execute_query.assert_called_once_with(expected_query)
+
+
 @mock.patch("snowflake.cli._plugins.spcs.image_repository.commands.requests.get")
 @mock.patch(EXECUTE_QUERY)
 @mock.patch(


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

`ObjectManager.show` (`src/snowflake/cli/_plugins/object/manager.py:61`) and
`ImageRepositoryManager.list_images`
(`src/snowflake/cli/_plugins/spcs/image_repository/manager.py:88`) both build
`SHOW ... LIKE '{pattern}'` by f-string interpolation of the raw `--like`
argument. A single quote in the pattern terminates the SQL string literal
early; because `execute_stream` splits the resulting statement on semicolons,
anything after the injected quote is run as its own statement in the caller's
own session.

Fix: double single quotes at the SQL construction site (`'` → `''`), which is
the canonical way to escape a single quote inside a Snowflake string literal
and leaves legitimate `%` / `_` metacharacters untouched.

The exploit path requires access to the developer's own CLI invocation
(`--like` is not read from a project file or external source), so there is no
supply-chain vector and no privilege escalation — but a user who pastes an
attacker-supplied `--like` value will execute arbitrary SQL with their own
role. The fix is also precondition for any future feature that plumbs
`--like` from a less-trusted source (e.g. a template or config).

Ticket: [SNOW-3417304](https://snowflakecomputing.atlassian.net/browse/SNOW-3417304)

[SNOW-3417304]: https://snowflakecomputing.atlassian.net/browse/SNOW-3417304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ