### PR TITLE
fix: wrap DCM project name in IDENTIFIER() for list/drop deployments

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 ## Fixes and improvements
 * Fixed `TooManyFilesError` during `snow streamlit deploy` when `main_file` is a descendant of a directory listed in `artifacts`.
 * Upgraded `snowflake-connector-python` from 4.5.0 to 4.6.0.
+* `snow dcm list-deployments` and `snow dcm drop-deployment` now wrap the project name in `IDENTIFIER(...)`, matching every other DCM subcommand. Fully-qualified and quoted project names are now handled consistently.
 
 
 # v3.19.0

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -152,7 +152,7 @@ class DCMProjectManager(SqlExecutionMixin):
             "Running DCM list-deployments manager operation (project_identifier=%s).",
             project_identifier,
         )
-        query = f"SHOW DEPLOYMENTS IN DCM PROJECT {project_identifier.identifier}"
+        query = f"SHOW DEPLOYMENTS IN DCM PROJECT {project_identifier.sql_identifier}"
         return self.execute_query(query=query)
 
     def drop_deployment(
@@ -169,7 +169,7 @@ class DCMProjectManager(SqlExecutionMixin):
             project_identifier,
             if_exists,
         )
-        query = f"ALTER DCM PROJECT {project_identifier.identifier} DROP DEPLOYMENT"
+        query = f"ALTER DCM PROJECT {project_identifier.sql_identifier} DROP DEPLOYMENT"
         if if_exists:
             query += " IF EXISTS"
         query += f' "{deployment_name}"'

--- a/tests/dcm/test_manager.py
+++ b/tests/dcm/test_manager.py
@@ -341,7 +341,7 @@ def test_list_deployments(mock_execute_query):
     mgr.list_deployments(project_identifier=TEST_PROJECT)
 
     mock_execute_query.assert_called_once_with(
-        query="SHOW DEPLOYMENTS IN DCM PROJECT my_project"
+        query="SHOW DEPLOYMENTS IN DCM PROJECT IDENTIFIER('my_project')"
     )
 
 
@@ -353,7 +353,7 @@ def test_drop_deployment(mock_execute_query, if_exists):
         project_identifier=TEST_PROJECT, deployment_name="v1", if_exists=if_exists
     )
 
-    expected_query = "ALTER DCM PROJECT my_project DROP DEPLOYMENT"
+    expected_query = "ALTER DCM PROJECT IDENTIFIER('my_project') DROP DEPLOYMENT"
     if if_exists:
         expected_query += " IF EXISTS"
     expected_query += ' "v1"'


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

`DCMProjectManager` emits SQL for 10 DCM subcommands, but the project-name identifier was being injected two different ways:

- 8 methods use `FQN.sql_identifier`, which wraps the name in `IDENTIFIER('<name>')`. This is the conventional pattern across the CLI (see `apps/manager.py`'s `ALTER WORKSPACE {workspace_fqn.sql_identifier}` call sites) and is the form used everywhere else in the DCM plugin: `EXECUTE DCM PROJECT IDENTIFIER('<name>') DEPLOY/ANALYZE/PLAN/PREVIEW/REFRESH/PURGE/TEST`, and `CREATE DCM PROJECT IDENTIFIER('<name>')`.
- 2 methods — `list_deployments` and `drop_deployment` — were still using the raw `FQN.identifier` property, emitting `SHOW DEPLOYMENTS IN DCM PROJECT <name>` and `ALTER DCM PROJECT <name> DROP DEPLOYMENT`.

That inconsistency meant these two subcommands did not normalize fully-qualified / case-sensitive project names through the same `IDENTIFIER(...)` path that the rest of the manager (and the account-level session) relies on, producing different behaviour for the same FQN depending on which `snow dcm` subcommand the user ran.

This PR makes both call sites use `project_identifier.sql_identifier`, matching the other 8 sites and the parser-supported form (`SHOW ... IN DCM PROJECT IDENTIFIER(:PROJ_NAME)`, `ALTER DCM PROJECT <id> DROP DEPLOYMENT`).

### Testing

* Updated the two affected unit tests in `tests/dcm/test_manager.py` to assert on the new `IDENTIFIER('my_project')` wrapping.
* Full DCM unit suite (`tests/dcm/`) passes locally — 295 tests, 46 snapshots.