### PR TITLE
chore: catch release-notes bullets duplicated across released sections

### DIFF
--- a/scripts/check_release_notes_duplicates.py
+++ b/scripts/check_release_notes_duplicates.py
@@ -110,7 +110,10 @@ def find_duplicates(path: Path) -> list[str]:
         # in an older released section is the rebase-context-drift case:
         # the author's patch dragged context bullets that already shipped
         # in a prior release into the current release-staging section.
-        if most_recent_released:
+        # Skip when the bullet is also in Unreleased — the check above
+        # already flagged it, and firing here would emit a contradictory
+        # second message ("move to Unreleased" vs. "remove from Unreleased").
+        if most_recent_released and not in_unreleased:
             in_recent = [p for p in places if p[0] == most_recent_released]
             in_older_released = [
                 p

--- a/scripts/check_release_notes_duplicates.py
+++ b/scripts/check_release_notes_duplicates.py
@@ -16,9 +16,16 @@
 
 Companion to the `RELEASE-NOTES.md merge=union` git attribute. Union merge
 auto-resolves the "two PRs each append a bullet" conflict but silently keeps
-both copies of a bullet that the release cut has already moved from
-"Unreleased version" into a `# vX.Y.Z` section. This script flags that case
-so the author removes the already-released bullet from Unreleased.
+both copies of a bullet in scenarios that produce an invalid file:
+
+* The release cut moved a bullet from "Unreleased version" into a `# vX.Y.Z`
+  section, but the author's branch still has the bullet under Unreleased.
+* A rebase keyed on adjacent bullets as patch context dropped the author's
+  new bullet under the most-recent released section instead of Unreleased,
+  carrying along context bullets that are also present in an older released
+  section.
+
+The script flags both cases so the author can remove the misplaced bullet.
 """
 
 from __future__ import annotations
@@ -61,6 +68,15 @@ def _iter_bullets(lines: Iterable[str]) -> Iterable[tuple[str, str, int]]:
             yield current_section, _normalize(bullet.group(1)), lineno
 
 
+def _first_released_section(lines: Iterable[str]) -> str | None:
+    """Return the first `# vX.Y.Z` header in document order, or None."""
+    for raw in lines:
+        header = _TOP_HEADER_RE.match(raw)
+        if header and _RELEASED_SECTION_RE.match(header.group(1).strip()):
+            return header.group(1).strip()
+    return None
+
+
 def find_duplicates(path: Path) -> list[str]:
     """Return human-readable error messages, or an empty list if clean."""
     text = path.read_text(encoding="utf-8").splitlines()
@@ -68,6 +84,8 @@ def find_duplicates(path: Path) -> list[str]:
     occurrences: dict[str, list[tuple[str, int]]] = defaultdict(list)
     for section, bullet, lineno in _iter_bullets(text):
         occurrences[bullet].append((section, lineno))
+
+    most_recent_released = _first_released_section(text)
 
     errors: list[str] = []
     for bullet, places in occurrences.items():
@@ -88,6 +106,25 @@ def find_duplicates(path: Path) -> list[str]:
                 f"({unreleased_lines}) and released section(s) "
                 f"[{released_names}]: {bullet!r}"
             )
+        # A bullet under the most-recent released section that also appears
+        # in an older released section is the rebase-context-drift case:
+        # the author's patch dragged context bullets that already shipped
+        # in a prior release into the current release-staging section.
+        if most_recent_released:
+            in_recent = [p for p in places if p[0] == most_recent_released]
+            in_older_released = [
+                p
+                for p in places
+                if _RELEASED_SECTION_RE.match(p[0]) and p[0] != most_recent_released
+            ]
+            if in_recent and in_older_released:
+                older_names = ", ".join(sorted({s for s, _ in in_older_released}))
+                recent_lines = ", ".join(f"line {ln}" for _, ln in in_recent)
+                errors.append(
+                    f"Bullet appears in both '{most_recent_released}' "
+                    f"({recent_lines}) and older released section(s) "
+                    f"[{older_names}]: {bullet!r}"
+                )
     return errors
 
 
@@ -100,10 +137,15 @@ def main(argv: list[str] | None = None) -> int:
     if errors:
         print(
             "Duplicate bullets found in RELEASE-NOTES.md.\n"
-            "After a release cut, the `merge=union` driver can leave bullets "
-            "in both 'Unreleased version' and the new released section.\n"
-            "Remove the bullet from 'Unreleased version' — it's already "
-            "documented under the released version.\n",
+            "Common causes:\n"
+            "  * The `merge=union` driver kept a bullet in both 'Unreleased "
+            "version' and a released section after a release cut. Remove "
+            "the bullet from 'Unreleased version'.\n"
+            "  * A rebase landed a new bullet in the most-recent released "
+            "section instead of 'Unreleased version', dragging along "
+            "context bullets that already shipped in older releases. "
+            "Move the new bullet to 'Unreleased version' and remove the "
+            "stale duplicates.\n",
             file=sys.stderr,
         )
         for err in errors:

--- a/tests/test_check_release_notes_duplicates.py
+++ b/tests/test_check_release_notes_duplicates.py
@@ -176,6 +176,31 @@ def test_bullet_in_recent_release_and_older_release_is_flagged(notes_file):
     assert "select *" in errors[0]
 
 
+def test_bullet_in_unreleased_and_two_released_sections_emits_one_error(notes_file):
+    # When a bullet is in Unreleased + most-recent release + older release,
+    # only the Unreleased-vs-released error should fire. The cross-released
+    # check would otherwise add a contradictory second message telling the
+    # author to move the bullet *into* Unreleased.
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+        * Fixed the same thing.
+
+        # v3.17.1
+        ## Fixes and improvements
+        * Fixed the same thing.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed the same thing.
+        """
+    )
+    errors = check.find_duplicates(path)
+    assert len(errors) == 1
+    assert "Unreleased version" in errors[0]
+
+
 def test_distinct_bullets_in_separate_releases_are_not_flagged(notes_file):
     path = notes_file(
         """

--- a/tests/test_check_release_notes_duplicates.py
+++ b/tests/test_check_release_notes_duplicates.py
@@ -219,6 +219,29 @@ def test_distinct_bullets_in_separate_releases_are_not_flagged(notes_file):
     assert check.find_duplicates(path) == []
 
 
+def test_duplicate_across_two_older_releases_is_not_flagged(notes_file):
+    # The cross-released check only fires when a bullet is shared between the
+    # most-recent released section and an older one — that's the rebase-drift
+    # signature. Duplicates between two already-shipped older releases are
+    # left alone, so historical patterns in old notes don't false-positive.
+    path = notes_file(
+        """
+        # v3.17.2
+        ## Fixes and improvements
+        * Fixed the newest thing.
+
+        # v3.17.1
+        ## Fixes and improvements
+        * Fixed an old shared thing.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed an old shared thing.
+        """
+    )
+    assert check.find_duplicates(path) == []
+
+
 def test_legacy_within_section_duplicates_are_ignored(notes_file):
     # The historical RELEASE-NOTES.md has sections that legitimately repeat
     # a header-style bullet under multiple sub-sections of one release

--- a/tests/test_check_release_notes_duplicates.py
+++ b/tests/test_check_release_notes_duplicates.py
@@ -151,3 +151,66 @@ def test_main_returns_one_on_dirty_file(notes_file, capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "Duplicate bullet" in err
+
+
+def test_bullet_in_recent_release_and_older_release_is_flagged(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+
+        # v3.17.1
+        ## Fixes and improvements
+        * Fixed boolean env-var coercion.
+        * Fixed `SELECT *` output being corrupted when joined tables share columns.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed `SELECT *` output being corrupted when joined tables share columns.
+        """
+    )
+    errors = check.find_duplicates(path)
+    assert len(errors) == 1
+    assert "v3.17.1" in errors[0]
+    assert "v3.17.0" in errors[0]
+    assert "select *" in errors[0]
+
+
+def test_distinct_bullets_in_separate_releases_are_not_flagged(notes_file):
+    path = notes_file(
+        """
+        # Unreleased version
+        ## Fixes and improvements
+
+        # v3.17.1
+        ## Fixes and improvements
+        * Fixed boolean env-var coercion.
+
+        # v3.17.0
+        ## Fixes and improvements
+        * Fixed something else.
+        """
+    )
+    assert check.find_duplicates(path) == []
+
+
+def test_legacy_within_section_duplicates_are_ignored(notes_file):
+    # The historical RELEASE-NOTES.md has sections that legitimately repeat
+    # a header-style bullet under multiple sub-sections of one release
+    # (e.g. v2.2.0 listing `* snow snowpark package create:` under both
+    # Deprecations and New additions). The cross-released-section check
+    # must not fire on these — it only cares about bullets shared between
+    # the most-recent released section and an older one.
+    path = notes_file(
+        """
+        # v2.2.0
+        ## Deprecations
+        * `snow snowpark package create`:
+          * `--pypi-download` is deprecated.
+
+        ## New additions
+        * `snow snowpark package create`:
+          * new `--ignore-anaconda` flag.
+        """
+    )
+    assert check.find_duplicates(path) == []


### PR DESCRIPTION
### Pre-review checklist
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description

The existing `check-release-notes-duplicates` pre-commit hook (added in #3025) catches bullets duplicated between "Unreleased version" and a released section. It does not catch the rebase-drift case: when an author's patch hunks are keyed on adjacent bullets as context, `git rebase` will silently apply the hunk under whichever header those context lines now live under. If main has moved bullets into a new `# vX.Y.Z` section since the branch was authored, the rebased patch can land in that section AND drag in context bullets that already shipped in an older release. Hit this on #2932 — two bullets ended up duplicated across `# v3.17.1` and `# v3.17.0` and the existing hook reported the file clean.

This adds a third rule to `find_duplicates`: a bullet appearing in both the most-recent `# vX.Y.Z` section and any older released section is flagged. The check is intentionally scoped to most-recent-vs-older (not all pairs of released sections) so legacy within-release patterns in old notes — e.g. v2.2.0 repeating `* snow snowpark package create:` as a header bullet under both Deprecations and New additions — do not false-positive.

The hook's error message is updated to name both failure modes so authors know whether to remove the bullet from Unreleased (post-release-cut case) or move a new bullet there from a released section (rebase-drift case).

No release-notes entry — this is internal tooling, matching #3025.