### PR TITLE
Snowflake Apps: default SPCS test project type to empty string

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -608,6 +608,7 @@ def snowflake_app_deploy(
                 )
 
             cli_console.step("Building app using artifact repository...")
+            project_type_override = getattr(entity, "spcs_test_project_type", None)
             build_kwargs: dict = dict(
                 artifact_repo_fqn=artifact_repo_fqn_str,
                 app_id=app_name,
@@ -616,6 +617,11 @@ def snowflake_app_deploy(
                 schema=schema,
                 runtime_image=entity.runtime_image,
                 build_eai=build_eai,
+                project_type=(
+                    project_type_override
+                    if isinstance(project_type_override, str)
+                    else ""
+                ),
             )
             if use_workspace:
                 build_kwargs["source_uri"] = manager.workspace_last_subdirectory_uri(

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -864,7 +864,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         schema: str = "",
         runtime_image: str = "",
         build_eai: Optional[str] = None,
-        project_type: str = "nodejs",
+        project_type: str = "",
         source_uri: Optional[str] = None,
     ) -> str:
         """Build an app using SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO.

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -225,6 +225,20 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
         default="",
     )
 
+    spcs_test_project_type: Optional[str] = Field(
+        title="Project type override for SPCS_TEST builds",
+        default=None,
+    )
+
+    @field_validator("spcs_test_project_type", mode="before")
+    @classmethod
+    def _validate_spcs_test_project_type(cls, value):
+        if value is None or value == "null":
+            return None
+        if not isinstance(value, str):
+            raise ValueError("spcs_test_project_type must be a string or null")
+        return value.strip()
+
     build_image: Optional[str] = Field(
         title="Custom container image for building the app",
         default=None,

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -864,6 +864,30 @@ class TestSnowflakeAppManager:
         assert "'BUILD_POOL'" in build_query
 
     @patch(EXECUTE_QUERY)
+    def test_build_app_artifact_repo_defaults_project_type_to_empty_string(
+        self, mock_execute
+    ):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("Build job submitted: DB.SCHEMA.JOB",)
+        mock_execute.return_value = cursor
+
+        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
+        SnowflakeAppManager().build_app_artifact_repo(
+            stage_fqn=stage_fqn,
+            artifact_repo_fqn="DB.SCHEMA.REPO",
+            app_id="my_app",
+            compute_pool="BUILD_POOL",
+            database="DB",
+            schema="SCHEMA",
+            runtime_image="runtime:latest",
+        )
+        build_query = self._find_query(
+            mock_execute.call_args_list, "SPCS_TEST_BUILD_APP_ARTIFACT_REPO"
+        )
+        assert ", '', '{}')" in build_query
+        assert "'nodejs'" not in build_query
+
+    @patch(EXECUTE_QUERY)
     def test_build_app_artifact_repo_escapes_single_quotes(self, mock_execute):
         cursor = Mock()
         cursor.fetchone.return_value = ("Build job submitted: DB.SCHEMA.JOB",)
@@ -3555,6 +3579,7 @@ class TestDeployCommand:
             schema="TEST_SCHEMA",
             runtime_image="runtime:latest",
             build_eai="MY_EAI",
+            project_type="",
         )
         mock_mgr.workspace_last_subdirectory_uri.assert_called_once_with(
             FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP_CODE"),
@@ -3571,6 +3596,101 @@ class TestDeployCommand:
             comment='{"appId": "MY_APP"}',
         )
         assert mock_poll.call_count == 2
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_forwards_project_type_override(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = Mock(database=None, schema_=None)
+        entity.code_workspace.name = "MY_APP_CODE"
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = "runtime:latest"
+        entity.query_warehouse = "WH"
+        entity.build_image = None
+        entity.execute_as_caller = False
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        entity.spcs_test_project_type = "nextjs"
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
+            _WORKSPACE_BUILD_SOURCE_URI
+        )
+        mock_mgr.artifact_repo_exists.return_value = False
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {
+                "url": "my-app.snowflakecomputing.app",
+                "is_upgrading": "false",
+            },
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+
+        mock_mgr.build_app_artifact_repo.assert_called_once()
+        assert mock_mgr.build_app_artifact_repo.call_args.kwargs["project_type"] == (
+            "nextjs"
+        )
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")
@@ -3671,6 +3791,7 @@ class TestDeployCommand:
             schema="TEST_SCHEMA",
             runtime_image="runtime:latest",
             build_eai="MY_EAI",
+            project_type="",
         )
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -42,6 +42,7 @@ class TestSnowflakeAppEntityModel:
         assert model.code_stage is None
         assert model.meta is None
         assert model.build_image is None
+        assert model.spcs_test_project_type is None
         assert model.execute_as_caller is True
         assert model.dev_roles is None
 
@@ -319,6 +320,25 @@ class TestSnowflakeAppEntityModel:
                 build_image='/my/"image":latest',
             )
 
+    def test_spcs_test_project_type_strips_whitespace(self):
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            spcs_test_project_type="  nextjs  ",
+        )
+        assert model.spcs_test_project_type == "nextjs"
+
+    @pytest.mark.parametrize("value", [None, "null"])
+    def test_spcs_test_project_type_allows_null_values(self, value):
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            spcs_test_project_type=value,
+        )
+        assert model.spcs_test_project_type is None
+
     def test_execute_as_caller_defaults_to_true(self):
         model = SnowflakeAppEntityModel(
             type="snowflake-app",
@@ -491,6 +511,23 @@ class TestSnowflakeAppInProjectDefinition:
         assert entity.meta.title == "My App Title"
         assert entity.meta.description == "My App Description"
         assert entity.meta.icon == "icon.png"
+
+    def test_snowflake_app_with_spcs_test_project_type_override(self):
+        definition_input = {
+            "definition_version": "2",
+            "entities": {
+                "my_app": {
+                    "type": "snowflake-app",
+                    "identifier": "MY_APP",
+                    "artifacts": ["app/*"],
+                    "spcs_test_project_type": "  nextjs  ",
+                }
+            },
+        }
+        result = render_definition_template(definition_input, {})
+        project = result.project_definition
+        entity = project.entities["my_app"]
+        assert entity.spcs_test_project_type == "nextjs"
 
 
 class TestSubModels:


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- pass an empty string as `project_type` to `SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO` by default
- add an optional `spcs_test_project_type` app YAML field to override that build argument when needed
- cover the default and override behavior in Snowflake Apps deploy/model tests
