### PR TITLE
Snowflake Apps: Fix schema FQNs semantics in artifact repo lookup

### DIFF
--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -869,13 +869,14 @@ class SnowflakeAppManager(SqlExecutionMixin):
         """Return True if the artifact repository already exists."""
         from snowflake.cli.api.project.util import (
             identifier_to_show_like_pattern,
+            to_identifier,
             unquote_identifier,
         )
 
-        schema_fqn = FQN(database=None, schema=database, name=schema)
+        schema_identifier = f"{to_identifier(database)}.{to_identifier(schema)}"
         cursor = self.execute_query(
             f"SHOW ARTIFACT REPOSITORIES LIKE {identifier_to_show_like_pattern(repo_name)}"
-            f" IN SCHEMA {schema_fqn.sql_identifier}",
+            f" IN SCHEMA {schema_identifier}",
             cursor_class=DictCursor,
         )
         unqualified = unquote_identifier(repo_name).upper()

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1231,6 +1231,23 @@ class TestSnowflakeAppManager:
         assert "DB.SCHEMA" in query
 
     @patch(EXECUTE_QUERY)
+    def test_artifact_repo_exists_quotes_database_and_schema_independently(
+        self, mock_execute
+    ):
+        mock_cursor = Mock()
+        mock_cursor.__iter__ = Mock(return_value=iter([]))
+        mock_execute.return_value = mock_cursor
+
+        SnowflakeAppManager().artifact_repo_exists(
+            database="my db", schema='my "schema"', repo_name="MY_REPO"
+        )
+
+        query = mock_execute.call_args[0][0]
+        assert 'IN SCHEMA "my db"."my ""schema"""' in query
+        assert "IDENTIFIER(" not in query
+        assert mock_execute.call_args.kwargs["cursor_class"] is DictCursor
+
+    @patch(EXECUTE_QUERY)
     def test_create_artifact_repo(self, mock_execute):
         SnowflakeAppManager().create_artifact_repo(
             database="DB", schema="SCHEMA", repo_name="MY_REPO"


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- fix db/schema passed to `FQN` as schema/object in `artifact_repo_exists` (underlying generated SQL is the same)
- qualify the `IN SCHEMA` clause by quoting the database and schema separately
