### PR TITLE
chore: [SNOW-3012806] add v3.17.1 release notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,7 +23,17 @@
 
 ## Fixes and improvements
 * Fixed macOS arm64 installer incorrectly requiring Rosetta 2. The `Distribution.xml` package metadata now declares `hostArchitectures="arm64,x86_64"`, so the installer is recognized as native on Apple Silicon.
-* Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set.
+
+
+# v3.17.1
+## Backward incompatibility
+
+## Deprecations
+
+## New additions
+
+## Fixes and improvements
+* Encrypted private key files no longer require `PRIVATE_KEY_PASSPHRASE` to be set in the environment. The passphrase can now be read from `private_key_file_pwd` (the name used by `snowflake-connector-python`) or `private_key_passphrase` in `connections.toml` / `config.toml`. The `PRIVATE_KEY_PASSPHRASE` environment variable continues to take precedence when set. This also fixes a regression in 3.17.0 where commands using key-pair authentication with `private_key_passphrase` in `connections.toml` failed with `argument 'password': Cannot convert "<class 'str'>" instance to a buffer`.
 
 
 # v3.17.0


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

Mirrors the 3.17.1 release notes section from #3017 onto `main`, so the patch release is reflected in the authoritative release notes.

- Adds a new `# v3.17.1` section between `# Unreleased version` and `# v3.17.0`
- Moves the `private_key_file_pwd` bullet out of `# Unreleased version` (where PR #2933 had placed it) into the new v3.17.1 section
- Extends the bullet with the regression clause so users understand this also fixes #3012 (the `argument 'password': Cannot convert "<class 'str'>" instance to a buffer` error)

The macOS arm64 bullet under `# Unreleased version` is a pre-existing inconsistency (already shipped in v3.17.0) and is intentionally left alone — out of scope for this patch.

After this merges, #3017 will cherry-pick this commit in place of its current release-notes commit, so the same wording lands on both `main` and `release-v3.17.1`.

### Related

- Addresses review feedback on #3017
- Fixes #3012 (via #2933 cherry-pick in #3017)