### PR TITLE
Add @snowflakedb/client-side-interfaces to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-* @snowflakedb/snowcli
+* @snowflakedb/snowcli @snowflakedb/client-side-interfaces
 
 # Apps plugin
-/src/snowflake/cli/_plugins/apps/ @snowflakedb/snowcli @snowflakedb/native-apps
-/tests/apps/ @snowflakedb/snowcli @snowflakedb/native-apps
-/tests_integration/apps/ @snowflakedb/snowcli @snowflakedb/native-apps
-/tests/__snapshots__/ @snowflakedb/snowcli @snowflakedb/native-apps
-/tests_integration/__snapshots__/ @snowflakedb/snowcli @snowflakedb/native-apps
+/src/snowflake/cli/_plugins/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests_integration/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests/__snapshots__/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests_integration/__snapshots__/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [x] I've described my changes in the documentation.

   _CODEOWNERS-only change; no code, tests, or docs are affected._

### Changes description

Adds the new `@snowflakedb/client-side-interfaces` team alongside the existing `@snowflakedb/snowcli` global owner. The new team is the master team for Client-Side Services (Snowflake CLI, Terraform Provider, CI/CD integrations) under Developer Platform. Additive change — `@snowflakedb/snowcli` retains ownership.