### PR TITLE
Snowflake Apps: report terminal poll failures as failures

### DIFF
--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -117,6 +117,11 @@ def _poll_until(
     Raises ``CliError`` on error or timeout.  Returns the final value on
     success.
     """
+
+    def _failure_message_from_timeout_message(message: str) -> str:
+        """Convert timeout-style wording into failure wording for terminal error states."""
+        return re.sub(r"\btimed out\b", "failed", message, count=1, flags=re.IGNORECASE)
+
     for _attempt in range(max_attempts):
         if on_poll is not None:
             for _ in range(interval_seconds):
@@ -136,13 +141,19 @@ def _poll_until(
             if is_done(result):
                 return result
             if is_error is not None and is_error(result):
-                raise CliError(f"{timeout_message} (status={format_status(result)})")
+                raise CliError(
+                    f"{_failure_message_from_timeout_message(timeout_message)} "
+                    f"(status={format_status(result)})"
+                )
         else:
             # ── State-set mode (original behaviour) ───────────────
             if done_states and result in done_states:
                 return result
             if error_states and result in error_states:
-                raise CliError(f"{timeout_message} (status={result})")
+                raise CliError(
+                    f"{_failure_message_from_timeout_message(timeout_message)} "
+                    f"(status={result})"
+                )
             if known_pending_states is not None and result not in known_pending_states:
                 raise CliError(f"{timeout_message} (unexpected status={result})")
 

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -220,6 +220,16 @@ class TestPollUntilPredicateMode:
             )
 
     @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    def test_is_error_predicate_rewrites_timeout_wording(self, mock_sleep):
+        with pytest.raises(CliError, match="Upgrade failed"):
+            _poll_until(
+                poll_fn=lambda: "FAILED",
+                is_done=lambda v: v == "READY",
+                is_error=lambda v: v == "FAILED",
+                timeout_message="Upgrade timed out. Check logs:",
+            )
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
     def test_predicate_mode_timeout(self, mock_sleep):
         with pytest.raises(CliError, match="timed out"):
             _poll_until(
@@ -262,7 +272,7 @@ class TestPollUntilStateSetMode:
 
     @patch("snowflake.cli._plugins.apps.manager.time.sleep")
     def test_error_state_raises(self, mock_sleep):
-        with pytest.raises(CliError, match="timed out"):
+        with pytest.raises(CliError, match="failed"):
             _poll_until(
                 poll_fn=lambda: "FAILED",
                 done_states={"DONE"},


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- Fix `_poll_until` error-state reporting so terminal failures no longer surface as timeout wording.
- Rewrite timeout-style messages to failure-style wording when `is_error` or `error_states` is triggered.
- Preserve true timeout behavior and wording when max attempts are exhausted.
- Add/adjust polling unit tests for predicate and state-set modes.
