### PR TITLE
Snowflake Apps: Verify snow app teardown drops the real application service

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -841,7 +841,7 @@ def snowflake_app_teardown(
 
     app_name = fqn.name
     service_fqn = FQN(database=db, schema=schema, name=app_name)
-    use_artifact_repo = entity.artifact_repository is not None
+    is_application_service = manager.is_application_service(service_fqn)
 
     use_workspace = entity.code_workspace is not None
     if use_workspace:
@@ -859,7 +859,38 @@ def snowflake_app_teardown(
     storage_fqn = FQN(database=storage_db, schema=storage_schema, name=storage_name)
     build_job_fqn = FQN(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
 
-    object_kind = "application service" if use_artifact_repo else "service"
+    object_kind = "application service" if is_application_service else "service"
+
+    def _app_service_still_exists() -> bool:
+        try:
+            if manager.describe_app_service(service_fqn):
+                return True
+        except ProgrammingError:
+            pass
+        return manager.get_service_status(service_fqn) != "IDLE"
+
+    def _verify_service_drop() -> None:
+        try:
+            still_exists = (
+                _app_service_still_exists()
+                if is_application_service
+                else manager.get_service_status(service_fqn) != "IDLE"
+            )
+        except Exception as err:
+            raise CliError(
+                f"Could not verify {object_kind} {service_fqn.identifier} was dropped: {err}"
+            ) from err
+
+        if still_exists:
+            if is_application_service:
+                raise CliError(
+                    f"Failed to drop application service {service_fqn.identifier}. "
+                    f"Check: DESCRIBE APPLICATION SERVICE {service_fqn.identifier}"
+                )
+            raise CliError(
+                f"Failed to drop service {service_fqn.identifier}. "
+                f"Check: SHOW SERVICES IN SCHEMA {service_fqn.prefix}"
+            )
 
     if not force:
         should_continue = typer.confirm(
@@ -871,10 +902,11 @@ def snowflake_app_teardown(
 
     cli_console.step(f"Dropping {object_kind} {service_fqn.identifier}")
     with metrics.span("snowflake_app.teardown.drop_service"):
-        if use_artifact_repo:
+        if is_application_service:
             manager.drop_app_service_if_exists(service_fqn)
         else:
             manager.drop_service_if_exists(service_fqn)
+        _verify_service_drop()
 
     if use_workspace:
         # The workspace may be shared across apps (e.g. the default
@@ -890,7 +922,7 @@ def snowflake_app_teardown(
         with metrics.span("snowflake_app.teardown.drop_stage"):
             manager.drop_stage_if_exists(storage_fqn)
 
-    if not use_artifact_repo:
+    if not is_application_service:
         cli_console.step(f"Dropping build job service {build_job_fqn.identifier}")
         with metrics.span("snowflake_app.teardown.drop_build_job"):
             manager.drop_service_if_exists(build_job_fqn)

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -4992,3 +4992,115 @@ class TestDeployCommand:
 
         _, create_kwargs = mock_mgr.create_app_service.call_args
         assert create_kwargs["compute_pool"] == "YML_SVC_POOL"
+
+
+class TestTeardownCommand:
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_detects_application_service_and_drops_it(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_application_service.return_value = True
+        mock_mgr.describe_app_service.return_value = {}
+        mock_mgr.get_service_status.return_value = "IDLE"
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "teardown", "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            "Successfully dropped application service TEST_DB.TEST_SCHEMA.MY_APP."
+            in result.output
+        )
+        mock_mgr.drop_app_service_if_exists.assert_called_once_with(
+            FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
+        )
+        mock_mgr.drop_service_if_exists.assert_not_called()
+        mock_mgr.drop_stage_if_exists.assert_called_once_with(
+            FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP_CODE")
+        )
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_teardown_fails_when_application_service_still_exists(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_application_service.return_value = True
+        mock_mgr.describe_app_service.return_value = {"status": "READY"}
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            _reset_command_metrics()
+            result = runner.invoke(["app", "teardown", "--force"])
+
+        assert result.exit_code == 1
+        assert (
+            "Failed to drop application service TEST_DB.TEST_SCHEMA.MY_APP."
+            in result.output
+        )
+        assert "Successfully dropped" not in result.output
+        mock_mgr.drop_app_service_if_exists.assert_called_once_with(
+            FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
+        )
+        mock_mgr.drop_stage_if_exists.assert_not_called()
+        span = _get_completed_span("snowflake_app.teardown.drop_service")
+        assert span[CLIMetricsSpan.ERROR_KEY] == CliError.__name__


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.
   * [ ] I've described my changes in the documentation.

### Changes description
- detect the actual deployed service type during `snow app teardown` instead of inferring it from `artifact_repository`
- fail teardown before printing success when the target service still exists after the drop call
