### PR TITLE
chore: auto-resolve RELEASE-NOTES.md conflicts with merge=union + dup check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
 # Ensure snapshot files are treated as text with LF line endings and UTF-8 encoding
 *.ambr text eol=lf
+
+# Auto-resolve the common RELEASE-NOTES.md conflict where two PRs each append
+# a bullet under the same section. The check-release-notes-duplicates
+# pre-commit hook catches the one case this hides: a bullet ending up in
+# both "Unreleased version" and a released "# vX.Y.Z" section after a
+# release cut.
+RELEASE-NOTES.md merge=union

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
       - id: check-release-notes-duplicates
         name: "Check RELEASE-NOTES.md for duplicated bullets"
         language: system
-        entry: python scripts/check_release_notes_duplicates.py
+        entry: python3 scripts/check_release_notes_duplicates.py
         pass_filenames: false
         files: ^RELEASE-NOTES\.md$
   - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,12 @@ repos:
           ^import requirements.*
         pass_filenames: true
         exclude: ^src/snowflake/cli/_plugins/snowpark/models.py$
+      - id: check-release-notes-duplicates
+        name: "Check RELEASE-NOTES.md for duplicated bullets"
+        language: system
+        entry: python scripts/check_release_notes_duplicates.py
+        pass_filenames: false
+        files: ^RELEASE-NOTES\.md$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,6 @@ Please keep in mind that you need these python versions available in your `$PATH
 
 Every user-visible change should get one line in `RELEASE-NOTES.md` under `# Unreleased version`, in the appropriate subsection (`## Backward incompatibility`, `## Deprecations`, `## New additions`, or `## Fixes and improvements`).
 
-Conflicts between PRs that each append a bullet are resolved automatically by the `merge=union` attribute in `.gitattributes` — no manual resolution needed.
-
-The one case the auto-merge cannot handle is a **release cut overlap**: if your branch added bullets under "Unreleased version" and `main` has since moved those bullets into a new `# vX.Y.Z` section, merging `main` can leave the same bullet in both sections. The `check-release-notes-duplicates` pre-commit hook flags this; fix it by removing the duplicated bullet from "Unreleased version" (it's already documented under the released version).
-
 ## Unit tests
 
 Unit tests are executed in random order. If tests fail after your change, you can re-execute them in the same order using `pytest --randomly-seed=<number>`, where number is a seed printed at the beginning of the test execution output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,14 @@ hatch env show
 
 Please keep in mind that you need these python versions available in your `$PATH`. You can install them using `hatch` or other tool like [pyenv](https://github.com/pyenv/pyenv)
 
+## Release notes
+
+Every user-visible change should get one line in `RELEASE-NOTES.md` under `# Unreleased version`, in the appropriate subsection (`## Backward incompatibility`, `## Deprecations`, `## New additions`, or `## Fixes and improvements`).
+
+Conflicts between PRs that each append a bullet are resolved automatically by the `merge=union` attribute in `.gitattributes` — no manual resolution needed.
+
+The one case the auto-merge cannot handle is a **release cut overlap**: if your branch added bullets under "Unreleased version" and `main` has since moved those bullets into a new `# vX.Y.Z` section, merging `main` can leave the same bullet in both sections. The `check-release-notes-duplicates` pre-commit hook flags this; fix it by removing the duplicated bullet from "Unreleased version" (it's already documented under the released version).
+
 ## Unit tests
 
 Unit tests are executed in random order. If tests fail after your change, you can re-execute them in the same order using `pytest --randomly-seed=<number>`, where number is a seed printed at the beginning of the test execution output.

--- a/scripts/check_release_notes_duplicates.py
+++ b/scripts/check_release_notes_duplicates.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fail if RELEASE-NOTES.md has a bullet duplicated across sections.
+
+Companion to the `RELEASE-NOTES.md merge=union` git attribute. Union merge
+auto-resolves the "two PRs each append a bullet" conflict but silently keeps
+both copies of a bullet that the release cut has already moved from
+"Unreleased version" into a `# vX.Y.Z` section. This script flags that case
+so the author removes the already-released bullet from Unreleased.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RELEASE_NOTES = REPO_ROOT / "RELEASE-NOTES.md"
+
+_TOP_HEADER_RE = re.compile(r"^#\s+(.+?)\s*$")
+_BULLET_RE = re.compile(r"^\s*[*-]\s+(.*?)\s*$")
+_UNRELEASED_SECTION = "Unreleased version"
+_RELEASED_SECTION_RE = re.compile(r"^v\d+\.\d+\.\d+")
+
+
+def _normalize(text: str) -> str:
+    """Collapse whitespace so formatting tweaks don't split identical bullets."""
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def _iter_bullets(lines: Iterable[str]) -> Iterable[tuple[str, str, int]]:
+    """Yield (section_title, normalized_bullet_text, line_number) tuples.
+
+    Only lines under a `# ...` header are assigned to a section. Lines inside
+    the license comment at the top of the file land under section "" and are
+    skipped by the caller.
+    """
+    current_section = ""
+    for lineno, raw in enumerate(lines, start=1):
+        header = _TOP_HEADER_RE.match(raw)
+        if header:
+            current_section = header.group(1).strip()
+            continue
+        bullet = _BULLET_RE.match(raw)
+        if bullet and current_section:
+            yield current_section, _normalize(bullet.group(1)), lineno
+
+
+def find_duplicates(path: Path) -> list[str]:
+    """Return human-readable error messages, or an empty list if clean."""
+    text = path.read_text(encoding="utf-8").splitlines()
+    # bullet_text -> list of (section, lineno)
+    occurrences: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    for section, bullet, lineno in _iter_bullets(text):
+        occurrences[bullet].append((section, lineno))
+
+    errors: list[str] = []
+    for bullet, places in occurrences.items():
+        in_unreleased = [p for p in places if p[0] == _UNRELEASED_SECTION]
+        in_released = [p for p in places if _RELEASED_SECTION_RE.match(p[0])]
+
+        if len(in_unreleased) > 1:
+            lines = ", ".join(f"line {ln}" for _, ln in in_unreleased)
+            errors.append(
+                f"Bullet appears multiple times in '{_UNRELEASED_SECTION}' "
+                f"({lines}): {bullet!r}"
+            )
+        if in_unreleased and in_released:
+            released_names = ", ".join(sorted({s for s, _ in in_released}))
+            unreleased_lines = ", ".join(f"line {ln}" for _, ln in in_unreleased)
+            errors.append(
+                f"Bullet appears in both '{_UNRELEASED_SECTION}' "
+                f"({unreleased_lines}) and released section(s) "
+                f"[{released_names}]: {bullet!r}"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    path = Path(argv[0]) if argv else RELEASE_NOTES
+    if not path.exists():
+        print(f"RELEASE-NOTES.md not found at {path}", file=sys.stderr)
+        return 1
+    errors = find_duplicates(path)
+    if errors:
+        print(
+            "Duplicate bullets found in RELEASE-NOTES.md.\n"
+            "After a release cut, the `merge=union` driver can leave bullets "
+            "in both 'Unreleased version' and the new released section.\n"
+            "Remove the bullet from 'Unreleased version' — it's already "
+            "documented under the released version.\n",
+            file=sys.stderr,
+        )
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_release_notes_duplicates.py
+++ b/tests/test_check_release_notes_duplicates.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2024 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_release_notes_duplicates.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_release_notes_duplicates", _SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_script_module()
+
+
+@pytest.fixture
+def notes_file(tmp_path: Path):
+    def _write(body: str) -> Path:
+        path = tmp_path / "RELEASE-NOTES.md"
+        path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+        return path
+
+    return _write
+
+
+def test_clean_notes_have_no_duplicates(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * Fixed something new.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed something else.
+        """
+    )
+    assert check.find_duplicates(path) == []
+
+
+def test_bullet_duplicated_across_sections_is_flagged(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * Fixed the leaky connection pool.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed the leaky connection pool.
+        """
+    )
+    errors = check.find_duplicates(path)
+    assert len(errors) == 1
+    assert "Unreleased version" in errors[0]
+    assert "v3.17.0" in errors[0]
+    assert "leaky connection pool" in errors[0]
+
+
+def test_bullet_duplicated_inside_unreleased_is_flagged(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * Fixed broken thing.
+        * Fixed broken thing.
+        """
+    )
+    errors = check.find_duplicates(path)
+    assert len(errors) == 1
+    assert "multiple times" in errors[0]
+    assert "Unreleased version" in errors[0]
+
+
+def test_near_duplicates_are_not_flagged(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * Fixed the issue with connections.
+        * Fixed the issue with authentication.
+        """
+    )
+    assert check.find_duplicates(path) == []
+
+
+def test_whitespace_differences_are_treated_as_duplicates(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        *   Fixed   something    weird.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed something weird.
+        """
+    )
+    errors = check.find_duplicates(path)
+    assert len(errors) == 1
+    assert "Unreleased version" in errors[0]
+
+
+def test_main_returns_zero_on_clean_file(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * One bullet.
+        """
+    )
+    assert check.main([str(path)]) == 0
+
+
+def test_main_returns_one_on_dirty_file(notes_file, capsys):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * Duplicate bullet.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Duplicate bullet.
+        """
+    )
+    rc = check.main([str(path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Duplicate bullet" in err


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.

### Changes description

Contributors keep hitting merge conflicts on `RELEASE-NOTES.md` — almost always because two PRs each appended a bullet under the same section. This PR does two things that together auto-resolve that class of conflict without changing the contributor workflow.

**1. `RELEASE-NOTES.md merge=union` in `.gitattributes`**

Git's built-in union merge driver concatenates both sides' additions instead of producing a conflict. Works for local `git merge` / `git rebase` / `git pull` and for GitHub's "Merge pull request" button. Takes effect on any merge that runs after the attribute is checked out on the merging branch — so in-flight PRs get the benefit on their next `git merge origin/main` and beyond.

**2. `check-release-notes-duplicates` pre-commit hook**

Union merge has one silent failure mode: when a release cut moves bullets from "Unreleased version" into a new `# vX.Y.Z` section, an open PR that still has those bullets under Unreleased will end up with the same bullet in two sections after merging main. Union merge will not flag it.

The new stdlib-only script (`scripts/check_release_notes_duplicates.py`) parses `RELEASE-NOTES.md`, extracts bullets per section, and fails if any normalized bullet text appears in both "Unreleased version" and a released section, or is duplicated within Unreleased. It runs as a local pre-commit hook scoped to `RELEASE-NOTES.md`, so it only fires when that file is in the changeset.

The existing `lint.yaml` workflow already runs `pre-commit run --all-files`, so no CI config change is needed — the new hook runs in PR CI automatically.

**Why not towncrier / custom merge driver**

- Towncrier (fragment files like pytest/pip use) is the idiomatic long-term answer but changes every contributor's PR flow; worth a separate discussion.
- A custom merge driver would handle the release-cut case but only runs where installed client-side, and GitHub's support for custom drivers on the web merge is spotty.
- `merge=union` + a small CI trip-wire is ~60 lines total, keeps the "just edit RELEASE-NOTES.md" workflow, and closes the main conflict problem ~99%.

**Release notes**

Skipping a release-notes bullet intentionally: this change is dev-infra only with no user-visible behavior change.

### Files changed

- `.gitattributes` — one line enabling union merge for RELEASE-NOTES.md
- `scripts/check_release_notes_duplicates.py` — new stdlib-only detection script
- `.pre-commit-config.yaml` — registers the new hook in the existing `- repo: local` block
- `tests/test_check_release_notes_duplicates.py` — 7 unit tests
- `CONTRIBUTING.md` — new "Release notes" section explaining the workflow and the one edge case

### Testing

- `python scripts/check_release_notes_duplicates.py` against the current file exits 0.
- `hatch run test tests/test_check_release_notes_duplicates.py` — 7/7 pass.
- `pre-commit run check-release-notes-duplicates --files RELEASE-NOTES.md` passes.
- Manually verified the three error cases (cross-section duplicate, within-Unreleased duplicate, whitespace-normalized duplicate) all produce exit 1 with the offending bullet named.