### PR TITLE
docs generator: render Required/Optional marker for command arguments

### DIFF
--- a/src/snowflake/cli/_app/dev/docs/templates/usage.mdx.jinja2
+++ b/src/snowflake/cli/_app/dev/docs/templates/usage.mdx.jinja2
@@ -29,6 +29,8 @@ snow {% for part in path %}{{ part }}{{ " " if not loop.last }}{% endfor %}
 </em></code></dt>
 <dd>
 
+*{{ "Required" if param.required else "Optional" }}*
+
 {% if param.help %}{{ param.help | replace("\n", " ") }}{% if param.help[-1] != '.' %}.{% endif %}{% if param.default %} Default: {{ param.default }}.{% endif %}{% else %}TBD{% endif %}
 
 </dd>

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -56,6 +56,8 @@
   <dt><code className="samp"><em>text</em></code></dt>
   <dd>
   
+  *Optional*
+  
   Prompt to be used to generate a completion. Cannot be combined with --file option.
   
   </dd>


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.

### Changes description

Stacked on #3013 (base = `docs-generator-mdx-dry-templates`), which is itself stacked on #3008. Retarget to `main` as each base merges.

The generated `Arguments` section previously stripped `[brackets]` from optional-arg metavars, which removed the only visual signal that an argument was optional. The project-definition template already uses an italic `*Required*` / `*Optional*` marker above each property's description; the hand-authored command-reference pages in `snowflake-prod-docs` follow the same pattern.

**Changes**
- `usage.mdx.jinja2` — each argument's `<dd>` gets a `*{{ "Required" if param.required else "Optional" }}*` line above the help text.
- Snapshot regenerated (`tests/__snapshots__/test_docs_generation_output.ambr`) — the only delta is two added lines for the `<text>` argument in `cortex complete`.

**Before → after** (argument block for `cortex complete`)
```diff
 <dt><code className="samp"><em>text</em></code></dt>
 <dd>

+*Optional*
+
 Prompt to be used to generate a completion. Cannot be combined with --file option.

 </dd>
```

**Tests**
- `tests/test_docs_generation_output.py` — 4 passed with regenerated snapshot.

**Jira:** [SNOW-3521151](https://snowflakecomputing.atlassian.net/browse/SNOW-3521151)

[SNOW-3521151]: https://snowflakecomputing.atlassian.net/browse/SNOW-3521151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ