### PR TITLE
docs generator: extract shared option-list Jinja macro

### DIFF
--- a/src/snowflake/cli/_app/dev/docs/templates/_macros.mdx.jinja2
+++ b/src/snowflake/cli/_app/dev/docs/templates/_macros.mdx.jinja2
@@ -1,0 +1,23 @@
+{%- macro render_option_list(params, show_default=true) -%}
+<dl>
+{%- for param in params if not param.hidden %}
+{%- if param.is_flag %}
+<dt>`
+    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %}
+    {%- if param.secondary_opts|length > 0  %} {{ "/ " }}{{ param.secondary_opts[0] }}{% endif -%}
+`</dt>
+{%- elif param.type.name == "choice" %}
+<dt>`
+    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %} {{ param.make_metavar() }}`</dt>
+{%- else %}
+<dt><code className="samp">
+    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %} <em>{{ param.make_metavar() }}</em></code></dt>
+{%- endif %}
+<dd>
+
+{% if param.help %}{{ param.help | replace("\n", " ") }}{% if param.help[-1] != '.' %}.{% endif %}{% if show_default and param.default is not none and param.default != "" %} Default: {{ param.default }}.{% endif %}{% else %}TBD{% endif %}
+
+</dd>
+{%- endfor %}
+</dl>
+{%- endmacro -%}

--- a/src/snowflake/cli/_app/dev/docs/templates/overview.mdx.jinja2
+++ b/src/snowflake/cli/_app/dev/docs/templates/overview.mdx.jinja2
@@ -1,26 +1,7 @@
+{%- from "_macros.mdx.jinja2" import render_option_list -%}
 {{ help }}
 
 
 ## Global options
 
-<dl>
-{%- for param in options if not param.hidden %}
-{%- if param.is_flag %}
-<dt>`
-    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %}
-    {%- if param.secondary_opts|length > 0  %} {{ "/ " }}{{ param.secondary_opts[0] }}{% endif -%}
-`</dt>
-{%- elif param.type.name == "choice" %}
-<dt>`
-    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %} {{ param.make_metavar() }}`</dt>
-{%- else %}
-<dt><code className="samp">
-    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %} <em>{{ param.make_metavar() }}</em></code></dt>
-{%- endif %}
-<dd>
-
-{% if param.help %}{{ param.help | replace("\n", " ") }}{% if param.help[-1] != '.' %}.{% endif %}{% else %}TBD{% endif %}
-
-</dd>
-{%- endfor %}
-</dl>
+{{ render_option_list(options, show_default=false) }}

--- a/src/snowflake/cli/_app/dev/docs/templates/usage.mdx.jinja2
+++ b/src/snowflake/cli/_app/dev/docs/templates/usage.mdx.jinja2
@@ -1,3 +1,4 @@
+{%- from "_macros.mdx.jinja2" import render_option_list -%}
 {{ help | replace("\n", " ") }}
 
 ## Syntax
@@ -42,27 +43,7 @@ None
 
 {%- if options %}
 
-<dl>
-{%- for param in options if not param.hidden %}
-{%- if param.is_flag %}
-<dt>`
-    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %}
-    {%- if param.secondary_opts|length > 0  %} {{ "/ " }}{{ param.secondary_opts[0] }}{% endif -%}
-`</dt>
-{%- elif param.type.name == "choice" %}
-<dt>`
-    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %} {{ param.make_metavar() }}`</dt>
-{%- else %}
-<dt><code className="samp">
-    {%- for p in param.opts %}{{ p }}{{ ", " if not loop.last }}{% endfor %} <em>{{ param.make_metavar() }}</em></code></dt>
-{%- endif %}
-<dd>
-
-{% if param.help %}{{ param.help | replace("\n", " ") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default is not none and param.default != "" %} Default: {{ param.default }}.{% endif %}{% else %}TBD{% endif %}
-
-</dd>
-{%- endfor %}
-</dl>
+{{ render_option_list(options) }}
 {% else %}
 
 None


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.

### Changes description

Stacked on #3008 (base = `docs-generator-mdx`). Retarget to `main` after #3008 merges.

The three-branch `<dl>` block for rendering boolean flags, choice-typed options, and typed options was duplicated across `overview.mdx.jinja2` and the Options section of `usage.mdx.jinja2`, differing only in whether to append a "Default: …" sentence for typed options.

**Changes**
- New `src/snowflake/cli/_app/dev/docs/templates/_macros.mdx.jinja2` with a `render_option_list(params, show_default=true)` macro.
- `usage.mdx.jinja2` Options section and `overview.mdx.jinja2` Global-options section both call the macro.
- 38 lines of duplicated template removed; 4 lines of macro-import-and-call added.

**Why it's safe**
- Output is byte-identical to the `docs-generator-mdx` tip — the existing docs-generation snapshot test passes unchanged.
- Jinja `FileSystemLoader` is rooted at the templates directory (see `template_utils.py`), so the `{% from "_macros.mdx.jinja2" %}` import resolves the same way in both callers.

**Tests**
- `tests/test_docs_generation_output.py` — 4 passed, snapshot unchanged.

**Jira:** [SNOW-3521151](https://snowflakecomputing.atlassian.net/browse/SNOW-3521151)

[SNOW-3521151]: https://snowflakecomputing.atlassian.net/browse/SNOW-3521151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ