### PR TITLE
fix: correct app_flow telemetry for all snow app code paths

### DIFF
--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -50,7 +50,6 @@ from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
     find_entity,
     force_project_definition_v2,
     native_app_only,
-    set_app_flow,
     with_app_flow_routing,
 )
 from snowflake.cli._plugins.nativeapp.version.commands import app as versions_app
@@ -89,13 +88,21 @@ app.add_typer(release_channels_app)
 
 @app.callback()
 def _app_group_callback() -> None:
-    """Default the telemetry ``app_flow`` to ``snowflake_app`` for every
-    ``snow app *`` invocation so new commands are correctly attributed by
-    default. Native-App routing decorators (``with_app_flow_routing``,
-    ``force_project_definition_v2``, ``native_app_only``) override this
-    when they detect or assert a Native App project.
+    """Typer group callback for ``snow app *``.
+
+    Previously this set ``app_flow = snowflake_app`` as a blanket default.
+    That caused incorrect telemetry: the ``executing_command`` event (emitted
+    before the command body runs) reported ``app_flow = snowflake_app`` even
+    for native-app projects. The routing decorators (``with_app_flow_routing``,
+    ``native_app_only``) set the correct value inside the command callable,
+    which is after ``executing_command`` fires but before
+    ``result_executing_command``.
+
+    We no longer set a default here. The ``app_flow`` field will be absent on
+    ``executing_command`` events (matching the documented contract in
+    telemetry.py) and present with the correct value on result/error events.
     """
-    set_app_flow(AppFlow.SNOWFLAKE_APP)
+    pass
 
 
 log = logging.getLogger(__name__)

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -50,6 +50,7 @@ from snowflake.cli._plugins.nativeapp.v2_conversions.compat import (
     find_entity,
     force_project_definition_v2,
     native_app_only,
+    set_app_flow,
     with_app_flow_routing,
 )
 from snowflake.cli._plugins.nativeapp.version.commands import app as versions_app
@@ -183,6 +184,7 @@ def app_setup(
     ``snowflake-app`` entity preconfigured from account parameters and the
     current connection. This command does not apply to Native App projects.
     """
+    set_app_flow(AppFlow.SNOWFLAKE_APP)
     return snowflake_app_setup(app_name, dry_run, compute_pool, build_eai)
 
 

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -407,16 +407,118 @@ def test_app_flow_native_app_in_telemetry_data(mock_conn, project_directory, run
     with project_directory("napp_post_deploy_missing_file"):
         runner.invoke(["app", "run"], catch_exceptions=False)
 
-    error_command_event = (
-        mock_conn.return_value._telemetry.try_add_log_to_batch.call_args_list[  # noqa: SLF001
-            1
-        ]
-        .args[0]
-        .to_dict()
-    )
+    events = _get_telemetry_events(mock_conn)
+    _assert_executing_event_has_no_app_flow(events)
+    _assert_result_or_error_event_has_app_flow(events, "native_app")
 
-    assert error_command_event["message"]["type"] == "error_executing_command"
-    assert error_command_event["message"]["app_flow"] == "native_app"
+
+# ── Comprehensive app_flow telemetry attribution tests ─────────────────
+
+
+def _get_telemetry_events(mock_conn):
+    """Extract all telemetry event dicts from the mock connector."""
+    telemetry = mock_conn.return_value._telemetry  # noqa: SLF001
+    return [
+        call.args[0].to_dict() for call in telemetry.try_add_log_to_batch.call_args_list
+    ]
+
+
+def _assert_executing_event_has_no_app_flow(events):
+    """The executing_command event fires before routing decorators run,
+    so app_flow must be absent (matching the contract in telemetry.py)."""
+    executing = [e for e in events if e["message"]["type"] == "executing_command"]
+    assert executing, "Expected at least one executing_command event"
+    for event in executing:
+        assert (
+            "app_flow" not in event["message"]
+        ), f"executing_command must not contain app_flow, got: {event['message']}"
+
+
+def _assert_result_or_error_event_has_app_flow(events, expected_flow):
+    """The result or error event (whichever fires) must contain the
+    expected app_flow value."""
+    post_events = [
+        e
+        for e in events
+        if e["message"]["type"]
+        in ("result_executing_command", "error_executing_command")
+    ]
+    assert post_events, "Expected a result or error telemetry event"
+    for event in post_events:
+        assert event["message"].get("app_flow") == expected_flow, (
+            f"Expected app_flow={expected_flow!r} on {event['message']['type']}, "
+            f"got: {event['message'].get('app_flow')!r}"
+        )
+
+
+class TestAppFlowTelemetryAttribution:
+    """Verify that all snow app code paths stamp the correct app_flow on
+    result/error telemetry events, and that the executing_command event
+    never contains app_flow (since routing resolves after pre_execute)."""
+
+    @mock.patch("snowflake.connector.connect")
+    def test_native_app_bundle(self, mock_conn, project_directory, runner):
+        """with_app_flow_routing detects native_app from v1 project."""
+        with project_directory("napp_post_deploy_missing_file"):
+            runner.invoke(["app", "bundle"], catch_exceptions=False)
+
+        events = _get_telemetry_events(mock_conn)
+        _assert_executing_event_has_no_app_flow(events)
+        _assert_result_or_error_event_has_app_flow(events, "native_app")
+
+    @mock.patch("snowflake.connector.connect")
+    def test_snowflake_app_bundle(self, mock_conn, project_directory, runner):
+        """with_app_flow_routing detects snowflake_app from entity type."""
+        with project_directory("snowflake_app_v2"):
+            runner.invoke(["app", "bundle"], catch_exceptions=False)
+
+        events = _get_telemetry_events(mock_conn)
+        _assert_executing_event_has_no_app_flow(events)
+        _assert_result_or_error_event_has_app_flow(events, "snowflake_app")
+
+    @mock.patch("snowflake.connector.connect")
+    def test_snowflake_app_deploy(self, mock_conn, project_directory, runner):
+        """with_app_flow_routing detects snowflake_app for deploy.
+        The command will fail trying to execute SQL (the mock connector
+        returns no cursor results), but the error event still carries
+        app_flow because routing resolves before the SQL call."""
+        with project_directory("snowflake_app_v2"):
+            try:
+                runner.invoke(["app", "deploy"], catch_exceptions=False)
+            except ValueError:
+                pass  # execute_string returns empty iterator with mocked connector
+
+        events = _get_telemetry_events(mock_conn)
+        _assert_executing_event_has_no_app_flow(events)
+        _assert_result_or_error_event_has_app_flow(events, "snowflake_app")
+
+    @mock.patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @mock.patch("snowflake.connector.connect")
+    def test_snowflake_app_setup(self, mock_conn, mock_manager, runner):
+        """setup is Snowflake-Apps-only; must stamp snowflake_app directly."""
+        mock_mgr = mock_manager.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {}
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.get_personal_database.return_value = None
+
+        runner.invoke(
+            ["app", "setup", "--app-name", "test_app", "--dry-run"],
+            catch_exceptions=False,
+        )
+
+        events = _get_telemetry_events(mock_conn)
+        _assert_executing_event_has_no_app_flow(events)
+        _assert_result_or_error_event_has_app_flow(events, "snowflake_app")
+
+    @mock.patch("snowflake.connector.connect")
+    def test_native_app_deploy(self, mock_conn, project_directory, runner):
+        """with_app_flow_routing detects native_app for deploy."""
+        with project_directory("napp_post_deploy_missing_file"):
+            runner.invoke(["app", "deploy"], catch_exceptions=False)
+
+        events = _get_telemetry_events(mock_conn)
+        _assert_executing_event_has_no_app_flow(events)
+        _assert_result_or_error_event_has_app_flow(events, "native_app")
 
 
 @mock.patch("snowflake.connector.connect")

--- a/tests/test_data/projects/snowflake_app_v2/snowflake.yml
+++ b/tests/test_data/projects/snowflake_app_v2/snowflake.yml
@@ -1,0 +1,8 @@
+definition_version: '2'
+entities:
+  my_app:
+    type: snowflake-app
+    identifier: my_app
+    artifacts:
+      - src: "*"
+        dest: ./


### PR DESCRIPTION
The _app_group_callback set app_flow='snowflake_app' before the command body runs, causing the executing_command telemetry event to report an incorrect app_flow for native-app projects. The result_executing_command event was correct because routing decorators (with_app_flow_routing, native_app_only) set the real value inside the command callable.

This PR:

1. Removes the premature default from _app_group_callback (aligning with the documented contract in telemetry.py lines 94-99: app_flow should NOT appear on executing_command because the routing decorators haven't resolved it yet).

2. Adds explicit `set_app_flow(AppFlow.SNOWFLAKE_APP)` to `snow app setup`, which is Snowflake-Apps-only but has no routing decorator.

3. Adds `TestAppFlowTelemetryAttribution`, a comprehensive test class that verifies all major routing paths stamp the correct app_flow on result/error events while keeping it absent from executing_command events.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- Remove premature app_flow default from _app_group_callback
- Add set_app_flow(AppFlow.SNOWFLAKE_APP) to snow app setup command
- Add TestAppFlowTelemetryAttribution test class covering native_app and snowflake_app paths