### PR TITLE
Snowflake Apps: fix recording ProgrammingError on `deploy_service.create` span for redeploys

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -715,17 +715,28 @@ def snowflake_app_deploy(
     with metrics.span("snowflake_app.deploy_service"):
         cli_console.step("Creating application service...")
         try:
-            with metrics.span("snowflake_app.deploy_service.create"):
-                manager.create_app_service(
-                    service_fqn=service_fqn,
-                    artifact_repo_fqn=artifact_repo_fqn_str,
-                    package_name=app_name,
-                    compute_pool=service_compute_pool,
-                    version="LATEST",
-                    query_warehouse=query_warehouse,
-                    external_access_integrations=eai_list,
-                    comment=app_comment,
-                )
+            with metrics.span("snowflake_app.deploy_service.create") as create_span:
+                try:
+                    manager.create_app_service(
+                        service_fqn=service_fqn,
+                        artifact_repo_fqn=artifact_repo_fqn_str,
+                        package_name=app_name,
+                        compute_pool=service_compute_pool,
+                        version="LATEST",
+                        query_warehouse=query_warehouse,
+                        external_access_integrations=eai_list,
+                        comment=app_comment,
+                    )
+                except ProgrammingError as e:
+                    # "Already exists" is the expected re-deploy path: the
+                    # outer handler dispatches to ALTER ... UPGRADE. Finish
+                    # the Create span successfully so telemetry doesn't
+                    # double-count every redeploy as a ProgrammingError on
+                    # this span; the recovery is recorded by
+                    # ``deploy_service.upgrade`` instead.
+                    if e.errno == 2002 and "already exists" in str(e).lower():
+                        create_span.finish()
+                    raise
         except ProgrammingError as e:
             if e.errno == 2002 and "already exists" in str(e).lower():
                 cli_console.step(

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -3824,7 +3824,10 @@ class TestDeployCommand:
             )
             create_span = _get_completed_span("snowflake_app.deploy_service.create")
             upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
-            assert create_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
+            # The "already exists" ProgrammingError on CREATE is an
+            # expected redeploy signal, not a failure of the Create step;
+            # only the upgrade span should record the failure.
+            assert create_span[CLIMetricsSpan.ERROR_KEY] is None
             assert upgrade_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
             mock_log.info.assert_any_call("upgrade failed line1")
             mock_log.info.assert_any_call("upgrade failed line2")
@@ -4040,8 +4043,13 @@ class TestDeployCommand:
 
         with change_directory(tmp_path):
             _write_snowflake_app_yml(tmp_path)
+            _reset_command_metrics()
             result = runner.invoke(["app", "deploy", "--deploy-only"])
             assert result.exit_code == 0, result.output
+            create_span = _get_completed_span("snowflake_app.deploy_service.create")
+            upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
+            assert create_span[CLIMetricsSpan.ERROR_KEY] is None
+            assert upgrade_span[CLIMetricsSpan.ERROR_KEY] is None
 
         _, kwargs = mock_poll.call_args
         assert (


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

The `snowflake_app.deploy_service.create` span wraps a raw `CREATE APPLICATION SERVICE` SQL call, and the surrounding code intentionally catches the "already exists" `ProgrammingError` (errno `2002`) so it can dispatch to `ALTER ... UPGRADE` instead. Because the `try / except` lived **outside** the `with metrics.span(...)` block, the span context manager recorded the exception on the Create span before it could be handled — marking *every* re-deploy of an existing app as a failed Create in telemetry, even though the command succeeded via the upgrade fallback. The reported error rate on this span was therefore dominated by the normal "redeploy" flow rather than real failures.

#### Fix

Catch the recoverable "already exists" case **inside** the span body and call `create_span.finish()` (no error) before re-raising. `CLIMetricsSpan.finish()` is idempotent, so the outer span context manager's `except BaseException as err: new_span.finish(error=err)` becomes a no-op and no error is attached. The existing outer handler still dispatches to `ALTER ... UPGRADE`, and real CREATE failures (non-2002 `ProgrammingError`s) still mark the Create span as errored.
