### PR TITLE
fix: bump GitPython to 3.1.49 (CVE-2026-44244)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Updated `GitPython` to 3.1.49 to address CVE-2026-44244, a config injection vulnerability in `GitConfigParser.set_value()` that could allow arbitrary hook path injection and remove code execution via crafted author names or emails.
 
 
 # v3.17.0

--- a/pylock.toml
+++ b/pylock.toml
@@ -268,9 +268,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5
 
 [[packages]]
 name = "gitpython"
-version = "3.1.44"
-sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", upload-time = 2025-01-02T07:32:43Z, size = 214196, hashes = { sha256 = "c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", upload-time = 2025-01-02T07:32:40Z, size = 207599, hashes = { sha256 = "9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110" } }]
+version = "3.1.49"
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", upload-time = 2026-04-29T00:31:20Z, size = 219367, hashes = { sha256 = "42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", upload-time = 2026-04-29T00:31:18Z, size = 212190, hashes = { sha256 = "024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c" } }]
 
 [[packages]]
 name = "id"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 dependencies = [
   # Actual project dependencies, from which we generate [project.dependencies] section serving as a lockfile for PyPi
   "click==8.1.8",
-  "GitPython==3.1.44",
+  "GitPython==3.1.49",
   "PyYAML==6.0.2",
   "id==1.5.0",
   "jinja2==3.1.6",


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
       * n/a - I have executed the existing test suite, patch version of a dependency does not introduce new behaviour
   * [x] I've added or updated integration tests to verify correctness of my new code.
       * n/a - I have executed the existing test suite, patch version of a dependency does not introduce new behaviour
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
       * n/a - I have executed the existing test suite, patch version of a dependency does not introduce new behaviour
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
       * n/a - I have executed the existing test suite, patch version of a dependency does not introduce new behaviour
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.
       * n/a - updating a dependency version does not introduce documentable behaivour

### Changes description

GitPython <=3.1.48 does not validate newlines in
GitConfigParser.set_value(), allowing injection of arbitrary config sections, and potential RCE via crafted author names or emails.
