### PR TITLE
Snowflake Apps: quote identifier components with special characters in FQN and USE statements

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -39,6 +39,7 @@ from snowflake.cli._plugins.apps.manager import (
     _poll_until,
     _resolve_deploy_defaults,
     _resolve_entity_id,
+    app_fqn,
     perform_bundle,
 )
 from snowflake.cli._plugins.connection.util import make_snowsight_url
@@ -330,7 +331,7 @@ def snowflake_app_open(
                 f".{identifier_for_url(schema)}"
                 f".{identifier_for_url(fqn.name)}"
             )
-            service_fqn = FQN(database=db, schema=schema, name=fqn.name)
+            service_fqn = app_fqn(database=db, schema=schema, name=fqn.name)
             manager = SnowflakeAppManager()
             segment = (
                 "app-service"
@@ -341,11 +342,7 @@ def snowflake_app_open(
                 ctx.connection, f"#/apps/{segment}/{app_id}/details"
             )
     else:
-        service_fqn = FQN(
-            database=db,
-            schema=schema,
-            name=fqn.name,
-        )
+        service_fqn = app_fqn(database=db, schema=schema, name=fqn.name)
 
         manager = SnowflakeAppManager()
         try:
@@ -377,7 +374,7 @@ def snowflake_app_events(
 
     fqn = entity.fqn
     # Rebuild to a 3-part name; entity FQN may carry extra fields (e.g. prefix)
-    service_fqn = FQN(database=fqn.database, schema=fqn.schema, name=fqn.name)
+    service_fqn = app_fqn(database=fqn.database, schema=fqn.schema, name=fqn.name)
 
     effective_last = last if last is not None else DEFAULT_SNOWFLAKE_APP_EVENTS_LAST
 
@@ -543,7 +540,9 @@ def snowflake_app_deploy(
     ar_name = defaults["artifact_repository"]
     ar_database = defaults["artifact_repo_database"]
     ar_schema = defaults["artifact_repo_schema"]
-    artifact_repo_fqn_str = f"{ar_database}.{ar_schema}.{ar_name}"
+    artifact_repo_fqn_str = app_fqn(
+        database=ar_database, schema=ar_schema, name=ar_name
+    ).identifier
 
     # ── Derived names ─────────────────────────────────────────────────
     # If the code storage was defined as a fully-qualified identifier
@@ -551,12 +550,12 @@ def snowflake_app_deploy(
     # to the app's resolved database/schema for backwards-compatibility
     # with entities that configure ``code_stage``/``code_workspace`` as a
     # bare name.
-    storage_fqn = FQN(
+    storage_fqn = app_fqn(
         database=storage_db_override or database,
         schema=storage_schema_override or schema,
         name=storage_name,
     )
-    service_fqn = FQN(database=database, schema=schema, name=app_name)
+    service_fqn = app_fqn(database=database, schema=schema, name=app_name)
     workspace_source_uri = manager.workspace_subdirectory_uri(storage_fqn, app_name)
 
     stage_manager = StageManager()
@@ -840,7 +839,7 @@ def snowflake_app_teardown(
         )
 
     app_name = fqn.name
-    service_fqn = FQN(database=db, schema=schema, name=app_name)
+    service_fqn = app_fqn(database=db, schema=schema, name=app_name)
     is_application_service = manager.is_application_service(service_fqn)
 
     use_workspace = entity.code_workspace is not None
@@ -856,8 +855,8 @@ def snowflake_app_teardown(
         storage_name = f"{app_name}_CODE"
         storage_db, storage_schema = db, schema
 
-    storage_fqn = FQN(database=storage_db, schema=storage_schema, name=storage_name)
-    build_job_fqn = FQN(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
+    storage_fqn = app_fqn(database=storage_db, schema=storage_schema, name=storage_name)
+    build_job_fqn = app_fqn(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")
 
     object_kind = "application service" if is_application_service else "service"
 

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -41,6 +41,7 @@ from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.exceptions import CliError
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.project_paths import ProjectPaths
+from snowflake.cli.api.project.util import to_identifier
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.utils.path_utils import resolve_without_follow
@@ -48,6 +49,41 @@ from snowflake.connector.cursor import DictCursor
 from snowflake.connector.errors import ProgrammingError
 
 log = logging.getLogger(__name__)
+
+
+def app_fqn(
+    *,
+    database: Optional[str] = None,
+    schema: Optional[str] = None,
+    name: str,
+) -> FQN:
+    """Build an :class:`FQN` with each component pre-quoted when needed.
+
+    Snowflake App Runtime entities frequently target *personal databases*
+    whose names contain characters illegal in unquoted identifiers — e.g.
+    ``USER$first.last@domain.com``. ``FQN.identifier`` (and via it
+    ``sql_identifier`` / ``prefix``) joins the components with literal
+    dots, so without per-component quoting the server parses the result
+    as several dot-separated identifiers and fails with ``invalid
+    identifier`` / ``syntax error``.
+
+    Routing each component through :func:`to_identifier` at construction
+    time stores the already-quoted form on the FQN, so every downstream
+    ``fqn.identifier`` / ``fqn.sql_identifier`` / ``fqn.prefix`` access
+    produces valid SQL with zero changes to the SQL emission methods.
+    :func:`to_identifier` is a no-op for names that are already valid
+    (quoted or unquoted), so plain identifiers like ``DB.SCHEMA.OBJ`` are
+    unchanged.
+
+    The shared ``FQN`` API in :mod:`snowflake.cli.api.identifiers` is left
+    untouched — this fix is scoped to the snowflake-app plugin.
+    """
+    return FQN(
+        database=to_identifier(str(database)) if database else None,
+        schema=to_identifier(str(schema)) if schema else None,
+        name=to_identifier(str(name)),
+    )
+
 
 DEFINITION_FILENAME = "snowflake.yml"
 SNOWFLAKE_APP_ENTITY_TYPE = "snowflake-app"
@@ -804,18 +840,26 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
     @contextmanager
     def _use_database_and_schema(self, database: str, schema: str):
-        """Temporarily set session database and schema, restoring previous values on exit."""
+        """Temporarily set session database and schema, restoring previous values on exit.
+
+        Names that contain characters illegal in unquoted identifiers
+        (e.g. personal databases like ``USER$first.last@domain.com``) are
+        wrapped in double quotes via :func:`to_identifier`. The previous
+        values returned by ``CURRENT_DATABASE()`` / ``CURRENT_SCHEMA()``
+        are also routed through ``to_identifier`` since they come back
+        as raw, unquoted strings.
+        """
         prev_db = self.execute_query("SELECT CURRENT_DATABASE()").fetchone()[0]
         prev_schema = self.execute_query("SELECT CURRENT_SCHEMA()").fetchone()[0]
-        self.execute_query(f"USE DATABASE {database}")
-        self.execute_query(f"USE SCHEMA {schema}")
+        self.execute_query(f"USE DATABASE {to_identifier(database)}")
+        self.execute_query(f"USE SCHEMA {to_identifier(schema)}")
         try:
             yield
         finally:
             if prev_db:
-                self.execute_query(f"USE DATABASE {prev_db}")
+                self.execute_query(f"USE DATABASE {to_identifier(prev_db)}")
                 if prev_schema:
-                    self.execute_query(f"USE SCHEMA {prev_schema}")
+                    self.execute_query(f"USE SCHEMA {to_identifier(prev_schema)}")
 
     @staticmethod
     def _build_artifact_repo_config(
@@ -850,7 +894,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         Uses IF NOT EXISTS so concurrent invocations (e.g. parallel CI
         jobs) don't race on the CREATE after both pass the existence check.
         """
-        fqn = FQN(database=database, schema=schema, name=repo_name)
+        fqn = app_fqn(database=database, schema=schema, name=repo_name)
         self.execute_query(
             f"CREATE ARTIFACT REPOSITORY IF NOT EXISTS {fqn.sql_identifier} TYPE=APPLICATION"
         )
@@ -888,6 +932,26 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
         with self._use_database_and_schema(database, schema):
             config = self._build_artifact_repo_config(build_eai)
+            log.info(
+                "Calling SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO with arguments:\n"
+                "  source_uri=%r\n"
+                "  artifact_repo_fqn=%r\n"
+                "  app_id=%r\n"
+                "  compute_pool=%r\n"
+                "  runtime_image=%r\n"
+                "  project_type=%r\n"
+                "  config=%s\n"
+                "  (session database=%r, schema=%r)",
+                source_uri,
+                artifact_repo_fqn,
+                app_id,
+                compute_pool or "",
+                runtime_image,
+                project_type,
+                config,
+                database,
+                schema,
+            )
             query = (
                 f"SELECT SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO("
                 f"{to_string_literal(source_uri)}, "

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -30,6 +30,7 @@ from snowflake.cli._plugins.apps.manager import (
     _object_exists,
     _poll_until,
     _resolve_entity_id,
+    app_fqn,
     perform_bundle,
 )
 from snowflake.cli.api.cli_global_context import get_cli_context_manager
@@ -788,6 +789,75 @@ class TestSchemaExists:
         assert SnowflakeAppManager().schema_exists("MY_DB", "NO_SUCH") is False
 
 
+class TestAppFqn:
+    """``app_fqn`` is the apps-plugin FQN factory: it routes each component
+    through :func:`to_identifier` so the resulting FQN's ``identifier`` /
+    ``sql_identifier`` / ``prefix`` produce valid SQL even for personal
+    databases (``USER$first.last@domain.com``) and other components with
+    characters illegal in unquoted Snowflake identifiers.
+
+    The shared :class:`FQN` API is intentionally untouched, so the apps
+    plugin opts in by constructing FQNs through this factory at the
+    handful of entry points where database / schema / name strings cross
+    into apps code.
+    """
+
+    @pytest.mark.parametrize(
+        "database, schema, name, expected_identifier",
+        [
+            # No-regression: plain unquoted names pass through unchanged.
+            ("DB", "SCHEMA", "OBJ", "DB.SCHEMA.OBJ"),
+            ("USER$ADMIN", "APPS", "MY_APP", "USER$ADMIN.APPS.MY_APP"),
+            # Personal databases — dotted + ``@``.
+            (
+                "USER$GUY.BLOOM@SNOWFLAKE.COM",
+                "APPS",
+                "MY_APP",
+                '"USER$GUY.BLOOM@SNOWFLAKE.COM".APPS.MY_APP',
+            ),
+            (
+                "USER$guy.bloom@snowflake.com",
+                "APPS",
+                "MY_APP",
+                '"USER$guy.bloom@snowflake.com".APPS.MY_APP',
+            ),
+            # Dotted schema and dotted name should also be quoted.
+            ("DB", "dotted.schema", "MY_APP", 'DB."dotted.schema".MY_APP'),
+            ("DB", "APPS", "dotted.name", 'DB.APPS."dotted.name"'),
+            # Already-quoted components are passed through unchanged.
+            ('"already.quoted"', "APPS", "MY_APP", '"already.quoted".APPS.MY_APP'),
+            # Optional database / schema.
+            (None, "SCHEMA", "MY_APP", "SCHEMA.MY_APP"),
+            (None, None, "MY_APP", "MY_APP"),
+        ],
+    )
+    def test_identifier(self, database, schema, name, expected_identifier):
+        fqn = app_fqn(database=database, schema=schema, name=name)
+        assert fqn.identifier == expected_identifier
+
+    def test_sql_identifier_quotes_personal_database(self):
+        fqn = app_fqn(
+            database="USER$GUY.BLOOM@SNOWFLAKE.COM",
+            schema="APPS",
+            name="SNOWFLAKE_APPS",
+        )
+        assert fqn.sql_identifier == (
+            "IDENTIFIER('\"USER$GUY.BLOOM@SNOWFLAKE.COM\".APPS.SNOWFLAKE_APPS')"
+        )
+
+    def test_sql_identifier_no_regression_for_simple_names(self):
+        fqn = app_fqn(database="DB", schema="SCHEMA", name="OBJ")
+        assert fqn.sql_identifier == "IDENTIFIER('DB.SCHEMA.OBJ')"
+
+    def test_prefix_quotes_personal_database(self):
+        fqn = app_fqn(
+            database="USER$guy.bloom@snowflake.com",
+            schema="APPS",
+            name="X",
+        )
+        assert fqn.prefix == '"USER$guy.bloom@snowflake.com".APPS'
+
+
 class TestSnowflakeAppManager:
     @patch(EXECUTE_QUERY)
     def test_stage_exists_returns_true(self, mock_execute):
@@ -1015,6 +1085,150 @@ class TestSnowflakeAppManager:
         restore_schema_idx = queries.index("USE SCHEMA PREV_SCHEMA")
         assert restore_db_idx > spcs_idx
         assert restore_schema_idx > restore_db_idx
+
+    @patch(EXECUTE_QUERY)
+    def test_use_database_and_schema_quotes_personal_database(self, mock_execute):
+        """Personal databases like ``USER$guy.bloom@snowflake.com`` contain
+        dots and ``@`` so the ``USE DATABASE`` / ``USE SCHEMA`` statements
+        emitted by ``_use_database_and_schema`` must wrap them in double
+        quotes. Without the quoting Snowflake parses the value as multiple
+        identifier parts and fails with ``invalid identifier`` /
+        ``syntax error``.
+        """
+        cursor = Mock()
+        cursor.fetchone.side_effect = [
+            (None,),  # CURRENT_DATABASE() — no previous session DB
+            (None,),  # CURRENT_SCHEMA()
+            None,  # USE DATABASE
+            None,  # USE SCHEMA
+            ("Build job submitted: DB.SCHEMA.JOB",),
+        ]
+        mock_execute.return_value = cursor
+
+        stage_fqn = FQN(database="DB", schema="APPS", name="STAGE")
+        SnowflakeAppManager().build_app_artifact_repo(
+            stage_fqn=stage_fqn,
+            artifact_repo_fqn='"USER$guy.bloom@snowflake.com".APPS.IMAGE_REPO',
+            app_id="my_app",
+            compute_pool="BUILD_POOL",
+            database="USER$guy.bloom@snowflake.com",
+            schema="APPS",
+            runtime_image="runtime:latest",
+        )
+        queries = [c[0][0] for c in mock_execute.call_args_list]
+        assert (
+            'USE DATABASE "USER$guy.bloom@snowflake.com"' in queries
+        ), f"Expected quoted USE DATABASE, got queries: {queries}"
+        assert "USE SCHEMA APPS" in queries
+
+    @patch(EXECUTE_QUERY)
+    def test_use_database_and_schema_quotes_personal_database_on_restore(
+        self, mock_execute
+    ):
+        """``CURRENT_DATABASE()`` / ``CURRENT_SCHEMA()`` return the raw
+        (unquoted) identifier, so the restore-session ``USE DATABASE`` /
+        ``USE SCHEMA`` must quote the previous values too — otherwise we
+        crash *after* the build with the same parser error.
+        """
+        cursor = Mock()
+        cursor.fetchone.side_effect = [
+            ("USER$guy.bloom@snowflake.com",),  # CURRENT_DATABASE()
+            ("dotted.schema",),  # CURRENT_SCHEMA()
+            None,  # USE DATABASE
+            None,  # USE SCHEMA
+            ("Build job submitted: DB.SCHEMA.JOB",),
+            None,  # restore USE DATABASE
+            None,  # restore USE SCHEMA
+        ]
+        mock_execute.return_value = cursor
+
+        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
+        SnowflakeAppManager().build_app_artifact_repo(
+            stage_fqn=stage_fqn,
+            artifact_repo_fqn="DB.SCHEMA.REPO",
+            app_id="my_app",
+            compute_pool="BUILD_POOL",
+            database="DB",
+            schema="SCHEMA",
+            runtime_image="runtime:latest",
+        )
+        queries = [c[0][0] for c in mock_execute.call_args_list]
+        assert 'USE DATABASE "USER$guy.bloom@snowflake.com"' in queries
+        assert 'USE SCHEMA "dotted.schema"' in queries
+
+    @patch(EXECUTE_QUERY)
+    def test_build_app_artifact_repo_logs_arguments(self, mock_execute, caplog):
+        """``--verbose`` users need to see the resolved arguments handed to
+        ``SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`` so they can diagnose
+        quoting / escaping / config issues without re-running with
+        ``--debug`` and reading raw connector logs."""
+        import logging
+
+        cursor = Mock()
+        cursor.fetchone.side_effect = [
+            (None,),
+            (None,),
+            None,
+            None,
+            ("Build job submitted: DB.SCHEMA.JOB",),
+        ]
+        mock_execute.return_value = cursor
+
+        stage_fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
+        with caplog.at_level(
+            logging.INFO, logger="snowflake.cli._plugins.apps.manager"
+        ):
+            SnowflakeAppManager().build_app_artifact_repo(
+                stage_fqn=stage_fqn,
+                artifact_repo_fqn="DB.SCHEMA.REPO",
+                app_id="my_app",
+                compute_pool="BUILD_POOL",
+                database="DB",
+                schema="SCHEMA",
+                runtime_image="runtime:latest",
+                build_eai="MY_EAI",
+                project_type="nodejs",
+            )
+
+        log_record = next(
+            (
+                r
+                for r in caplog.records
+                if "SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO" in r.getMessage()
+            ),
+            None,
+        )
+        assert log_record is not None, (
+            f"No SPCS_TEST_BUILD_APP_ARTIFACT_REPO log emitted; "
+            f"got: {[r.getMessage() for r in caplog.records]}"
+        )
+        assert log_record.levelno == logging.INFO
+        msg = log_record.getMessage()
+        assert "source_uri='@DB.SCHEMA.STAGE'" in msg
+        assert "artifact_repo_fqn='DB.SCHEMA.REPO'" in msg
+        assert "app_id='my_app'" in msg
+        assert "compute_pool='BUILD_POOL'" in msg
+        assert "runtime_image='runtime:latest'" in msg
+        assert "project_type='nodejs'" in msg
+        assert "MY_EAI" in msg
+        assert "database='DB'" in msg
+        assert "schema='SCHEMA'" in msg
+
+    @patch(EXECUTE_QUERY)
+    def test_create_artifact_repo_quotes_personal_database(self, mock_execute):
+        """``create_artifact_repo`` builds its FQN via :func:`app_fqn` so a
+        personal database name is wrapped in double quotes before being
+        embedded in ``IDENTIFIER('...')``."""
+        SnowflakeAppManager().create_artifact_repo(
+            database="USER$guy.bloom@snowflake.com",
+            schema="APPS",
+            repo_name="MY_APP_REPO",
+        )
+        mock_execute.assert_called_once_with(
+            "CREATE ARTIFACT REPOSITORY IF NOT EXISTS "
+            "IDENTIFIER('\"USER$guy.bloom@snowflake.com\".APPS.MY_APP_REPO') "
+            "TYPE=APPLICATION"
+        )
 
     @patch(EXECUTE_QUERY)
     def test_create_app_service_generates_correct_sql(self, mock_execute):
@@ -3974,6 +4188,115 @@ class TestDeployCommand:
             comment='{"appId": "MY_APP"}',
         )
         assert mock_poll.call_count == 2
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "USER$guy.bloom@snowflake.com",
+            "schema": "APPS",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "USER$guy.bloom@snowflake.com",
+            "artifact_repo_schema": "APPS",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_quotes_personal_database_in_artifact_repo_fqn(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """When the resolved deploy defaults point at a personal database
+        (e.g. ``USER$first.last@domain.com``), the ``artifact_repo_fqn``
+        string forwarded to ``build_app_artifact_repo`` and
+        ``create_app_service`` must wrap the database in double quotes.
+        ``SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`` parses this string
+        server-side as a Snowflake identifier; without quoting the dots
+        in the email cause the parser to interpret it as a 5-part name.
+        """
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "USER$guy.bloom@snowflake.com"
+        fqn.schema = "APPS"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = Mock(database=None, schema_=None)
+        entity.code_workspace.name = "MY_APP_CODE"
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = "runtime:latest"
+        entity.query_warehouse = "WH"
+        entity.build_image = None
+        entity.execute_as_caller = False
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        project_paths = ProjectPaths(project_root=tmp_path)
+        mock_perform_bundle.return_value = project_paths
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
+            _WORKSPACE_BUILD_SOURCE_URI
+        )
+        mock_mgr.artifact_repo_exists.return_value = True
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: DB.SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {
+                "url": "my-app.snowflakecomputing.app",
+                "is_upgrading": "false",
+            },
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+
+        expected_repo_fqn = '"USER$guy.bloom@snowflake.com".APPS.MY_APP_REPO'
+        build_kwargs = mock_mgr.build_app_artifact_repo.call_args.kwargs
+        assert build_kwargs["artifact_repo_fqn"] == expected_repo_fqn
+        # The session DB/schema are still passed unquoted because
+        # ``_use_database_and_schema`` quotes them itself before issuing
+        # the ``USE`` statements.
+        assert build_kwargs["database"] == "USER$guy.bloom@snowflake.com"
+        assert build_kwargs["schema"] == "APPS"
+        create_kwargs = mock_mgr.create_app_service.call_args.kwargs
+        assert create_kwargs["artifact_repo_fqn"] == expected_repo_fqn
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")


### PR DESCRIPTION
### Pre-review checklist

- [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
- [x] I've added or updated automated unit tests to verify correctness of my new code.
- [ ] I've added or updated integration tests to verify correctness of my new code.
- [x] I've confirmed that my changes are working by executing CLI's commands manually on MacOS.
- [ ] I've confirmed that my changes are working by executing CLI's commands manually on Windows.
- [x] I've confirmed that my changes are up-to-date with the target branch.
- [ ] I've described my changes in the release notes.
- [x] I've described my changes in the section below.
- [ ] I've described my changes in the documentation.

### Changes description

Personal databases like `USER$first.last@domain.com` (and any database/schema/name containing dots, `@`, or other characters illegal in unquoted Snowflake identifiers) caused `snow app deploy` to fail with `invalid identifier` and `syntax error` errors because the raw, unquoted name was interpolated directly into SQL.

Three fixes:

1. New `app_fqn(database=, schema=, name=)` factory in `apps/manager.py` pre-routes each component through `to_identifier()` (a no-op for already-valid names) so every downstream `fqn.identifier` / `fqn.sql_identifier` / `fqn.prefix` produces valid SQL. Apps-side `FQN(...)` constructions in `commands.py` and `manager.py::create_artifact_repo` now go through this factory.
2. `_use_database_and_schema` wraps both the target and the restored `CURRENT_DATABASE()` / `CURRENT_SCHEMA()` values via `to_identifier()`. Previously the `USE DATABASE` / `USE SCHEMA` statements crashed at the parser when the database name contained `@` or dots.
3. `artifact_repo_fqn_str` is now built via `app_fqn(...).identifier` so the string forwarded to `SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO` and `CREATE APPLICATION SERVICE ... FROM ARTIFACT REPOSITORY ...` is properly quoted server-side.
