### PR TITLE
Add `--protocol` global connection override (SNOW-2683101)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* Added a `--protocol` option (plus matching `SNOWFLAKE_PROTOCOL` env var and `protocol` config key) to `snow connection add` and the global connection overrides. This allows selecting `http` or `https` as the connection protocol without editing `config.toml`, which is primarily useful for local development against `http` deployments.
 
 ## Fixes and improvements
 

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -65,6 +65,7 @@ SUPPORTED_ENV_OVERRIDES = [
     "password",
     "host",
     "port",
+    "protocol",
     "authenticator",
     "workload_identity_provider",
     "private_key_file",

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -230,7 +230,7 @@ def add(
     protocol: Optional[str] = typer.Option(
         None,
         *ProtocolOption.param_decls,
-        help="Protocol to use for the connection, `http` or `https`.",
+        help="Protocol to use for the connection, for example `https`.",
     ),
     region: Optional[str] = typer.Option(
         None,

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -43,6 +43,7 @@ from snowflake.cli.api.commands.flags import (
     PasswordOption,
     PortOption,
     PrivateKeyPathOption,
+    ProtocolOption,
     RoleOption,
     SchemaOption,
     SecondaryRolesOption,
@@ -226,6 +227,11 @@ def add(
         *PortOption.param_decls,
         help="Port to communicate with on the host.",
     ),
+    protocol: Optional[str] = typer.Option(
+        None,
+        *ProtocolOption.param_decls,
+        help="Protocol to use for the connection, `http` or `https`.",
+    ),
     region: Optional[str] = typer.Option(
         None,
         "--region",
@@ -287,6 +293,7 @@ def add(
         "schema": schema,
         "host": host,
         "port": port,
+        "protocol": protocol,
         "region": region,
         "authenticator": authenticator,
         "workload_identity_provider": workload_identity_provider,

--- a/src/snowflake/cli/api/commands/decorators.py
+++ b/src/snowflake/cli/api/commands/decorators.py
@@ -48,6 +48,7 @@ from snowflake.cli.api.commands.flags import (
     PasswordOption,
     PortOption,
     PrivateKeyPathOption,
+    ProtocolOption,
     RoleOption,
     SchemaOption,
     SecondaryRolesOption,
@@ -240,6 +241,12 @@ GLOBAL_CONNECTION_OPTIONS = [
         inspect.Parameter.KEYWORD_ONLY,
         annotation=Optional[int],
         default=PortOption,
+    ),
+    inspect.Parameter(
+        "protocol",
+        inspect.Parameter.KEYWORD_ONLY,
+        annotation=Optional[str],
+        default=ProtocolOption,
     ),
     inspect.Parameter(
         "account",

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -133,7 +133,7 @@ PortOption = typer.Option(
 ProtocolOption = typer.Option(
     None,
     "--protocol",
-    help="Protocol to use for the connection, `http` or `https`. Overrides the value specified for the connection.",
+    help="Protocol to use for the connection, for example `https`. Overrides the value specified for the connection.",
     callback=_connection_callback("protocol"),
     show_default=False,
     rich_help_panel=_CONNECTION_SECTION,

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -130,6 +130,15 @@ PortOption = typer.Option(
     rich_help_panel=_CONNECTION_SECTION,
 )
 
+ProtocolOption = typer.Option(
+    None,
+    "--protocol",
+    help="Protocol to use for the connection, `http` or `https`. Overrides the value specified for the connection.",
+    callback=_connection_callback("protocol"),
+    show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
+)
+
 AccountOption = typer.Option(
     None,
     "--account",

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -111,6 +111,7 @@ class ConnectionConfig:
     host: Optional[str] = None
     region: Optional[str] = None
     port: Optional[int] = None
+    protocol: Optional[str] = None
     database: Optional[str] = None
     schema: Optional[str] = None
     warehouse: Optional[str] = None

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -53,6 +53,7 @@ class ConnectionContext:
     connection_name: Optional[str] = None
     host: Optional[str] = None
     port: Optional[int] = None
+    protocol: Optional[str] = None
     account: Optional[str] = None
     database: Optional[str] = None
     role: Optional[str] = None

--- a/tests/__snapshots__/test_connection.ambr
+++ b/tests/__snapshots__/test_connection.ambr
@@ -52,6 +52,7 @@
   host = "baz"
   region = "Kaszuby"
   port = 12345
+  protocol = ""
   database = "foo"
   schema = "bar"
   warehouse = "some warehouse"
@@ -73,6 +74,7 @@
               "host": "baz",
               "region": "Kaszuby",
               "port": 12345,
+              "protocol": "",
               "database": "foo",
               "schema": "bar",
               "warehouse": "some warehouse",

--- a/tests/__snapshots__/test_connection.ambr
+++ b/tests/__snapshots__/test_connection.ambr
@@ -126,6 +126,18 @@
   
   '''
 # ---
+# name: test_new_connection_can_be_added_with_protocol
+  '''
+  [connections.conn-http]
+  account = "account1"
+  user = "user1"
+  password = "password1"
+  host = "localhost"
+  port = 8080
+  protocol = "http"
+  
+  '''
+# ---
 # name: test_new_connection_with_jwt_auth
   '''
   [connections.conn2]

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -14,6 +14,7 @@
     --connection <connection>
     --host <host>
     --port <port>
+    --protocol <protocol>
     --account <account>
     --user <user>
     --password <password>
@@ -101,6 +102,12 @@
   <dd>
   
   Port for the connection. Overrides the value specified for the connection.
+  
+  </dd>
+  <dt><code className="samp">--protocol <em>TEXT</em></code></dt>
+  <dd>
+  
+  Protocol to use for the connection, for example `https`. Overrides the value specified for the connection.
   
   </dd>
   <dt><code className="samp">--account, --accountname <em>TEXT</em></code></dt>

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -239,6 +239,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -392,6 +396,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -631,6 +639,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -800,6 +812,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -1044,6 +1060,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1205,6 +1225,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -1369,6 +1393,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1525,6 +1553,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -1690,6 +1722,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1852,6 +1888,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2007,6 +2047,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -2197,6 +2241,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2366,6 +2414,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2529,6 +2581,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -2705,6 +2761,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2863,6 +2923,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -3138,6 +3202,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3290,6 +3358,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -3493,6 +3565,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3656,6 +3732,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -3886,6 +3966,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -4072,6 +4156,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -4224,6 +4312,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -4507,6 +4599,8 @@
   |                                                 Snowflake.                   |
   | --port                         -P      INTEGER  Port to communicate with on  |
   |                                                 the host.                    |
+  | --protocol                             TEXT     Protocol to use for the      |
+  |                                                 connection, http or https.   |
   | --region                       -R      TEXT     Region name if not the       |
   |                                                 default Snowflake            |
   |                                                 deployment.                  |
@@ -4581,6 +4675,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -4724,6 +4822,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -5000,6 +5102,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -5283,6 +5389,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -5426,6 +5536,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -5573,6 +5687,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -5728,6 +5846,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -5911,6 +6033,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6090,6 +6216,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -6273,6 +6403,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6452,6 +6586,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -6635,6 +6773,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6814,6 +6956,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -6997,6 +7143,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7176,6 +7326,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -7359,6 +7513,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7538,6 +7696,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -7721,6 +7883,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7900,6 +8066,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -8082,6 +8252,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8259,6 +8433,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8418,6 +8596,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8569,6 +8751,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -8733,6 +8919,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8888,6 +9078,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9039,6 +9233,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -9199,6 +9397,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9355,6 +9557,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -9514,6 +9720,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -9693,6 +9903,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9848,6 +10062,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -10006,6 +10224,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10160,6 +10382,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -10356,6 +10582,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10499,6 +10729,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -10646,6 +10880,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -10815,6 +11053,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10959,6 +11201,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -11109,6 +11355,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -11262,6 +11512,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11410,6 +11664,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -11564,6 +11822,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -11722,6 +11984,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -11972,6 +12238,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12119,6 +12389,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -12279,6 +12553,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12423,6 +12701,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -12571,6 +12853,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12715,6 +13001,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -12905,6 +13195,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13056,6 +13350,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -13211,6 +13509,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -13377,6 +13679,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -13711,6 +14017,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13873,6 +14183,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14022,6 +14336,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -14177,6 +14495,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14328,6 +14650,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -14486,6 +14812,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -14648,6 +14978,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14791,6 +15125,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -14939,6 +15277,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -15196,6 +15538,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15347,6 +15693,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15491,6 +15841,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -15641,6 +15995,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15787,6 +16145,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15931,6 +16293,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -16099,6 +16465,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16244,6 +16614,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -16392,6 +16766,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16537,6 +16915,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -16692,6 +17074,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -16871,6 +17257,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17013,6 +17403,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -17166,6 +17560,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -17338,6 +17736,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17487,6 +17889,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17633,6 +18039,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -17785,6 +18195,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17935,6 +18349,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -18091,6 +18509,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18235,6 +18657,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -18457,6 +18883,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18660,6 +19090,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18812,6 +19246,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18955,6 +19393,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -19105,6 +19547,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -19278,6 +19724,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19421,6 +19871,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -19568,6 +20022,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19713,6 +20171,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19856,6 +20318,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -20010,6 +20476,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -20169,6 +20639,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20324,6 +20798,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20467,6 +20945,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -20661,6 +21143,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20810,6 +21296,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20953,6 +21443,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -21117,6 +21611,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21262,6 +21760,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -21537,6 +22039,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21714,6 +22220,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21868,6 +22378,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22011,6 +22525,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -22160,6 +22678,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22305,6 +22827,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -22471,6 +22997,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22618,6 +23148,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -22774,6 +23308,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22919,6 +23457,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -23114,6 +23656,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23258,6 +23804,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -23408,6 +23958,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23552,6 +24106,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -23699,6 +24257,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -23853,6 +24415,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -24169,6 +24735,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
@@ -24585,6 +25155,10 @@
   |                                                value specified for the       |
   |                                                connection.                   |
   | --port                                INTEGER  Port for the connection.      |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -240,9 +240,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -399,9 +399,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -640,9 +640,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -815,9 +815,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1061,9 +1061,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1228,9 +1228,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1394,9 +1394,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1556,9 +1556,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1723,9 +1723,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -1889,9 +1889,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2050,9 +2050,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2242,9 +2242,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2415,9 +2415,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2584,9 +2584,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2762,9 +2762,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -2926,9 +2926,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3203,9 +3203,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3361,9 +3361,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3566,9 +3566,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3735,9 +3735,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -3967,9 +3967,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -4157,9 +4157,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -4315,9 +4315,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -4600,7 +4600,8 @@
   | --port                         -P      INTEGER  Port to communicate with on  |
   |                                                 the host.                    |
   | --protocol                             TEXT     Protocol to use for the      |
-  |                                                 connection, http or https.   |
+  |                                                 connection, for example      |
+  |                                                 https.                       |
   | --region                       -R      TEXT     Region name if not the       |
   |                                                 default Snowflake            |
   |                                                 deployment.                  |
@@ -4678,9 +4679,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -4825,9 +4826,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -5105,9 +5106,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -5390,9 +5391,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -5539,9 +5540,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -5690,9 +5691,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -5849,9 +5850,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6034,9 +6035,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6219,9 +6220,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6404,9 +6405,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6589,9 +6590,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6774,9 +6775,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -6959,9 +6960,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7144,9 +7145,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7329,9 +7330,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7514,9 +7515,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7699,9 +7700,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -7884,9 +7885,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8069,9 +8070,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8253,9 +8254,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8434,9 +8435,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8597,9 +8598,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8754,9 +8755,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -8920,9 +8921,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9079,9 +9080,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9236,9 +9237,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9398,9 +9399,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9560,9 +9561,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9723,9 +9724,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -9904,9 +9905,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10065,9 +10066,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10225,9 +10226,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10385,9 +10386,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10583,9 +10584,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10732,9 +10733,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -10883,9 +10884,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11054,9 +11055,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11204,9 +11205,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11358,9 +11359,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11513,9 +11514,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11667,9 +11668,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11825,9 +11826,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -11987,9 +11988,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12239,9 +12240,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12392,9 +12393,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12554,9 +12555,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12704,9 +12705,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -12854,9 +12855,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13004,9 +13005,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13196,9 +13197,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13353,9 +13354,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13512,9 +13513,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -13682,9 +13683,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14018,9 +14019,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14184,9 +14185,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14339,9 +14340,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14496,9 +14497,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14653,9 +14654,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14815,9 +14816,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -14979,9 +14980,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15128,9 +15129,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15280,9 +15281,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15539,9 +15540,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15694,9 +15695,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15844,9 +15845,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -15996,9 +15997,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16146,9 +16147,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16296,9 +16297,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16466,9 +16467,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16617,9 +16618,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16767,9 +16768,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -16918,9 +16919,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17077,9 +17078,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17258,9 +17259,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17406,9 +17407,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17563,9 +17564,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17737,9 +17738,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -17890,9 +17891,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18042,9 +18043,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18196,9 +18197,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18352,9 +18353,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18510,9 +18511,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18660,9 +18661,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -18884,9 +18885,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19091,9 +19092,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19247,9 +19248,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19396,9 +19397,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19550,9 +19551,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19725,9 +19726,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -19874,9 +19875,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20023,9 +20024,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20172,9 +20173,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20321,9 +20322,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20479,9 +20480,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20640,9 +20641,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20799,9 +20800,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -20948,9 +20949,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21144,9 +21145,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21297,9 +21298,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21446,9 +21447,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21612,9 +21613,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -21763,9 +21764,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22040,9 +22041,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22221,9 +22222,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22379,9 +22380,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22528,9 +22529,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22679,9 +22680,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22830,9 +22831,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -22998,9 +22999,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23151,9 +23152,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23309,9 +23310,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23460,9 +23461,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23657,9 +23658,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23807,9 +23808,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -23959,9 +23960,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -24109,9 +24110,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -24260,9 +24261,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -24418,9 +24419,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -24589,6 +24590,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -24738,9 +24743,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |
@@ -25158,9 +25163,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |

--- a/tests/api/commands/__snapshots__/test_snow_typer.ambr
+++ b/tests/api/commands/__snapshots__/test_snow_typer.ambr
@@ -21,6 +21,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |

--- a/tests/api/commands/__snapshots__/test_snow_typer.ambr
+++ b/tests/api/commands/__snapshots__/test_snow_typer.ambr
@@ -22,9 +22,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |

--- a/tests/output/__snapshots__/test_silent_output.ambr
+++ b/tests/output/__snapshots__/test_silent_output.ambr
@@ -27,9 +27,9 @@
   |                                                Overrides the value specified |
   |                                                for the connection.           |
   | --protocol                            TEXT     Protocol to use for the       |
-  |                                                connection, http or https.    |
-  |                                                Overrides the value specified |
-  |                                                for the connection.           |
+  |                                                connection, for example       |
+  |                                                https. Overrides the value    |
+  |                                                specified for the connection. |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |

--- a/tests/output/__snapshots__/test_silent_output.ambr
+++ b/tests/output/__snapshots__/test_silent_output.ambr
@@ -26,6 +26,10 @@
   | --port                                INTEGER  Port for the connection.      |
   |                                                Overrides the value specified |
   |                                                for the connection.           |
+  | --protocol                            TEXT     Protocol to use for the       |
+  |                                                connection, http or https.    |
+  |                                                Overrides the value specified |
+  |                                                for the connection.           |
   | --account,--accountname               TEXT     Name assigned to your         |
   |                                                Snowflake account. Overrides  |
   |                                                the value specified for the   |

--- a/tests/test_common_decorators.py
+++ b/tests/test_common_decorators.py
@@ -31,6 +31,7 @@ _KNOWN_SIG_GLOBAL_PARAMETERS_WITH_CONNECTION = [
     "connection",
     "host",
     "port",
+    "protocol",
     "account",
     "user",
     "password",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -62,6 +62,34 @@ def test_new_connection_can_be_added(
     assert content == os_agnostic_snapshot
 
 
+def test_new_connection_can_be_added_with_protocol(runner):
+    with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
+            [
+                "connection",
+                "add",
+                "--connection-name",
+                "conn-http",
+                "--username",
+                "user1",
+                "--password",
+                "password1",
+                "--account",
+                "account1",
+                "--host",
+                "localhost",
+                "--port",
+                "8080",
+                "--protocol",
+                "http",
+            ],
+        )
+        content = tmp_file.read()
+    assert result.exit_code == 0, result.output
+    assert 'protocol = "http"' in content
+
+
 def test_new_connection_can_be_added_as_default(runner, os_agnostic_snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
         result = runner.invoke_with_config_file(
@@ -126,7 +154,7 @@ def test_if_whitespaces_are_stripped_from_connection_name(runner, os_agnostic_sn
                 "--account",
                 "             accName",
             ],
-            input="123\n some role    \n some warehouse\n foo \n bar     \n baz \n    12345 \n Kaszuby \n foo   \n \n",
+            input="123\n some role    \n some warehouse\n foo \n bar     \n baz \n    12345 \n \n Kaszuby \n foo   \n \n",
         )
         content = tmp_file.read()
 
@@ -190,7 +218,7 @@ def test_port_has_cannot_be_float(runner):
 
 @pytest.mark.parametrize(
     "selected_option",
-    [10, 11],  # 10 - private_key_file prompt, 11 - token_file_path prompt
+    [11, 12],  # 11 - private_key_file prompt, 12 - token_file_path prompt
 )
 def test_file_paths_have_to_exist_when_given_in_prompt(selected_option, runner):
     result = _run_connection_add_with_path_provided_as_prompt(
@@ -202,8 +230,8 @@ def test_file_paths_have_to_exist_when_given_in_prompt(selected_option, runner):
 
 
 @pytest.mark.parametrize(
-    "selected_option", [9, 10]
-)  # 9 - private_key_file prompt, 10 - token_file_path prompt
+    "selected_option", [10, 11]
+)  # 10 - private_key_file prompt, 11 - token_file_path prompt
 def test_connection_can_be_added_with_existing_paths_in_prompt(selected_option, runner):
     with NamedTemporaryFile("w+") as tmp_path:
         result = _run_connection_add_with_path_provided_as_prompt(
@@ -312,6 +340,7 @@ def test_lists_connection_information(mock_get_default_conn_name, runner):
                 "database": "dev_database",
                 "host": "dev_host",
                 "port": 8000,
+                "protocol": "dev_protocol",
                 "role": "dev_role",
                 "schema": "dev_schema",
                 "user": "dev_user",
@@ -497,6 +526,7 @@ def test_connection_list_does_not_print_too_many_env_variables(
                 "database": "dev_database",
                 "host": "dev_host",
                 "port": 8000,
+                "protocol": "dev_protocol",
                 "role": "dev_role",
                 "schema": "dev_schema",
                 "user": "dev_user",
@@ -892,6 +922,73 @@ def test_host_and_port_are_read_from_env_for_temporary_connection(
     kwargs = mock_connector.call_args.kwargs
     assert kwargs["host"] == "env-host.snowflakecomputing.com"
     assert kwargs["port"] == "4242"
+
+
+@mock.patch("snowflake.connector.connect")
+def test_protocol_flag_is_forwarded_for_temporary_connection(
+    mock_connector, mock_ctx, runner
+):
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    result = runner.invoke(
+        [
+            "object",
+            "list",
+            "warehouse",
+            "--temporary-connection",
+            "--account",
+            "test_account",
+            "--user",
+            "snowcli_test",
+            "--password",
+            "top_secret",
+            "--host",
+            "localhost",
+            "--port",
+            "8080",
+            "--protocol",
+            "http",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_connector.call_args.kwargs
+    assert kwargs["protocol"] == "http"
+    assert kwargs["host"] == "localhost"
+    assert kwargs["port"] == 8080
+
+
+@mock.patch.dict(
+    os.environ,
+    {"SNOWFLAKE_PROTOCOL": "http"},
+    clear=True,
+)
+@mock.patch("snowflake.connector.connect")
+def test_protocol_is_read_from_env_for_temporary_connection(
+    mock_connector, mock_ctx, runner
+):
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    result = runner.invoke(
+        [
+            "object",
+            "list",
+            "warehouse",
+            "--temporary-connection",
+            "--account",
+            "test_account",
+            "--user",
+            "snowcli_test",
+            "--password",
+            "top_secret",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_connector.call_args.kwargs
+    assert kwargs["protocol"] == "http"
 
 
 @mock.patch("snowflake.connector.connect")
@@ -2128,6 +2225,7 @@ def test_connection_add_no_key_pair_setup_if_private_key_provided(
         "\n"  # schema:
         "\n"  # host:
         "\n"  # port:
+        "\n"  # protocol:
         "\n"  # region:
         "\n"  # authenticator:
         "\n"  # workload identity provider:
@@ -2148,6 +2246,7 @@ def test_connection_add_no_key_pair_setup_if_private_key_provided(
         Enter schema: 
         Enter host: 
         Enter port: 
+        Enter protocol: 
         Enter region: 
         Enter authenticator: 
         Enter workload identity provider: 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -62,7 +62,7 @@ def test_new_connection_can_be_added(
     assert content == os_agnostic_snapshot
 
 
-def test_new_connection_can_be_added_with_protocol(runner):
+def test_new_connection_can_be_added_with_protocol(runner, os_agnostic_snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
         result = runner.invoke_with_config_file(
             tmp_file.name,
@@ -87,7 +87,7 @@ def test_new_connection_can_be_added_with_protocol(runner):
         )
         content = tmp_file.read()
     assert result.exit_code == 0, result.output
-    assert 'protocol = "http"' in content
+    assert content == os_agnostic_snapshot
 
 
 def test_new_connection_can_be_added_as_default(runner, os_agnostic_snapshot):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Closes [SNOW-2683101](https://snowflakecomputing.atlassian.net/browse/SNOW-2683101) / #2689 (follow-up to the closed #2154).

Adds a `--protocol` CLI flag (plus matching `SNOWFLAKE_PROTOCOL` environment variable and `protocol` key for `snow connection add`) to the global connection overrides. `snowflake-connector-python` already treats `protocol` as a first-class parameter and defaults it to `https`, but until now there was no way to override the value from the command line — users had to edit `config.toml`, which is awkward for ad-hoc local development against an `http` deployment.

The implementation mirrors the recently merged `--secondary-roles` change (#2942):

- `ProtocolOption` in `flags.py` with the standard `_connection_callback("protocol")` wiring.
- `protocol` entry added to `GLOBAL_CONNECTION_OPTIONS`, `ConnectionConfig`, `ConnectionContext`, `SUPPORTED_ENV_OVERRIDES`, and `snow connection add`.
- No change needed in `config_ng/sources.py` — `protocol` is already in `_ENV_CONFIG_KEYS`, so TOML/env parsing already round-trips.

No behaviour change for users who do not pass the flag: the connector keeps defaulting to `https`.

### Tests

- `test_new_connection_can_be_added_with_protocol` — end-to-end `snow connection add … --protocol http` writes `protocol = "http"` to the config file.
- `test_protocol_flag_is_forwarded_for_temporary_connection` — `--protocol http` on a temporary connection reaches `snowflake.connector.connect`.
- `test_protocol_is_read_from_env_for_temporary_connection` — `SNOWFLAKE_PROTOCOL=http` is picked up without the flag.
- Existing prompt/interactive tests updated because `protocol` is now part of the `snow connection add` prompt sequence (new position is after `port` and before `region`).
- Help-text snapshots regenerated to include the new `--protocol` row in every command's connection section.

[SNOW-2683101]: https://snowflakecomputing.atlassian.net/browse/SNOW-2683101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ