### PR TITLE
fix: [SNOW-3480430] actionable error when a [connections] entry is not a table

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).
 * Fixed `snow connection generate-jwt` and `snow connection generate-workload-identity-token` failing with `Connection None is not configured` when used with `--temporary-connection`.
 * The internal connection cache now remembers failed connect attempts and re-raises the original exception on subsequent accesses within the same process, instead of re-dialing Snowflake every time a command accesses the shared connection. This fixes, among other cases, the customer-visible duplicate `LOGIN_HISTORY` events (and `OVERFLOW_FAILURE_EVENTS_ELIDED`) previously emitted when a `snow` invocation was rejected by an authentication policy.
+* `snow connection list` (and other commands that enumerate connections) now raises a clear, actionable error when the `[connections]` section of `config.toml` contains an entry that is not a table (for example, a stray `default = "something"` line at the top of the section). Previously these configurations produced an unhandled `AttributeError: 'String' object has no attribute 'items'` with no indication of which entry was wrong.
 
 
 # v3.17.0

--- a/src/snowflake/cli/api/config_provider.py
+++ b/src/snowflake/cli/api/config_provider.py
@@ -136,14 +136,21 @@ class LegacyConfigProvider(ConfigProvider):
             )
 
     def get_all_connections(self, include_env_connections: bool = False) -> dict:
+        from click import ClickException
         from snowflake.cli.api.config import ConnectionConfig, get_config_section
 
         # Legacy provider ignores the flag since it never had env connections
         connections = get_config_section("connections")
-        return {
-            name: ConnectionConfig.from_dict(config)
-            for name, config in connections.items()
-        }
+        result = {}
+        for name, config in connections.items():
+            if not isinstance(config, dict):
+                raise ClickException(
+                    f"Connection '{name}' in the configuration file is malformed: "
+                    f"expected a table of connection parameters but found a {type(config).__name__}. "
+                    f"Each connection must be defined as [connections.{name}] with key = value entries."
+                )
+            result[name] = ConnectionConfig.from_dict(config)
+        return result
 
 
 class AlternativeConfigProvider(ConfigProvider):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -415,6 +415,32 @@ def test_mask_sensitive_parameters_masks_all_known_sensitive_keys():
     assert params["password"] == "hunter2"
 
 
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_connection_list_reports_malformed_connection_entry(runner):
+    with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
+        tmp_file.write(
+            dedent(
+                """\
+                [connections]
+                default = "conn"
+
+                [connections.conn]
+                user = "foo"
+                """
+            )
+        )
+        tmp_file.flush()
+        os.chmod(tmp_file.name, 0o600)
+        result = runner.invoke_with_config_file(
+            tmp_file.name, ["connection", "list", "--format", "json"]
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "malformed" in result.output
+    assert "default" in result.output
+    assert "[connections.default]" in result.output
+
+
 @mock.patch.dict(
     os.environ,
     {


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Fixes #2954 (SNOW-3480430).

`snow connection list` (and other commands that enumerate connections) crashed with
`AttributeError: 'String' object has no attribute 'items'` when the `[connections]`
section of `config.toml` contained an entry that was not a TOML table. The canonical
cause is a scalar assignment directly under `[connections]`, e.g.

```toml
[connections]
default = "conn"          # <-- this line is the problem

[connections.conn]
account = "..."
```

The legacy config provider iterates over each entry in the `[connections]` section
and passes the raw value to `ConnectionConfig.from_dict`, which assumes a dict and
calls `.items()`. For the scalar `"conn"` above, tomlkit returns a `tomlkit.items.String`,
and `.items()` blows up with a bare `AttributeError` — no mention of which entry is wrong
or how to fix it.

#### Fix

In `LegacyConfigProvider.get_all_connections`, validate each entry and raise a
`ClickException` that:

- names the offending entry, and
- shows the correct `[connections.<name>]` form.

I considered silently filtering non-dict entries (mirroring `AlternativeConfigProvider.
_get_file_based_connections`, which does exactly that), but silently skipping would hide
a connection the user actually meant to define, and the user would have no idea why their
connection doesn't show up. An actionable error matches the existing "Configuration file
seems to be corrupted" pattern in `config.py` and is more useful.

The check uses `isinstance(config, dict)` — `tomlkit.items.Table` is a `dict` subclass, so
valid connection tables pass through unchanged.

#### Testing

Added a regression test (`test_connection_list_reports_malformed_connection_entry`) that
reproduces the exact config from the issue and asserts the command fails with a message
naming the entry and showing the correct form. Verified that the test fails on `main`
with the original `AttributeError` and passes with this fix.