### PR TITLE
test(dcm): fix test_plan_project_with_delta mock after DCM v1 cleanup

### DIFF
--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -861,9 +861,7 @@ class TestDCMPlan:
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().plan.return_value = mock_cursor(
-            rows=[("[]",)], columns=("operations",)
-        )
+        mock_dcm_manager().plan.return_value = _plan_cursor(mock_cursor)
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = _manifest_without_config()
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

The DCM v1 API cleanup in #2973 migrated all plan/deploy test mocks from the legacy `rows=[("[]",)]` format to a new `_plan_cursor` helper (which returns a v2 plan response). It missed a single test: `test_plan_project_with_delta`, added shortly before #2973 in #2961.

With v1 support removed, `PlanReporter.process` strictly validates the payload as a v2 dict. The legacy list mock now fails with:

```
INFO snowflake.cli._plugins.dcm.reporters.plan:plan.py:163 Unexpected response type: <class 'list'>, expected dict
CliError: Could not process response.
```

`main` CI has been red since #2973 landed. This one-line fix aligns the test with its siblings (`test_plan_project`, `test_plan_project_with_save_output`, etc.), which all already use `_plan_cursor(mock_cursor)`.

No user-facing change — test-only, so no release note.

### How this slipped into main

Classic "semantic merge conflict":

| Date | Event |
|---|---|
| **2026-05-07 12:04 UTC** | PR #2973 (DCM v1 cleanup) CI ran and passed — `test_plan_project_with_delta` did not exist yet |
| **2026-05-08 07:15 UTC** | PR #2961 merged — added `test_plan_project_with_delta` with the legacy `rows=[("[]",)]` mock |
| **2026-05-14 09:05 UTC** | PR #2973 was **merged a week later without re-running CI against latest main** |

Git merged cleanly because the two PRs never touched the same lines (PR #2961 only added a test; PR #2973 only removed a code path), but the combined behavior was incompatible. CI didn't re-run against the updated base on merge, so the incompatibility was invisible until it hit `main`.

Enabling **"Require branches to be up to date before merging"** on `main` — or a merge queue that re-runs CI against the tip of the base before landing — would close this entire class of bug.