### PR TITLE
Snowflake Apps: Use workspace last alias for Snowflake Apps builds

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -618,29 +618,9 @@ def snowflake_app_deploy(
                 build_eai=build_eai,
             )
             if use_workspace:
-                # NOTE: We intentionally do not use ``.../versions/last/...`` here.
-                # Due to a current SPCS_TEST_BUILD_APP_ARTIFACT_REPO issue, that
-                # alias path can fail. Resolve the workspace default version URI
-                # from ``DESCRIBE WORKSPACE`` and pass that exact version location.
-                workspace_build_source_uri = (
-                    manager.get_default_workspace_version_subdirectory_uri(
-                        storage_fqn, app_name
-                    )
+                build_kwargs["source_uri"] = manager.workspace_last_subdirectory_uri(
+                    storage_fqn, app_name
                 )
-                workspace_build_source_uri_str = str(workspace_build_source_uri)
-                version_match = re.search(
-                    r"/versions/([^/]+)/", workspace_build_source_uri_str
-                )
-                if not version_match:
-                    raise CliError(
-                        "Could not parse workspace version from default version URI "
-                        f"(unexpected format): {workspace_build_source_uri_str!r}"
-                    )
-                workspace_version = version_match.group(1)
-                cli_console.step(
-                    f"Using workspace version for build: {workspace_version}"
-                )
-                build_kwargs["source_uri"] = workspace_build_source_uri
             else:
                 build_kwargs["stage_fqn"] = storage_fqn
             build_result = manager.build_app_artifact_repo(**build_kwargs)

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -624,45 +624,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
         normalized_directory = directory_name.strip("/")
         return f"{self.workspace_last_uri(workspace_fqn)}/{normalized_directory}"
 
-    def get_default_workspace_version_uri(self, workspace_fqn: FQN) -> str:
-        """Return URI for the workspace default version."""
-        cursor = self.execute_query(
-            f"DESCRIBE WORKSPACE {workspace_fqn.sql_identifier}",
-            cursor_class=DictCursor,
-        )
-        row = cursor.fetchone()
-        if row is None:
-            raise CliError(
-                f"Could not describe workspace {workspace_fqn.identifier} "
-                "to resolve default version."
-            )
-        location_uri = (
-            row.get("default_version_location_uri")
-            or row.get("DEFAULT_VERSION_LOCATION_URI")
-            or ""
-        )
-        if not location_uri:
-            version_name = row.get("default_version_name") or row.get(
-                "DEFAULT_VERSION_NAME"
-            )
-            if version_name:
-                location_uri = f"snow://workspace/{workspace_fqn.identifier}/versions/{version_name}/"
-        if not location_uri:
-            raise CliError(
-                f"Could not resolve default version for workspace {workspace_fqn.identifier}."
-            )
-        return str(location_uri).rstrip("/")
-
-    def get_default_workspace_version_subdirectory_uri(
-        self, workspace_fqn: FQN, directory_name: str
-    ) -> str:
-        """Return URI for *directory_name* under the workspace default version."""
-        normalized_directory = directory_name.strip("/")
-        return (
-            f"{self.get_default_workspace_version_uri(workspace_fqn)}"
-            f"/{normalized_directory}"
-        )
-
     def clear_workspace_subdirectory(
         self, workspace_fqn: FQN, directory_name: str
     ) -> None:

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -819,67 +819,19 @@ class TestSnowflakeAppManager:
         with pytest.raises(ProgrammingError):
             SnowflakeAppManager().ensure_workspace_live_version(fqn)
 
-    @patch(EXECUTE_QUERY)
-    def test_get_default_workspace_version_uri(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = {
-            "default_version_name": "VERSION$7",
-            "default_version_location_uri": (
-                "snow://workspace/DB.SCHEMA.WORKSPACE/versions/version$7/"
-            ),
-        }
-        mock_execute.return_value = cursor
+    def test_workspace_last_uri(self):
         fqn = FQN(database="DB", schema="SCHEMA", name="WORKSPACE")
         assert (
-            SnowflakeAppManager().get_default_workspace_version_uri(fqn)
-            == "snow://workspace/DB.SCHEMA.WORKSPACE/versions/version$7"
-        )
-        mock_execute.assert_called_once_with(
-            "DESCRIBE WORKSPACE IDENTIFIER('DB.SCHEMA.WORKSPACE')",
-            cursor_class=DictCursor,
+            SnowflakeAppManager().workspace_last_uri(fqn)
+            == "snow://workspace/DB.SCHEMA.WORKSPACE/versions/last"
         )
 
-    @patch(EXECUTE_QUERY)
-    def test_get_default_workspace_version_uri_uses_name_fallback(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = {
-            "default_version_name": "VERSION$9",
-            "default_version_location_uri": "",
-        }
-        mock_execute.return_value = cursor
+    def test_workspace_last_subdirectory_uri_normalizes_directory_name(self):
         fqn = FQN(database="DB", schema="SCHEMA", name="WORKSPACE")
         assert (
-            SnowflakeAppManager().get_default_workspace_version_uri(fqn)
-            == "snow://workspace/DB.SCHEMA.WORKSPACE/versions/VERSION$9"
+            SnowflakeAppManager().workspace_last_subdirectory_uri(fqn, "/MY_APP/")
+            == "snow://workspace/DB.SCHEMA.WORKSPACE/versions/last/MY_APP"
         )
-
-    @patch(EXECUTE_QUERY)
-    def test_get_default_workspace_version_uri_raises_when_describe_returns_no_row(
-        self, mock_execute
-    ):
-        cursor = Mock()
-        cursor.fetchone.return_value = None
-        mock_execute.return_value = cursor
-        fqn = FQN(database="DB", schema="SCHEMA", name="WORKSPACE")
-        with pytest.raises(
-            CliError,
-            match=r"Could not describe workspace DB\.SCHEMA\.WORKSPACE",
-        ):
-            SnowflakeAppManager().get_default_workspace_version_uri(fqn)
-
-    @patch(EXECUTE_QUERY)
-    def test_get_default_workspace_version_uri_raises_when_missing(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = {
-            "default_version_name": "",
-            "default_version_location_uri": "",
-        }
-        mock_execute.return_value = cursor
-        fqn = FQN(database="DB", schema="SCHEMA", name="WORKSPACE")
-        with pytest.raises(
-            CliError, match="Could not resolve default version for workspace"
-        ):
-            SnowflakeAppManager().get_default_workspace_version_uri(fqn)
 
     @staticmethod
     def _find_query(call_args_list, substr):
@@ -3353,9 +3305,9 @@ RESOLVE_DEPLOY_DEFAULTS = (
     "snowflake.cli._plugins.apps.commands._resolve_deploy_defaults"
 )
 
-# Shape must include ``/versions/<id>/`` — deploy parses this for the build step message.
+# Workspace builds use the committed ``last`` alias directly.
 _WORKSPACE_BUILD_SOURCE_URI = (
-    "snow://workspace/TEST_DB.TEST_SCHEMA.MY_APP_CODE/versions/version$1/MY_APP"
+    "snow://workspace/TEST_DB.TEST_SCHEMA.MY_APP_CODE/versions/last/MY_APP"
 )
 
 
@@ -3555,7 +3507,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.artifact_repo_exists.return_value = False
@@ -3595,7 +3547,7 @@ class TestDeployCommand:
         )
         mock_mgr.create_stage.assert_not_called()
         mock_mgr.build_app_artifact_repo.assert_called_once_with(
-            source_uri=mock_mgr.get_default_workspace_version_subdirectory_uri.return_value,
+            source_uri=mock_mgr.workspace_last_subdirectory_uri.return_value,
             artifact_repo_fqn="TEST_DB.TEST_SCHEMA.MY_APP_REPO",
             app_id="MY_APP",
             compute_pool="BUILD_POOL",
@@ -3604,7 +3556,7 @@ class TestDeployCommand:
             runtime_image="runtime:latest",
             build_eai="MY_EAI",
         )
-        mock_mgr.get_default_workspace_version_subdirectory_uri.assert_called_once_with(
+        mock_mgr.workspace_last_subdirectory_uri.assert_called_once_with(
             FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP_CODE"),
             "MY_APP",
         )
@@ -3787,7 +3739,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.artifact_repo_exists.return_value = True
@@ -3891,7 +3843,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.stage_exists.return_value = False
@@ -4040,7 +3992,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.artifact_repo_exists.return_value = False
@@ -4301,7 +4253,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.artifact_repo_exists.return_value = False
@@ -4404,7 +4356,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.artifact_repo_exists.return_value = False
@@ -4510,7 +4462,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = True
-        mock_mgr.get_default_workspace_version_subdirectory_uri.return_value = (
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
         mock_mgr.artifact_repo_exists.return_value = False


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- stop resolving Snowflake Apps workspace builds via `DESCRIBE WORKSPACE`
- use the committed `versions/last` alias for workspace build source URIs
