### PR TITLE
Snowflake Apps: add forking support to snowflake-app entities

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -667,6 +667,17 @@ def snowflake_app_deploy(
     if build_only:
         return MessageResult("Build completed successfully.")
 
+    # ── Clear source after build if forking is disabled ──────────────
+    if entity.forking is False:
+        if use_workspace:
+            cli_console.step(
+                f"Clearing workspace source (forking disabled): {storage_fqn.identifier}"
+            )
+            manager.clear_workspace_subdirectory(storage_fqn, app_name)
+        else:
+            cli_console.step(f"Clearing code stage (forking disabled): @{storage_fqn}")
+            manager.clear_stage(storage_fqn)
+
     # ── Deploy phase ──────────────────────────────────────────────────
 
     comment_data = {"appId": app_name}
@@ -676,6 +687,10 @@ def snowflake_app_deploy(
         comment_data["appDescription"] = app_description
     if app_icon:
         comment_data["appIcon"] = app_icon
+    if entity.forking is True:
+        comment_data[
+            "appSource"
+        ] = f"{storage_fqn.database}.{storage_fqn.schema}.{storage_fqn.name}"
     app_comment = json.dumps(comment_data)
 
     eai_list = [build_eai] if build_eai else None
@@ -702,6 +717,10 @@ def snowflake_app_deploy(
                 manager.upgrade_app_service(
                     service_fqn=service_fqn,
                     version="LATEST",
+                )
+                manager.set_app_service_comment(
+                    service_fqn=service_fqn,
+                    comment=app_comment,
                 )
                 did_upgrade = True
             else:

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -122,7 +122,8 @@ def _generate_snowflake_yml(
                   - .git
                   - snowflake.log
 
-            query_warehouse: {warehouse}"""
+            query_warehouse: {warehouse}
+            forking: false"""
         + build_compute_pool_block
         + service_compute_pool_block
         + build_eai_block

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -965,6 +965,17 @@ class SnowflakeAppManager(SqlExecutionMixin):
             query += f"\nTO VERSION {version}"
         self.execute_query(query)
 
+    def set_app_service_comment(
+        self,
+        service_fqn: FQN,
+        comment: str,
+    ) -> None:
+        """Set or update the comment on an application service."""
+        escaped = comment.replace("'", "''")
+        self.execute_query(
+            f"ALTER APPLICATION SERVICE {service_fqn.identifier} SET COMMENT = '{escaped}'"
+        )
+
     def is_application_service(self, service_fqn: FQN) -> bool:
         """Return True when settings should use the ``app-service`` URL segment.
 

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -258,3 +258,8 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
     dev_roles: Optional[List[str]] = Field(
         title="Development roles for the app", default=None
     )
+
+    forking: Optional[bool] = Field(
+        title="Whether to allow forking of this app's source code",
+        default=None,
+    )

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -4384,3 +4384,297 @@ class TestDeployCommand:
 
         _, create_kwargs = mock_mgr.create_app_service.call_args
         assert create_kwargs["compute_pool"] == "YML_SVC_POOL"
+
+
+class TestDeployForking:
+    """Tests for the forking field behavior during deploy."""
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_forking_true_includes_source_in_comment(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """When forking=True, the 'source' field is included in the service comment."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = Mock(
+            database=None, schema_=None, encryption_type="SNOWFLAKE_SSE"
+        )
+        entity.code_stage.name = "MY_APP_CODE"
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = ""
+        entity.query_warehouse = "WH"
+        entity.build_image = None
+        entity.execute_as_caller = False
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        entity.forking = True
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.stage_exists.return_value = True
+        mock_mgr.artifact_repo_exists.return_value = True
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {"url": "my-app.snowflakecomputing.app", "is_upgrading": "false"},
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+
+        _, create_kwargs = mock_mgr.create_app_service.call_args
+        import json
+
+        comment = json.loads(create_kwargs["comment"])
+        assert "appSource" in comment
+        assert comment["appSource"] == "TEST_DB.TEST_SCHEMA.MY_APP_CODE"
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_forking_false_clears_stage_after_build(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """When forking=False, the code stage is cleared after build."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = Mock(
+            database=None, schema_=None, encryption_type="SNOWFLAKE_SSE"
+        )
+        entity.code_stage.name = "MY_APP_CODE"
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = ""
+        entity.query_warehouse = "WH"
+        entity.build_image = None
+        entity.execute_as_caller = False
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        entity.forking = False
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.stage_exists.return_value = True
+        mock_mgr.artifact_repo_exists.return_value = True
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {"url": "my-app.snowflakecomputing.app", "is_upgrading": "false"},
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+
+        # clear_stage should be called TWICE: once before upload (clearing old files)
+        # and once after build (forking disabled)
+        assert mock_mgr.clear_stage.call_count == 2
+        # The comment should NOT contain an "appSource" field
+        _, create_kwargs = mock_mgr.create_app_service.call_args
+        import json
+
+        comment = json.loads(create_kwargs["comment"])
+        assert "appSource" not in comment
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_forking_none_does_not_include_source(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """When forking=None (unset), no 'source' field and no stage clearing after build."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = Mock(
+            database=None, schema_=None, encryption_type="SNOWFLAKE_SSE"
+        )
+        entity.code_stage.name = "MY_APP_CODE"
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = ""
+        entity.query_warehouse = "WH"
+        entity.build_image = None
+        entity.execute_as_caller = False
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        entity.forking = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.stage_exists.return_value = True
+        mock_mgr.artifact_repo_exists.return_value = True
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {"url": "my-app.snowflakecomputing.app", "is_upgrading": "false"},
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+
+        # clear_stage called only once (during upload, not after build)
+        mock_mgr.clear_stage.assert_called_once()
+        # No source in comment
+        _, create_kwargs = mock_mgr.create_app_service.call_args
+        import json
+
+        comment = json.loads(create_kwargs["comment"])
+        assert "appSource" not in comment

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -560,3 +560,23 @@ class TestSubModels:
         assert meta.title is None
         assert meta.description is None
         assert meta.icon is None
+
+    def test_forking_defaults_to_none(self):
+        """Forking field defaults to None when not specified."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+        )
+        assert model.forking is None
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_forking_accepts_boolean(self, value):
+        """Forking field accepts explicit True and False."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            forking=value,
+        )
+        assert model.forking is value


### PR DESCRIPTION
Add a `forking` field to the snowflake-app entity model that controls source code accessibility after deploy. When `forking: true`, the code stage FQN is written to the service comment JSON as a "source" field so UIs can offer fork functionality. When `forking: false`, the code stage is cleared after build to prevent source access. Generated projects default to `forking: false`.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [ ] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
...
