### PR TITLE
Snowflake Apps: Stream app service logs during deploy and clarify failures

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -423,6 +423,33 @@ def _make_build_log_streamer(
     return _stream
 
 
+def _make_service_log_streamer(
+    manager: SnowflakeAppManager, service_fqn: FQN
+) -> Callable[[], None]:
+    """Return an ``on_poll`` callback that streams new service log lines.
+
+    Service logs are returned as a single newline-delimited string, so the
+    callback splits them into lines and only emits the unseen suffix on each
+    poll. Like the build streamer, failures fetching logs are swallowed so the
+    surrounding deploy poll can continue.
+    """
+    seen_count = 0
+
+    def _stream() -> None:
+        nonlocal seen_count
+        try:
+            logs = manager.get_service_logs(service_fqn)
+        except Exception:
+            log.debug("Failed to fetch application service logs", exc_info=True)
+            return
+        new_lines = logs.splitlines()[seen_count:]
+        for line in new_lines:
+            log.info(line)
+        seen_count += len(new_lines)
+
+    return _stream
+
+
 def snowflake_app_deploy(
     entity_id: Optional[str],
     upload_only: bool,
@@ -745,6 +772,8 @@ def snowflake_app_deploy(
     def _url_is_ready(d: dict) -> bool:
         return manager.resolve_application_service_url_from_describe(d) is not None
 
+    service_log_streamer = _make_service_log_streamer(manager, service_fqn)
+
     with metrics.span("snowflake_app.endpoint_provision"):
         if did_upgrade:
             cli_console.step("Waiting for upgrade to complete...")
@@ -758,8 +787,9 @@ def snowflake_app_deploy(
                     ),
                     timeout_message=(
                         f"Upgrade timed out. Check logs:\n"
-                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{app_name}')"
+                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
                     ),
+                    on_poll=service_log_streamer,
                 )
         else:
             cli_console.step("Waiting for application service endpoint...")
@@ -770,9 +800,10 @@ def snowflake_app_deploy(
                     is_error=_svc_has_failed,
                     format_status=lambda d: d.get("url") or "url not yet available",
                     timeout_message=(
-                        f"Endpoint provisioning timed out. "
-                        f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
+                        f"Application service deployment timed out. Check logs:\n"
+                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
                     ),
+                    on_poll=service_log_streamer,
                 )
 
     endpoint_url = manager.resolve_application_service_url_from_describe(desc)

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -423,31 +423,20 @@ def _make_build_log_streamer(
     return _stream
 
 
-def _make_service_log_streamer(
-    manager: SnowflakeAppManager, service_fqn: FQN
-) -> Callable[[], None]:
-    """Return an ``on_poll`` callback that streams new service log lines.
+def _log_service_logs(manager: SnowflakeAppManager, service_fqn: FQN) -> None:
+    """Fetch service logs and emit them at INFO level.
 
-    Service logs are returned as a single newline-delimited string, so the
-    callback splits them into lines and only emits the unseen suffix on each
-    poll. Like the build streamer, failures fetching logs are swallowed so the
-    surrounding deploy poll can continue.
+    INFO-level output only appears when the user runs the deploy with
+    ``--verbose`` (or ``--debug``). Failures fetching logs are swallowed so the
+    original deployment error remains the primary failure signal.
     """
-    seen_count = 0
-
-    def _stream() -> None:
-        nonlocal seen_count
-        try:
-            logs = manager.get_service_logs(service_fqn)
-        except Exception:
-            log.debug("Failed to fetch application service logs", exc_info=True)
-            return
-        new_lines = logs.splitlines()[seen_count:]
-        for line in new_lines:
-            log.info(line)
-        seen_count += len(new_lines)
-
-    return _stream
+    try:
+        logs = manager.get_service_logs(service_fqn)
+    except Exception:
+        log.debug("Failed to fetch application service logs", exc_info=True)
+        return
+    for line in logs.splitlines():
+        log.info(line)
 
 
 def snowflake_app_deploy(
@@ -750,6 +739,7 @@ def snowflake_app_deploy(
                             version="LATEST",
                         )
                 except ProgrammingError as upgrade_error:
+                    _log_service_logs(manager, service_fqn)
                     raise CliError(
                         "Deployment failed while upgrading application service "
                         f"'{service_fqn.identifier}': {upgrade_error}. "
@@ -757,6 +747,7 @@ def snowflake_app_deploy(
                     ) from upgrade_error
                 did_upgrade = True
             else:
+                _log_service_logs(manager, service_fqn)
                 raise CliError(
                     "Deployment failed while creating application service "
                     f"'{service_fqn.identifier}': {e}. "
@@ -772,39 +763,48 @@ def snowflake_app_deploy(
     def _url_is_ready(d: dict) -> bool:
         return manager.resolve_application_service_url_from_describe(d) is not None
 
-    service_log_streamer = _make_service_log_streamer(manager, service_fqn)
-
-    with metrics.span("snowflake_app.endpoint_provision"):
-        if did_upgrade:
-            cli_console.step("Waiting for upgrade to complete...")
-            with metrics.span("snowflake_app.endpoint_provision.wait_for_upgrade"):
-                desc = _poll_until(
-                    poll_fn=lambda: manager.describe_app_service(service_fqn),
-                    is_done=_url_is_ready,
-                    is_error=_svc_has_failed,
-                    format_status=lambda d: (
-                        "upgrading" if _svc_is_upgrading(d) else "ready"
-                    ),
-                    timeout_message=(
-                        f"Upgrade timed out. Check logs:\n"
-                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
-                    ),
-                    on_poll=service_log_streamer,
-                )
-        else:
-            cli_console.step("Waiting for application service endpoint...")
-            with metrics.span("snowflake_app.endpoint_provision.wait_for_endpoint"):
-                desc = _poll_until(
-                    poll_fn=lambda: manager.describe_app_service(service_fqn),
-                    is_done=_url_is_ready,
-                    is_error=_svc_has_failed,
-                    format_status=lambda d: d.get("url") or "url not yet available",
-                    timeout_message=(
-                        f"Application service deployment timed out. Check logs:\n"
-                        f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
-                    ),
-                    on_poll=service_log_streamer,
-                )
+    try:
+        with metrics.span("snowflake_app.endpoint_provision"):
+            if did_upgrade:
+                cli_console.step("Waiting for upgrade to complete...")
+                with metrics.span("snowflake_app.endpoint_provision.wait_for_upgrade"):
+                    desc = _poll_until(
+                        poll_fn=lambda: manager.describe_app_service(service_fqn),
+                        is_done=_url_is_ready,
+                        is_error=_svc_has_failed,
+                        format_status=lambda d: (
+                            "upgrading" if _svc_is_upgrading(d) else "ready"
+                        ),
+                        timeout_message=(
+                            f"Upgrade timed out. Check application service state and logs:\n"
+                            f"  DESCRIBE APPLICATION SERVICE {service_fqn.identifier}\n"
+                            f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
+                        ),
+                    )
+            else:
+                cli_console.step("Waiting for application service endpoint...")
+                with metrics.span("snowflake_app.endpoint_provision.wait_for_endpoint"):
+                    desc = _poll_until(
+                        poll_fn=lambda: manager.describe_app_service(service_fqn),
+                        is_done=_url_is_ready,
+                        is_error=_svc_has_failed,
+                        format_status=lambda d: d.get("url") or "url not yet available",
+                        timeout_message=(
+                            f"Application service deployment timed out. Check application service state and logs:\n"
+                            f"  DESCRIBE APPLICATION SERVICE {service_fqn.identifier}\n"
+                            f"  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('{service_fqn.identifier}')"
+                        ),
+                    )
+    except CliError:
+        try:
+            if _svc_has_failed(manager.describe_app_service(service_fqn)):
+                _log_service_logs(manager, service_fqn)
+        except Exception:
+            log.debug(
+                "Failed to inspect application service after deploy error",
+                exc_info=True,
+            )
+        raise
 
     endpoint_url = manager.resolve_application_service_url_from_describe(desc)
     if not endpoint_url:

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -15,7 +15,10 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from snowflake.cli._plugins.apps.commands import _make_build_log_streamer
+from snowflake.cli._plugins.apps.commands import (
+    _make_build_log_streamer,
+    _make_service_log_streamer,
+)
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
 )
@@ -489,6 +492,59 @@ class TestMakeBuildLogStreamer:
             streamer()
             assert mock_log.info.call_count == 1
             mock_log.info.assert_called_with("line3")
+
+
+class TestMakeServiceLogStreamer:
+    """Tests for ``_make_service_log_streamer`` incremental log diffing."""
+
+    def test_first_call_prints_all_lines(self):
+        manager = Mock()
+        manager.get_service_logs.return_value = "line1\nline2\nline3"
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+
+        streamer = _make_service_log_streamer(manager, fqn)
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            streamer()
+
+        assert mock_log.info.call_count == 3
+        mock_log.info.assert_any_call("line1")
+        mock_log.info.assert_any_call("line2")
+        mock_log.info.assert_any_call("line3")
+
+    def test_subsequent_call_prints_only_new_lines(self):
+        manager = Mock()
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_service_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            manager.get_service_logs.return_value = "line1\nline2"
+            streamer()
+            assert mock_log.info.call_count == 2
+
+            mock_log.info.reset_mock()
+            manager.get_service_logs.return_value = "line1\nline2\nline3\nline4"
+            streamer()
+            assert mock_log.info.call_count == 2
+            mock_log.info.assert_any_call("line3")
+            mock_log.info.assert_any_call("line4")
+
+    def test_empty_logs_print_nothing(self):
+        manager = Mock()
+        manager.get_service_logs.return_value = ""
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_service_log_streamer(manager, fqn)
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            streamer()
+            mock_log.info.assert_not_called()
+
+    def test_exception_is_swallowed(self):
+        manager = Mock()
+        manager.get_service_logs.side_effect = RuntimeError("connection lost")
+        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
+        streamer = _make_service_log_streamer(manager, fqn)
+
+        streamer()  # should not raise
 
 
 # ── _generate_snowflake_yml tests ─────────────────────────────────────
@@ -3558,6 +3614,216 @@ class TestDeployCommand:
             upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
             assert create_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
             assert upgrade_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_wait_uses_service_log_streamer_and_fqn_log_hint(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.get_service_logs.return_value = "line1\nline2"
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            assert result.exit_code == 0, result.output
+
+        _, kwargs = mock_poll.call_args
+        assert (
+            kwargs["timeout_message"]
+            == "Application service deployment timed out. Check logs:\n"
+            "  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
+        )
+        assert callable(kwargs["on_poll"])
+
+        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
+            kwargs["on_poll"]()
+
+        mock_mgr.get_service_logs.assert_called_once()
+        service_fqn = mock_mgr.get_service_logs.call_args.args[0]
+        assert service_fqn.identifier == "TEST_DB.TEST_SCHEMA.MY_APP"
+        mock_log.info.assert_any_call("line1")
+        mock_log.info.assert_any_call("line2")
+
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_service_failed_status_reports_deployment_failure(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_sleep,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.get_service_logs.return_value = ""
+        mock_mgr.resolve_application_service_url_from_describe.return_value = None
+        mock_mgr.describe_app_service.return_value = {
+            "status": "FAILED",
+            "url": "provisioning in progress",
+            "is_upgrading": "false",
+        }
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only"])
+
+        assert result.exit_code == 1
+        assert "Application service deployment failed. Check logs:" in result.output
+        assert (
+            "CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
+            in result.output
+        )
+        assert "timed out" not in result.output
+        assert "Endpoint provisioning" not in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_upgrade_wait_uses_fqn_service_log_hint(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        already_exists = ProgrammingError("already exists")
+        already_exists.errno = 2002
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.create_app_service.side_effect = already_exists
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            assert result.exit_code == 0, result.output
+
+        _, kwargs = mock_poll.call_args
+        assert (
+            kwargs["timeout_message"] == "Upgrade timed out. Check logs:\n"
+            "  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
+        )
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -16,8 +16,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 from snowflake.cli._plugins.apps.commands import (
+    _log_service_logs,
     _make_build_log_streamer,
-    _make_service_log_streamer,
 )
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
@@ -494,57 +494,37 @@ class TestMakeBuildLogStreamer:
             mock_log.info.assert_called_with("line3")
 
 
-class TestMakeServiceLogStreamer:
-    """Tests for ``_make_service_log_streamer`` incremental log diffing."""
+class TestLogServiceLogs:
+    """Tests for ``_log_service_logs`` line-by-line emission."""
 
-    def test_first_call_prints_all_lines(self):
+    def test_logs_all_lines(self):
         manager = Mock()
         manager.get_service_logs.return_value = "line1\nline2\nline3"
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
 
-        streamer = _make_service_log_streamer(manager, fqn)
         with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            streamer()
+            _log_service_logs(manager, fqn)
 
         assert mock_log.info.call_count == 3
         mock_log.info.assert_any_call("line1")
         mock_log.info.assert_any_call("line2")
         mock_log.info.assert_any_call("line3")
 
-    def test_subsequent_call_prints_only_new_lines(self):
-        manager = Mock()
-        fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_service_log_streamer(manager, fqn)
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            manager.get_service_logs.return_value = "line1\nline2"
-            streamer()
-            assert mock_log.info.call_count == 2
-
-            mock_log.info.reset_mock()
-            manager.get_service_logs.return_value = "line1\nline2\nline3\nline4"
-            streamer()
-            assert mock_log.info.call_count == 2
-            mock_log.info.assert_any_call("line3")
-            mock_log.info.assert_any_call("line4")
-
     def test_empty_logs_print_nothing(self):
         manager = Mock()
         manager.get_service_logs.return_value = ""
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_service_log_streamer(manager, fqn)
 
         with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            streamer()
+            _log_service_logs(manager, fqn)
             mock_log.info.assert_not_called()
 
     def test_exception_is_swallowed(self):
         manager = Mock()
         manager.get_service_logs.side_effect = RuntimeError("connection lost")
         fqn = FQN.from_string("DB.SCHEMA.MY_APP")
-        streamer = _make_service_log_streamer(manager, fqn)
 
-        streamer()  # should not raise
+        _log_service_logs(manager, fqn)  # should not raise
 
 
 # ── _generate_snowflake_yml tests ─────────────────────────────────────
@@ -3526,12 +3506,18 @@ class TestDeployCommand:
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.create_app_service.side_effect = create_error
+        mock_mgr.get_service_logs.return_value = (
+            "create failed line1\ncreate failed line2"
+        )
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
         }
 
-        with change_directory(tmp_path):
+        with (
+            change_directory(tmp_path),
+            patch("snowflake.cli._plugins.apps.commands.log") as mock_log,
+        ):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
             result = runner.invoke(["app", "deploy", "--deploy-only"])
@@ -3542,6 +3528,12 @@ class TestDeployCommand:
             assert "Verify privileges for CREATE" in result.output
             create_span = _get_completed_span("snowflake_app.deploy_service.create")
             assert create_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
+            mock_log.info.assert_any_call("create failed line1")
+            mock_log.info.assert_any_call("create failed line2")
+
+        mock_mgr.get_service_logs.assert_called_once()
+        service_fqn = mock_mgr.get_service_logs.call_args.args[0]
+        assert service_fqn.identifier == "TEST_DB.TEST_SCHEMA.MY_APP"
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3597,12 +3589,18 @@ class TestDeployCommand:
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.create_app_service.side_effect = create_error
         mock_mgr.upgrade_app_service.side_effect = upgrade_error
+        mock_mgr.get_service_logs.return_value = (
+            "upgrade failed line1\nupgrade failed line2"
+        )
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
         }
 
-        with change_directory(tmp_path):
+        with (
+            change_directory(tmp_path),
+            patch("snowflake.cli._plugins.apps.commands.log") as mock_log,
+        ):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
             result = runner.invoke(["app", "deploy", "--deploy-only"])
@@ -3614,6 +3612,12 @@ class TestDeployCommand:
             upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
             assert create_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
             assert upgrade_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
+            mock_log.info.assert_any_call("upgrade failed line1")
+            mock_log.info.assert_any_call("upgrade failed line2")
+
+        mock_mgr.get_service_logs.assert_called_once()
+        service_fqn = mock_mgr.get_service_logs.call_args.args[0]
+        assert service_fqn.identifier == "TEST_DB.TEST_SCHEMA.MY_APP"
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3636,7 +3640,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_wait_uses_service_log_streamer_and_fqn_log_hint(
+    def test_deploy_wait_does_not_stream_service_logs_on_success(
         self,
         mock_resolve,
         mock_get_entity,
@@ -3662,7 +3666,6 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_service_logs.return_value = "line1\nline2"
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -3676,19 +3679,12 @@ class TestDeployCommand:
         _, kwargs = mock_poll.call_args
         assert (
             kwargs["timeout_message"]
-            == "Application service deployment timed out. Check logs:\n"
+            == "Application service deployment timed out. Check application service state and logs:\n"
+            "  DESCRIBE APPLICATION SERVICE TEST_DB.TEST_SCHEMA.MY_APP\n"
             "  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
         )
-        assert callable(kwargs["on_poll"])
-
-        with patch("snowflake.cli._plugins.apps.commands.log") as mock_log:
-            kwargs["on_poll"]()
-
-        mock_mgr.get_service_logs.assert_called_once()
-        service_fqn = mock_mgr.get_service_logs.call_args.args[0]
-        assert service_fqn.identifier == "TEST_DB.TEST_SCHEMA.MY_APP"
-        mock_log.info.assert_any_call("line1")
-        mock_log.info.assert_any_call("line2")
+        assert "on_poll" not in kwargs
+        mock_mgr.get_service_logs.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.manager.time.sleep")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3737,7 +3733,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.get_service_logs.return_value = ""
+        mock_mgr.get_service_logs.return_value = "failed line1\nfailed line2"
         mock_mgr.resolve_application_service_url_from_describe.return_value = None
         mock_mgr.describe_app_service.return_value = {
             "status": "FAILED",
@@ -3745,18 +3741,32 @@ class TestDeployCommand:
             "is_upgrading": "false",
         }
 
-        with change_directory(tmp_path):
+        with (
+            change_directory(tmp_path),
+            patch("snowflake.cli._plugins.apps.commands.log") as mock_log,
+        ):
             _write_snowflake_app_yml(tmp_path)
             result = runner.invoke(["app", "deploy", "--deploy-only"])
 
         assert result.exit_code == 1
-        assert "Application service deployment failed. Check logs:" in result.output
+        assert "Application service deployment failed." in result.output
+        assert "Check application service state and" in result.output
+        assert "logs:" in result.output
+        assert (
+            "DESCRIBE APPLICATION SERVICE TEST_DB.TEST_SCHEMA.MY_APP" in result.output
+        )
         assert (
             "CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
             in result.output
         )
         assert "timed out" not in result.output
         assert "Endpoint provisioning" not in result.output
+        mock_log.info.assert_any_call("failed line1")
+        mock_log.info.assert_any_call("failed line2")
+
+        mock_mgr.get_service_logs.assert_called_once()
+        service_fqn = mock_mgr.get_service_logs.call_args.args[0]
+        assert service_fqn.identifier == "TEST_DB.TEST_SCHEMA.MY_APP"
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -3821,9 +3831,13 @@ class TestDeployCommand:
 
         _, kwargs = mock_poll.call_args
         assert (
-            kwargs["timeout_message"] == "Upgrade timed out. Check logs:\n"
+            kwargs["timeout_message"]
+            == "Upgrade timed out. Check application service state and logs:\n"
+            "  DESCRIBE APPLICATION SERVICE TEST_DB.TEST_SCHEMA.MY_APP\n"
             "  CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('TEST_DB.TEST_SCHEMA.MY_APP')"
         )
+        assert "on_poll" not in kwargs
+        mock_mgr.get_service_logs.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- print verbose application service logs on failed service create/upgrade paths by calling `SYSTEM$GET_APPLICATION_SERVICE_LOGS`
- report FAILED application services as deployment failures instead of endpoint provisioning timeouts
