### PR TITLE
Cherry picks to 3.17.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,17 @@
 ## Fixes and improvements
 
 
+# v3.17.1
+## Backward incompatibility
+
+## Deprecations
+
+## New additions
+
+## Fixes and improvements
+* Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
+
+
 # v3.17.0
 
 ## Deprecations

--- a/src/snowflake/cli/__about__.py
+++ b/src/snowflake/cli/__about__.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 from enum import Enum, unique
 
-VERSION = "3.17.0"
+VERSION = "3.17.1"
 
 
 def get_display_version() -> str:

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -91,7 +91,12 @@ SUPPORTED_ENV_OVERRIDES = [
 ]
 
 # mapping of found key -> key to set
-CONNECTION_KEY_ALIASES = {"private_key_path": "private_key_file"}
+CONNECTION_KEY_ALIASES = {
+    "private_key_path": "private_key_file",
+    # `private_key_file_pwd` is the name used by the snowflake-connector-python
+    # TOML config; we normalize it to the CLI-native `private_key_passphrase`.
+    "private_key_file_pwd": "private_key_passphrase",
+}
 
 
 class _BufferedMirrorStream(io.StringIO):
@@ -308,9 +313,13 @@ def _load_private_key(connection_parameters: Dict, private_key_var_name: str) ->
         private_key_pem = _load_pem_from_file(
             connection_parameters[private_key_var_name]
         )
-        private_key = _load_pem_to_der(private_key_pem)
+        private_key = _load_pem_to_der(
+            private_key_pem,
+            passphrase=connection_parameters.get("private_key_passphrase"),
+        )
         connection_parameters["private_key"] = private_key.value
         del connection_parameters[private_key_var_name]
+        connection_parameters.pop("private_key_passphrase", None)
     else:
         raise CliError(
             "Private Key authentication requires authenticator set to SNOWFLAKE_JWT"
@@ -324,9 +333,13 @@ def _load_private_key_from_parameters(
         private_key_pem = _load_pem_from_parameters(
             connection_parameters[private_key_var_name]
         )
-        private_key = _load_pem_to_der(private_key_pem)
+        private_key = _load_pem_to_der(
+            private_key_pem,
+            passphrase=connection_parameters.get("private_key_passphrase"),
+        )
         connection_parameters["private_key"] = private_key.value
         del connection_parameters[private_key_var_name]
+        connection_parameters.pop("private_key_passphrase", None)
     else:
         raise CliError(
             "Private Key authentication requires authenticator set to SNOWFLAKE_JWT"
@@ -363,8 +376,9 @@ def _load_pem_from_parameters(private_key_raw: str) -> SecretType:
 def _validate_passphrase(passphrase: SecretType) -> None:
     if passphrase.value is None:
         raise CliError(
-            "Encrypted private key, you must provide the "
-            "passphrase in the environment variable PRIVATE_KEY_PASSPHRASE."
+            "Encrypted private key, you must provide the passphrase via the "
+            "`private_key_file_pwd` key in your connection config or the "
+            "`PRIVATE_KEY_PASSPHRASE` environment variable."
         )
     if passphrase.value == "":
         raise CliError(
@@ -373,23 +387,30 @@ def _validate_passphrase(passphrase: SecretType) -> None:
         )
 
 
-def _load_pem_to_der(private_key_pem: SecretType) -> SecretType:
+def _load_pem_to_der(
+    private_key_pem: SecretType, passphrase: Optional[str] = None
+) -> SecretType:
     """
     Given a private key file path (in PEM format), decode key data into DER
-    format
+    format. The ``PRIVATE_KEY_PASSPHRASE`` env var takes precedence over the
+    ``passphrase`` argument (sourced from ``private_key_file_pwd`` /
+    ``private_key_passphrase`` in the connection config) so existing setups
+    keep working.
     """
-    private_key_passphrase = SecretType(os.getenv("PRIVATE_KEY_PASSPHRASE", None))
+    env_passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE")
+    resolved_passphrase = env_passphrase if env_passphrase is not None else passphrase
+    passphrase_secret = SecretType(resolved_passphrase)
 
     if private_key_pem.value.startswith(ENCRYPTED_PKCS8_PK_HEADER):
-        _validate_passphrase(private_key_passphrase)
+        _validate_passphrase(passphrase_secret)
     elif private_key_pem.value.startswith(UNENCRYPTED_PKCS8_PK_HEADER):
-        private_key_passphrase = SecretType(None)
+        passphrase_secret = SecretType(None)
     else:
         raise CliError(
             "Private key provided is not in PKCS#8 format. Please use correct format."
         )
 
-    return prepare_private_key(private_key_pem, private_key_passphrase)
+    return prepare_private_key(private_key_pem, passphrase_secret)
 
 
 def prepare_private_key(

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -445,7 +445,15 @@ def generate_jwt(
     if not connection_details.private_key_file:
         raise UsageError(msq_template.format("Private key file"))
 
-    passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE", None)
+    # `PRIVATE_KEY_PASSPHRASE` env var takes precedence over the config-sourced
+    # `private_key_passphrase` (populated from `private_key_file_pwd` or
+    # `private_key_passphrase` in connections.toml) for back-compat.
+    env_passphrase = os.getenv("PRIVATE_KEY_PASSPHRASE")
+    passphrase = (
+        env_passphrase
+        if env_passphrase is not None
+        else connection_details.private_key_passphrase
+    )
 
     def _decrypt(passphrase: str | None):
         return connector.auth.get_token_from_private_key(

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -96,6 +96,9 @@ FEATURE_FLAGS_SECTION_PATH = [CLI_SECTION, "features"]
 LEGACY_OAUTH_PKCE_KEY: Literal["oatuh_enable_pkce"] = "oatuh_enable_pkce"
 LEGACY_CONNECTION_SETTING_ALIASES: Final[dict[str, str]] = {
     LEGACY_OAUTH_PKCE_KEY: "oauth_enable_pkce",
+    # `private_key_file_pwd` is the name supported by snowflake-connector-python
+    # in connections.toml; normalize it to the CLI-native `private_key_passphrase`.
+    "private_key_file_pwd": "private_key_passphrase",
 }
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -914,6 +914,66 @@ def test_key_pair_authentication_from_config(
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
+@pytest.mark.parametrize(
+    "passphrase_key", ["private_key_file_pwd", "private_key_passphrase"]
+)
+@mock.patch("snowflake.connector.connect")
+def test_key_pair_authentication_passphrase_from_config(
+    mock_connector, mock_ctx, runner, passphrase_key
+):
+    """SNOW-3012806: encrypted private key files work when the passphrase is
+    stored in connections.toml (under `private_key_file_pwd` or
+    `private_key_passphrase`), without PRIVATE_KEY_PASSPHRASE set."""
+    ctx = mock_ctx()
+    mock_connector.return_value = ctx
+
+    passphrase = "from-config-pass"
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    encrypted_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(
+            passphrase.encode("utf-8")
+        ),
+    )
+    expected_der = serialization.load_pem_private_key(
+        encrypted_pem, passphrase.encode("utf-8"), default_backend()
+    ).private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    with NamedTemporaryFile("wb", suffix=".p8") as pk_file:
+        pk_file.write(encrypted_pem)
+        pk_file.flush()
+
+        connection_details = {
+            "account": "my_account",
+            "user": "jdoe",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": pk_file.name,
+            passphrase_key: passphrase,
+        }
+        data = tomlkit.dumps({"connections": {"jwt": connection_details}})
+
+        with NamedTemporaryFile("w+", suffix=".toml") as toml_file:
+            toml_file.write(data)
+            toml_file.flush()
+            result = runner.invoke_with_config_file(
+                toml_file.name,
+                ["object", "list", "warehouse", "-c", "jwt"],
+            )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_connector.call_args.kwargs
+    assert kwargs["private_key"] == expected_der
+    # Config passphrase and its alias must not leak into connector kwargs.
+    assert "private_key_file_pwd" not in kwargs
+    assert "private_key_passphrase" not in kwargs
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_key_pair_authentication_no_passphrase_error(
     mock_ctx, temporary_directory, runner
 ):
@@ -1492,6 +1552,89 @@ def test_generate_jwt_with_pass_phrase_from_env(
     assert result.output == "funny token\n"
     mocked_get_token.assert_called_once_with(
         user="FooBar", account="account1", privatekey_path=str(f), key_password="123"
+    )
+
+
+@pytest.mark.parametrize(
+    "passphrase_key", ["private_key_file_pwd", "private_key_passphrase"]
+)
+@mock.patch.dict(os.environ, {}, clear=True)
+@mock.patch(
+    "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
+)
+def test_generate_jwt_with_pass_phrase_from_config(
+    mocked_get_token, runner, named_temporary_file, passphrase_key
+):
+    """SNOW-3012806: generate-jwt reads the passphrase from
+    `private_key_file_pwd` (connector-python name) or `private_key_passphrase`
+    (CLI-native) in connections.toml when the env var is not set."""
+    mocked_get_token.return_value = "funny token"
+
+    with named_temporary_file() as f:
+        f.write_text("secret from file")
+        connection_details = {
+            "account": "account1",
+            "user": "FooBar",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": str(f),
+            passphrase_key: "from-config",
+        }
+        data = tomlkit.dumps({"connections": {"jwt": connection_details}})
+
+        with NamedTemporaryFile("w+", suffix="toml") as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            result = runner.invoke_with_config_file(
+                tmp_file.name,
+                ["connection", "generate-jwt", "-c", "jwt"],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "funny token\n"
+    mocked_get_token.assert_called_once_with(
+        user="FooBar",
+        account="account1",
+        privatekey_path=str(f),
+        key_password="from-config",
+    )
+
+
+@mock.patch.dict(os.environ, {"PRIVATE_KEY_PASSPHRASE": "from-env"}, clear=True)
+@mock.patch(
+    "snowflake.cli._plugins.connection.commands.connector.auth.get_token_from_private_key"
+)
+def test_generate_jwt_env_passphrase_takes_precedence_over_config(
+    mocked_get_token, runner, named_temporary_file
+):
+    """PRIVATE_KEY_PASSPHRASE continues to win over the config-sourced
+    passphrase so existing setups are not broken by SNOW-3012806."""
+    mocked_get_token.return_value = "funny token"
+
+    with named_temporary_file() as f:
+        f.write_text("secret from file")
+        connection_details = {
+            "account": "account1",
+            "user": "FooBar",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": str(f),
+            "private_key_file_pwd": "from-config",
+        }
+        data = tomlkit.dumps({"connections": {"jwt": connection_details}})
+
+        with NamedTemporaryFile("w+", suffix="toml") as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            result = runner.invoke_with_config_file(
+                tmp_file.name,
+                ["connection", "generate-jwt", "-c", "jwt"],
+            )
+
+    assert result.exit_code == 0, result.output
+    mocked_get_token.assert_called_once_with(
+        user="FooBar",
+        account="account1",
+        privatekey_path=str(f),
+        key_password="from-env",
     )
 
 

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -182,7 +182,7 @@ def test_private_key_loading_and_aliases(
         )
         if expected_private_key_file_value is not None:
             mock_load_pem_from_file.assert_called_with(expected_private_key_file_value)
-            mock_load_pem_to_der.assert_called_with(key)
+            mock_load_pem_to_der.assert_called_with(key, passphrase=None)
 
 
 @mock.patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Patch release 3.17.1 cherry-picking the fix for the 3.17.0 `private_key_passphrase` regression.

**Commits on this branch (to be rebase-merged, not squashed, to preserve cherry-pick history):**
- `Bump version to v3.17.1`
- `fix: support private_key_file_pwd in connections.toml (#2933)` — cherry-picked from #2933 (SNOW-3012806) as a single squashed commit
- `chore: [NOSNOW] update release notes for 3.17.1`

**What gets fixed**

Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` in the environment — the passphrase can now come from `private_key_file_pwd` or `private_key_passphrase` in `connections.toml` / `config.toml`. The env var still takes precedence when set.

This also fixes the 3.17.0 regression reported in #3012 where every key-pair command failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer` — the passphrase was being passed as `str` when the connector expects `bytes`.

### Related

- Fixes #3012 (regression report)
- Cherry-picks #2933 (original fix)
- Jira: SNOW-3012806 / SNOW-3520530

### Merge note

Please merge with **rebase**, not squash — squashing destroys the cherry-pick history (per the release process).