### PR TITLE
Add `--preview` flag to `snow streamlit deploy` for personal-workspace deploys

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 * Added a `--secondary-roles` option (plus matching `SNOWFLAKE_SECONDARY_ROLES` env var and `secondary_roles` config key) to `snow connection add` and the global connection overrides. The value is forwarded to `snowflake-connector-python` and accepts `ALL` or `NONE`, so sessions can be pinned to the primary role without running an extra `USE SECONDARY ROLES` statement.
 * Added `--force` flag to `snow spcs service drop` to allow dropping services that contain block storage volumes.
+* Added `--preview` flag to `snow streamlit deploy`. Bundles local artifacts and uploads them to a per-entity subfolder under the user's default workspace live version (`snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live/<entity_id>/`), then creates the Streamlit at `user$.public.<name>` with `CREATE_CODE_STAGE = FALSE`. Incompatible with `--legacy` and `--prune`.
 
 ## Fixes and improvements
 * Fixed `SELECT *` output being corrupted when joined tables share column names. Duplicate column names are now disambiguated by appending a numeric suffix (e.g. `NAME`, `NAME_2`).

--- a/src/snowflake/cli/_plugins/streamlit/commands.py
+++ b/src/snowflake/cli/_plugins/streamlit/commands.py
@@ -44,7 +44,7 @@ from snowflake.cli.api.commands.utils import get_entity_for_operation
 from snowflake.cli.api.console.console import CliConsole
 from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.entities.utils import EntityActions
-from snowflake.cli.api.exceptions import NoProjectDefinitionError
+from snowflake.cli.api.exceptions import CliError, NoProjectDefinitionError
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.output.types import (
     CommandResult,
@@ -134,6 +134,19 @@ LegacyOption = typer.Option(
     is_flag=True,
 )
 
+PreviewOption = typer.Option(
+    False,
+    "--preview",
+    help=(
+        "Deploy the Streamlit as a personal preview in `user$.public.<name>` "
+        "sourced from your default workspace at "
+        "`snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live`. "
+        "Local artifacts are uploaded to a per-entity subfolder under that "
+        "workspace live version. Incompatible with `--legacy` and `--prune`."
+    ),
+    is_flag=True,
+)
+
 
 @app.command("deploy", requires_connection=True)
 @with_project_definition()
@@ -147,6 +160,7 @@ def streamlit_deploy(
     entity_id: str = entity_argument("streamlit"),
     open_: bool = OpenOption,
     legacy: bool = LegacyOption,
+    preview: bool = PreviewOption,
     **options,
 ) -> CommandResult:
     """
@@ -155,6 +169,14 @@ def streamlit_deploy(
     stage is used. If the specified stage does not exist, the command creates it. If multiple Streamlits are defined
     in snowflake.yml and no entity_id is provided then command will raise an error.
     """
+
+    if preview and legacy:
+        raise CliError("--preview is not compatible with --legacy.")
+    if preview and prune:
+        raise CliError(
+            "--prune is not supported with --preview because the workspace "
+            "live version is shared with other files."
+        )
 
     cli_context = get_cli_context()
     workspace_ctx = _get_current_workspace_context()
@@ -194,6 +216,7 @@ def streamlit_deploy(
         replace=replace,
         legacy=legacy,
         prune=prune,
+        preview=preview,
     )
 
     if open_:

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity.py
@@ -8,6 +8,9 @@ from snowflake.cli._plugins.nativeapp.artifacts import build_bundle
 from snowflake.cli._plugins.stage.manager import StageManager
 from snowflake.cli._plugins.streamlit.manager import StreamlitManager
 from snowflake.cli._plugins.streamlit.streamlit_entity_model import (
+    PREVIEW_DATABASE,
+    PREVIEW_SCHEMA,
+    PREVIEW_WORKSPACE_STAGE_URI,
     SPCS_RUNTIME_V2_NAME,
     StreamlitEntityModel,
 )
@@ -99,13 +102,22 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         prune: bool = False,
         bundle_map: Optional[BundleMap] = None,
         legacy: bool = False,
+        preview: bool = False,
         *args,
         **kwargs,
     ):
+        if preview and legacy:
+            raise CliError("--preview is not compatible with --legacy.")
+        if preview and prune:
+            raise CliError("--prune is not supported with --preview.")
+
         if (
             bundle_map is None
         ):  # TODO: maybe we could hold bundle map as a cached property?
             bundle_map = self.bundle()
+
+        if preview:
+            return self._deploy_preview(bundle_map=bundle_map, replace=replace)
 
         console = self._workspace_ctx.console
         console.step(f"Checking if object exists")
@@ -220,6 +232,50 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
 
         return query + ";"
 
+    def _preview_identifier(self) -> str:
+        """Personal-preview FQN as a bare identifier (no IDENTIFIER('...') wrap).
+
+        Wrapping in ``IDENTIFIER('...')`` interacts awkwardly with the ``$``
+        sigil in ``user$``, so we interpolate directly.
+        """
+        return f"{PREVIEW_DATABASE}.{PREVIEW_SCHEMA}.{self._entity_model.fqn.name}"
+
+    def get_preview_deploy_sql(self, replace: bool = False) -> str:
+        """Build the CREATE STREAMLIT statement for a personal-preview deploy.
+
+        ``MAIN_FILE`` is auto-prefixed with the entity_id so it points at the
+        per-entity workspace subfolder where artifacts were uploaded.
+        """
+        verb = "CREATE OR REPLACE STREAMLIT" if replace else "CREATE STREAMLIT"
+        main_file_with_prefix = f"{self.entity_id}/{self._entity_model.main_file}"
+
+        parts = [
+            f"{verb} {self._preview_identifier()}",
+            f"FROM '{PREVIEW_WORKSPACE_STAGE_URI}'",
+            f"MAIN_FILE = '{main_file_with_prefix}'",
+        ]
+
+        if self.model.imports:
+            parts.append(self.model.get_imports_sql())
+        if self.model.query_warehouse:
+            parts.append(f"QUERY_WAREHOUSE = {self.model.query_warehouse}")
+        if self.model.title:
+            parts.append(f"TITLE = '{self.model.title}'")
+        if self.model.comment:
+            parts.append(f"COMMENT = '{self.model.comment}'")
+        if self.model.external_access_integrations:
+            parts.append(self.model.get_external_access_integrations_sql())
+        if self.model.secrets:
+            parts.append(self.model.get_secrets_sql())
+
+        parts.append("CREATE_CODE_STAGE = FALSE")
+
+        if self._is_spcs_runtime_v2_mode():
+            parts.append(f"RUNTIME_NAME = '{self.model.runtime_name}'")
+            parts.append(f"COMPUTE_POOL = '{self.model.compute_pool}'")
+
+        return "\n".join(parts) + ";"
+
     def get_describe_sql(self) -> str:
         return f"DESCRIBE STREAMLIT {self._get_sql_identifier()};"
 
@@ -325,3 +381,89 @@ class StreamlitEntity(EntityBase[StreamlitEntityModel]):
         )
 
         StreamlitManager(connection=self._conn).grant_privileges(self.model)
+
+    def _preview_object_exists(self) -> bool:
+        """Existence check against the preview FQN (``user$.public.<name>``).
+
+        Cannot reuse ``_object_exists`` because that uses the yaml FQN.
+        """
+        sql = f"DESCRIBE STREAMLIT {self._preview_identifier()};"
+        try:
+            self._execute_query(sql, cursor_class=DictCursor)
+            return True
+        except ProgrammingError:
+            return False
+
+    def _get_preview_url(self) -> str:
+        # `user$` is a server-side alias resolved to `user$<current_user>`
+        # at SQL execution time. Snowsight URLs need the resolved name, so
+        # query CURRENT_USER() here and fall back to the literal `user$`
+        # if resolution fails (URL is informational; deploy already succeeded).
+        database = PREVIEW_DATABASE
+        try:
+            cursor = self._execute_query(
+                "SELECT 'USER$' || CURRENT_USER() AS personal_database"
+            )
+            row = cursor.fetchone()
+            # Empty CURRENT_USER() yields the literal 'USER$'; treat as unresolved.
+            if row and row[0] and not row[0].endswith("$"):
+                database = str(row[0])
+        except Exception:  # noqa: BLE001
+            log.warning(
+                "Could not resolve personal database; falling back to %r in URL.",
+                PREVIEW_DATABASE,
+                exc_info=True,
+            )
+
+        preview_fqn = FQN(
+            database=database,
+            schema=PREVIEW_SCHEMA,
+            name=self._entity_model.fqn.name,
+        ).using_connection(self._conn)
+        return make_snowsight_url(
+            self._conn, f"/#/streamlit-apps/{preview_fqn.url_identifier}"
+        )
+
+    def _deploy_preview(self, bundle_map: BundleMap, replace: bool = False) -> str:
+        console = self._workspace_ctx.console
+        preview_identifier = self._preview_identifier()
+
+        console.step(f"Checking if preview Streamlit {preview_identifier} exists")
+        if self._preview_object_exists() and not replace:
+            raise ClickException(
+                f"Preview Streamlit {preview_identifier} already exists. "
+                f"Use --replace to overwrite."
+            )
+
+        workspace_subfolder = f"{PREVIEW_WORKSPACE_STAGE_URI}/{self.entity_id}"
+        console.step(f"Uploading artifacts to {workspace_subfolder}")
+        sync_deploy_root_with_stage(
+            console=console,
+            deploy_root=bundle_map.deploy_root(),
+            bundle_map=bundle_map,
+            prune=False,  # workspace HEAD is shared; never prune unrelated files
+            recursive=True,
+            stage_path_parts=StageManager().stage_path_parts_from_str(
+                workspace_subfolder
+            ),
+            print_diff=True,
+            force_overwrite=True,
+        )
+
+        console.step(f"Creating preview Streamlit {preview_identifier}")
+        self._execute_query(self.get_preview_deploy_sql(replace=replace))
+
+        # `grants:` from snowflake.yml target the YAML FQN, not the preview
+        # FQN, so applying them here would either fail with "object does not
+        # exist" or silently grant on the wrong object. Preview deploys live
+        # in `user$.public.<name>`, which is private to the current user;
+        # users can apply grants manually if needed.
+        if self.model.grants:
+            console.warning(
+                "Skipping `grants:` in --preview mode. Preview deploys to "
+                f"{preview_identifier}, which is private to your user; apply "
+                "grants manually if needed."
+            )
+        else:
+            StreamlitManager(connection=self._conn).grant_privileges(self.model)
+        return self._get_preview_url()

--- a/src/snowflake/cli/_plugins/streamlit/streamlit_entity_model.py
+++ b/src/snowflake/cli/_plugins/streamlit/streamlit_entity_model.py
@@ -28,6 +28,11 @@ from snowflake.cli.api.project.schemas.updatable_model import DiscriminatorField
 # SPCS Runtime v2 constants
 SPCS_RUNTIME_V2_NAME = "SYSTEM$ST_CONTAINER_RUNTIME_PY3_11"
 
+# Personal-preview deploy constants (used by `snow streamlit deploy --preview`)
+PREVIEW_DATABASE = "user$"
+PREVIEW_SCHEMA = "public"
+PREVIEW_WORKSPACE_STAGE_URI = "snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live"
+
 
 class StreamlitEntityModel(
     EntityModelBaseWithArtifacts,

--- a/tests/streamlit/test_streamlit_commands.py
+++ b/tests/streamlit/test_streamlit_commands.py
@@ -556,3 +556,74 @@ class TestStreamlitCommands(StreamlitTestClass):
         assert mock_streamlit_ctx.get_queries() == [
             "EXECUTE STREAMLIT IDENTIFIER('test_streamlit')()"
         ]
+
+    # ---- Personal-preview deploy (`--preview`) ----
+
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._preview_object_exists",
+        return_value=False,
+    )
+    def test_deploy_preview_with_spcs_runtime(
+        self, _mock_preview_exists, project_directory, runner, alter_snowflake_yml
+    ):
+        """End-to-end: --preview emits the workspace-FROM SQL with SPCS runtime
+        clauses and uploads files to the per-entity workspace subfolder."""
+        with project_directory("example_streamlit_v2") as tmp_dir:
+            alter_snowflake_yml(
+                tmp_dir / "snowflake.yml",
+                parameter_path="entities.test_streamlit.runtime_name",
+                value="SYSTEM$ST_CONTAINER_RUNTIME_PY3_11",
+            )
+            alter_snowflake_yml(
+                tmp_dir / "snowflake.yml",
+                parameter_path="entities.test_streamlit.compute_pool",
+                value="MYPOOL",
+            )
+            result = runner.invoke(["streamlit", "deploy", "--preview", "--replace"])
+
+        expected_query = dedent(
+            """
+            CREATE OR REPLACE STREAMLIT user$.public.test_streamlit
+            FROM 'snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live'
+            MAIN_FILE = 'test_streamlit/streamlit_app.py'
+            QUERY_WAREHOUSE = test_warehouse
+            TITLE = 'My Fancy Streamlit'
+            CREATE_CODE_STAGE = FALSE
+            RUNTIME_NAME = 'SYSTEM$ST_CONTAINER_RUNTIME_PY3_11'
+            COMPUTE_POOL = 'MYPOOL';
+            """
+        ).strip()
+
+        assert result.exit_code == 0, result.output
+        self.mock_execute.assert_any_call(expected_query)
+
+        # No ADD LIVE VERSION should be issued for preview mode.
+        executed = [c.args[0] for c in self.mock_execute.call_args_list]
+        assert not any("ADD LIVE VERSION" in q for q in executed), executed
+
+        # Files must be uploaded under the per-entity workspace subfolder.
+        upload_destinations = [
+            call.kwargs.get("stage_path")
+            or (call.args[1] if len(call.args) > 1 else None)
+            for call in self.mock_put.call_args_list
+        ]
+        assert any(
+            d
+            and "snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live/test_streamlit"
+            in d
+            for d in upload_destinations
+        ), upload_destinations
+
+    def test_deploy_preview_with_prune_errors(self, project_directory, runner):
+        with project_directory("example_streamlit_v2"):
+            result = runner.invoke(["streamlit", "deploy", "--preview", "--prune"])
+
+        assert result.exit_code != 0, result.output
+        assert "--prune is not supported with --preview" in result.output
+
+    def test_deploy_preview_with_legacy_errors(self, project_directory, runner):
+        with project_directory("example_streamlit_v2"):
+            result = runner.invoke(["streamlit", "deploy", "--preview", "--legacy"])
+
+        assert result.exit_code != 0, result.output
+        assert "--preview is not compatible with --legacy" in result.output

--- a/tests/streamlit/test_streamlit_entity.py
+++ b/tests/streamlit/test_streamlit_entity.py
@@ -4,6 +4,9 @@ from unittest import mock
 import pytest
 from snowflake.cli._plugins.streamlit.streamlit_entity import StreamlitEntity
 from snowflake.cli._plugins.streamlit.streamlit_entity_model import (
+    PREVIEW_DATABASE,
+    PREVIEW_SCHEMA,
+    PREVIEW_WORKSPACE_STAGE_URI,
     SPCS_RUNTIME_V2_NAME,
     StreamlitEntityModel,
 )
@@ -531,5 +534,303 @@ class TestStreamlitEntity(StreamlitTestClass):
         # Verify warning was shown
         assert any(
             "Deployment style is changing from versioned to legacy" in str(call)
+            for call in workspace_context.console.warning.call_args_list
+        )
+
+    # ---- Personal-preview deploy (`--preview`) ----
+
+    def _build_preview_entity(
+        self,
+        workspace_context,
+        *,
+        entity_id: str = "streamlittestapp",
+        identifier_name: str = "testapp_vnext_private",
+        main_file: str = "streamlit_app.py",
+        query_warehouse: str = "REGRESS",
+        runtime_name: str | None = SPCS_RUNTIME_V2_NAME,
+        compute_pool: str | None = "MYPOOL",
+        title: str | None = None,
+        comment: str | None = None,
+    ) -> StreamlitEntity:
+        kwargs = {
+            "type": "streamlit",
+            "identifier": identifier_name,
+            "main_file": main_file,
+            "artifacts": [main_file],
+            "query_warehouse": query_warehouse,
+        }
+        if runtime_name is not None:
+            kwargs["runtime_name"] = runtime_name
+        if compute_pool is not None:
+            kwargs["compute_pool"] = compute_pool
+        if title is not None:
+            kwargs["title"] = title
+        if comment is not None:
+            kwargs["comment"] = comment
+        model = StreamlitEntityModel(**kwargs)
+        model.set_entity_id(entity_id)
+        return StreamlitEntity(workspace_ctx=workspace_context, entity_model=model)
+
+    def test_get_preview_deploy_sql_with_spcs_runtime(self, workspace_context):
+        """SPCS-runtime preview deploy must match the user's example SQL exactly."""
+        entity = self._build_preview_entity(workspace_context)
+
+        sql = entity.get_preview_deploy_sql(replace=True)
+
+        assert sql == (
+            "CREATE OR REPLACE STREAMLIT user$.public.testapp_vnext_private\n"
+            "FROM 'snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live'\n"
+            "MAIN_FILE = 'streamlittestapp/streamlit_app.py'\n"
+            "QUERY_WAREHOUSE = REGRESS\n"
+            "CREATE_CODE_STAGE = FALSE\n"
+            "RUNTIME_NAME = 'SYSTEM$ST_CONTAINER_RUNTIME_PY3_11'\n"
+            "COMPUTE_POOL = 'MYPOOL';"
+        )
+
+    def test_get_preview_deploy_sql_without_spcs_runtime(self, workspace_context):
+        """Warehouse-runtime preview omits SPCS clauses but keeps CREATE_CODE_STAGE = FALSE."""
+        entity = self._build_preview_entity(
+            workspace_context,
+            runtime_name=None,
+            compute_pool=None,
+        )
+
+        sql = entity.get_preview_deploy_sql(replace=True)
+
+        assert "RUNTIME_NAME" not in sql
+        assert "COMPUTE_POOL" not in sql
+        assert "CREATE_CODE_STAGE = FALSE" in sql
+        assert sql.startswith(
+            "CREATE OR REPLACE STREAMLIT user$.public.testapp_vnext_private"
+        )
+
+    def test_get_preview_deploy_sql_replace_false(self, workspace_context):
+        entity = self._build_preview_entity(workspace_context)
+        sql = entity.get_preview_deploy_sql(replace=False)
+        assert sql.startswith("CREATE STREAMLIT user$.public.testapp_vnext_private")
+        assert "CREATE OR REPLACE" not in sql
+
+    def test_get_preview_deploy_sql_main_file_prefix(self, workspace_context):
+        """MAIN_FILE is auto-prefixed with the entity_id regardless of yaml main_file."""
+        entity = self._build_preview_entity(
+            workspace_context,
+            entity_id="my_subdir",
+            main_file="nested/app.py",
+        )
+        sql = entity.get_preview_deploy_sql(replace=False)
+        assert "MAIN_FILE = 'my_subdir/nested/app.py'" in sql
+
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.sync_deploy_root_with_stage"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._preview_object_exists"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity.bundle"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._get_preview_url"
+    )
+    def test_deploy_with_preview_uploads_to_workspace_subfolder(
+        self,
+        mock_url,
+        mock_bundle,
+        mock_exists,
+        mock_sync,
+        workspace_context,
+        action_context,
+    ):
+        """sync_deploy_root_with_stage receives the per-entity workspace subfolder."""
+        mock_exists.return_value = False
+        mock_url.return_value = "https://snowflake.com/preview"
+        mock_bundle.return_value = BundleMap(
+            project_root=workspace_context.project_root,
+            deploy_root=workspace_context.project_root / "output",
+        )
+        entity = self._build_preview_entity(workspace_context)
+
+        entity.action_deploy(action_context, _open=False, replace=True, preview=True)
+
+        assert mock_sync.call_count == 1
+        kwargs = mock_sync.call_args.kwargs
+        # Stage-path-parts should be derived from
+        # snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live/streamlittestapp
+        assert "streamlittestapp" in kwargs["stage_path_parts"].full_path
+        assert PREVIEW_WORKSPACE_STAGE_URI in kwargs["stage_path_parts"].full_path
+        # Pruning is forced off because workspace HEAD is shared.
+        assert kwargs["prune"] is False
+
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.sync_deploy_root_with_stage"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._preview_object_exists"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity.bundle"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._get_preview_url"
+    )
+    def test_deploy_with_preview_does_not_call_add_live_version(
+        self,
+        mock_url,
+        mock_bundle,
+        mock_exists,
+        mock_sync,
+        workspace_context,
+        action_context,
+    ):
+        mock_exists.return_value = False
+        mock_url.return_value = "https://snowflake.com/preview"
+        mock_bundle.return_value = BundleMap(
+            project_root=workspace_context.project_root,
+            deploy_root=workspace_context.project_root / "output",
+        )
+        entity = self._build_preview_entity(workspace_context)
+
+        entity.action_deploy(action_context, _open=False, replace=True, preview=True)
+
+        executed_queries = [c.args[0] for c in self.mock_execute.call_args_list]
+        assert not any("ADD LIVE VERSION" in q for q in executed_queries), (
+            f"ADD LIVE VERSION should never be issued in preview mode. "
+            f"Queries: {executed_queries}"
+        )
+        # The preview CREATE STREAMLIT must be the executed query.
+        assert any(
+            q.startswith(
+                "CREATE OR REPLACE STREAMLIT user$.public.testapp_vnext_private"
+            )
+            for q in executed_queries
+        )
+
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.sync_deploy_root_with_stage"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._preview_object_exists"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity.bundle"
+    )
+    def test_deploy_with_preview_object_exists_no_replace_errors(
+        self,
+        mock_bundle,
+        mock_exists,
+        mock_sync,
+        workspace_context,
+        action_context,
+    ):
+        from click import ClickException
+
+        mock_exists.return_value = True
+        mock_bundle.return_value = BundleMap(
+            project_root=workspace_context.project_root,
+            deploy_root=workspace_context.project_root / "output",
+        )
+        entity = self._build_preview_entity(workspace_context)
+
+        with pytest.raises(ClickException, match="already exists"):
+            entity.action_deploy(
+                action_context, _open=False, replace=False, preview=True
+            )
+        # Upload must not have happened.
+        mock_sync.assert_not_called()
+
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity.bundle"
+    )
+    def test_deploy_with_preview_and_legacy_raises_error(
+        self, mock_bundle, workspace_context, action_context
+    ):
+        mock_bundle.return_value = BundleMap(
+            project_root=workspace_context.project_root,
+            deploy_root=workspace_context.project_root / "output",
+        )
+        entity = self._build_preview_entity(workspace_context)
+
+        with pytest.raises(CliError, match="--preview is not compatible with --legacy"):
+            entity.action_deploy(
+                action_context,
+                _open=False,
+                replace=True,
+                preview=True,
+                legacy=True,
+            )
+
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity.bundle"
+    )
+    def test_deploy_with_preview_and_prune_raises_error(
+        self, mock_bundle, workspace_context, action_context
+    ):
+        mock_bundle.return_value = BundleMap(
+            project_root=workspace_context.project_root,
+            deploy_root=workspace_context.project_root / "output",
+        )
+        entity = self._build_preview_entity(workspace_context)
+
+        with pytest.raises(CliError, match="--prune is not supported with --preview"):
+            entity.action_deploy(
+                action_context,
+                _open=False,
+                replace=True,
+                preview=True,
+                prune=True,
+            )
+
+    def test_preview_constants_match_user_example(self):
+        assert PREVIEW_DATABASE == "user$"
+        assert PREVIEW_SCHEMA == "public"
+        assert (
+            PREVIEW_WORKSPACE_STAGE_URI
+            == "snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live"
+        )
+
+    @mock.patch("snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitManager")
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.sync_deploy_root_with_stage"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._preview_object_exists",
+        return_value=False,
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity.bundle"
+    )
+    @mock.patch(
+        "snowflake.cli._plugins.streamlit.streamlit_entity.StreamlitEntity._get_preview_url",
+        return_value="https://snowflake.com/preview",
+    )
+    def test_deploy_with_preview_skips_grants_when_yaml_has_grants(
+        self,
+        _mock_url,
+        mock_bundle,
+        _mock_exists,
+        _mock_sync,
+        mock_streamlit_manager,
+        workspace_context,
+        action_context,
+    ):
+        """`grants:` from snowflake.yml target the YAML FQN, not the preview FQN.
+
+        Applying them in preview mode would either fail or silently grant on
+        the wrong object, so `_deploy_preview` must skip grants and warn.
+        """
+        mock_bundle.return_value = BundleMap(
+            project_root=workspace_context.project_root,
+            deploy_root=workspace_context.project_root / "output",
+        )
+        from snowflake.cli.api.project.schemas.entities.common import Grant
+
+        entity = self._build_preview_entity(workspace_context)
+        entity.model.grants = [Grant(privilege="USAGE", role="SOME_ROLE")]
+
+        entity.action_deploy(action_context, _open=False, replace=True, preview=True)
+
+        mock_streamlit_manager.return_value.grant_privileges.assert_not_called()
+        assert any(
+            "Skipping `grants:` in --preview mode" in str(call)
             for call in workspace_context.console.warning.call_args_list
         )


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

#### Context

Streamlit developers iterating on a SiS app today have to deploy to a real database and stage in their account every time they want to preview a change. That requires picking a target DB/schema, owning a stage, and (for SPCS apps) uploading artifacts to a per-app versioned stage and running `ALTER STREAMLIT … ADD LIVE VERSION FROM LAST`. For quick "is this change working?" iterations against the SPCS container runtime, that's heavier than it needs to be — and on accounts where the developer doesn't own a database it's outright blocking.

This PR adds a `--preview` flag to `snow streamlit deploy` that targets the user's personal database (`user$.public.<name>`) and sources the app from the user's **default workspace live version** (`snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live`). Local artifacts are still bundled from `snowflake.yml` and uploaded to a per-entity subfolder under the workspace; the streamlit object is created with `CREATE_CODE_STAGE = FALSE` and `FROM '<workspace_uri>'`. SPCS container runtime fields (`RUNTIME_NAME`, `COMPUTE_POOL`) are honored when present in `snowflake.yml`. No `ADD LIVE VERSION`, no separate stage to manage.

#### What this enables

- **One-flag personal preview** — `snow streamlit deploy --preview` deploys to `user$.public.<name>`, scoped to the current user. No need to choose or own a database.
- **Workspace live version as the source** — files go into a per-entity subfolder under `snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live/<entity_id>/`, and the streamlit reads from the workspace live URI (no `ALTER STREAMLIT … ADD LIVE VERSION` round-trip).
- **SPCS v2 runtime support** — when `runtime_name: SYSTEM$ST_CONTAINER_RUNTIME_PY3_11` and `compute_pool: …` are set in `snowflake.yml`, the emitted SQL includes the matching `RUNTIME_NAME` / `COMPUTE_POOL` clauses. Warehouse-runtime previews drop those clauses but still emit `CREATE_CODE_STAGE = FALSE`.
- **Snowsight URL with the resolved personal DB** — `user$` is a server-side alias resolved at SQL execution time; the CLI resolves it client-side via `SELECT 'USER$' || CURRENT_USER()` so the Snowsight URL points at `USER$<USERNAME>.PUBLIC.<NAME>` (not the literal `user%24`).
- **Safe defaults for the shared workspace** — the workspace live version is shared across an account user's preview deploys, so `--prune` is rejected up-front (it would prune unrelated files), and `force_overwrite=True` is scoped to the per-entity subfolder. `grants:` from `snowflake.yml` are skipped with a console warning because they target the YAML FQN, not the preview FQN — applying them in preview mode would either fail or silently grant on a different streamlit object.
- **Clean failure modes** — `--preview --legacy` and `--preview --prune` error out with `CliError` before any work happens. Re-deploying without `--replace` errors with a clear "already exists" message.

#### Sample emitted SQL

```sql
CREATE OR REPLACE STREAMLIT user$.public.testapp_vnext_private
FROM 'snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live'
MAIN_FILE = 'streamlittestapp/streamlit_app.py'
QUERY_WAREHOUSE = REGRESS
CREATE_CODE_STAGE = FALSE
RUNTIME_NAME = 'SYSTEM$ST_CONTAINER_RUNTIME_PY3_11'
COMPUTE_POOL = 'MYPOOL';
```

(Warehouse-runtime previews omit the `RUNTIME_NAME` / `COMPUTE_POOL` lines.)

#### How it works (user-facing flow)

1. The user runs `snow streamlit deploy --preview` (optionally with `--replace`) from a project with `snowflake.yml`.
2. The CLI fail-fasts on `--preview --legacy` and `--preview --prune` before any project work.
3. v1 → v2 conversion runs as usual.
4. Local artifacts are bundled from `snowflake.yml` (`bundle()`).
5. The CLI checks whether `user$.public.<name>` already exists via `DESCRIBE STREAMLIT`; without `--replace`, this aborts with `ClickException`.
6. Bundled artifacts are uploaded under `snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live/<entity_id>/`. `prune=False` and `force_overwrite=True` are forced to keep other workspace files untouched while still updating this preview's files.
7. `CREATE [OR REPLACE] STREAMLIT user$.public.<name> FROM '…/versions/live' …` is executed (with SPCS clauses if applicable).
8. `grants:` from `snowflake.yml` are skipped with a console warning if present.
9. The Snowsight URL is built using the resolved personal database name.

#### Flow diagram

```mermaid
flowchart TD
    A["snow streamlit deploy --preview [--replace]"] --> B{"--preview --legacy<br/>or --preview --prune?"}
    B -- Yes --> Z[CliError: incompatible flags]
    B -- No --> C[v1 to v2 conversion if needed]
    C --> D["bundle() local artifacts"]
    D --> E["DESCRIBE STREAMLIT user$.public.&lt;name&gt;"]
    E --> F{Exists & no --replace?}
    F -- Yes --> Y[ClickException: already exists]
    F -- No --> G["sync_deploy_root_with_stage<br/>to .../versions/live/&lt;entity_id&gt;/<br/>(prune=False, force_overwrite=True)"]
    G --> H{SPCS runtime in yaml?}
    H -- Yes --> I["CREATE STREAMLIT ... FROM workspace<br/>+ RUNTIME_NAME + COMPUTE_POOL<br/>+ CREATE_CODE_STAGE = FALSE"]
    H -- No --> J["CREATE STREAMLIT ... FROM workspace<br/>+ CREATE_CODE_STAGE = FALSE"]
    I --> K{Has grants in yaml?}
    J --> K
    K -- Yes --> L["console.warning:<br/>Skipping grants in --preview mode"]
    K -- No --> M["StreamlitManager.grant_privileges()"]
    L --> N["Resolve personal DB:<br/>SELECT 'USER$' || CURRENT_USER()"]
    M --> N
    N --> O["Snowsight URL:<br/>USER$<USER>.PUBLIC.<NAME>"]
```

#### Files added/modified

```
src/snowflake/cli/_plugins/streamlit/
    ├── commands.py                 # modified — `PreviewOption`, `--preview` flag, fail-fast on --legacy/--prune
    ├── streamlit_entity.py         # modified — preview branch in `deploy()`, `_deploy_preview`,
    │                               #   `get_preview_deploy_sql`, `_preview_object_exists`,
    │                               #   `_get_preview_url`, `_preview_identifier` helper
    └── streamlit_entity_model.py   # modified — `PREVIEW_DATABASE`, `PREVIEW_SCHEMA`,
                                    #   `PREVIEW_WORKSPACE_STAGE_URI` constants

tests/streamlit/
    ├── test_streamlit_commands.py  # modified — 3 CLI-level tests (SPCS runtime, --legacy/--prune errors)
    └── test_streamlit_entity.py    # modified — 11 unit tests (SQL builder shape, upload destination,
                                    #   skip-grants behavior, mutual-exclusion errors, no ADD LIVE VERSION)

RELEASE-NOTES.md                    # modified — bullet under "New additions"
```

No new files; preview is layered onto the existing `_deploy_legacy` / `_deploy_versioned` dispatch as a third sibling `_deploy_preview`.

#### Testing

- **102 streamlit unit + command tests pass** (`hatch run pytest tests/streamlit/`).
- **Manual MacOS verification** against `snowhouse_connection` end-to-end: `hatch run snow streamlit deploy --preview --replace --connection snowhouse_connection --project … --format json` deploys, files land at `snow://workspace/USER$.PUBLIC.DEFAULT$/versions/live/<entity_id>/`, the streamlit is created at `user$.public.<name>` with the SPCS runtime + compute pool clauses, and the returned URL correctly uses the resolved `USER$<USERNAME>.PUBLIC.<NAME>` identifier.

#### Out-of-scope follow-ups

- **`pyproject.toml` requirement for SPCSv2 apps** — the SiS container runtime requires a `pyproject.toml` for dependency installation, but the existing in-tree fixture (`tests_integration/test_data/projects/streamlit_spcs_v2/`) ships only `requirements.txt`. Affects both preview and non-preview SPCS deploys — worth a follow-up to auto-generate a minimal `pyproject.toml` from `requirements.txt` when `runtime_name` indicates SPCSv2.
- **`snow streamlit describe` / `drop` for preview-deployed apps** — both subcommands resolve via the YAML FQN, not `user$.public.<name>`. Out of scope here; worth a follow-up if real users hit it.

Made with [Cursor](https://cursor.com)