### PR TITLE
Snowflake Apps: drop meta.title from generated snowflake.yml

### DIFF
--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -108,8 +108,6 @@ def _generate_snowflake_yml(
               name: {app_id.upper()}
               database: {database}
               schema: {schema}
-            meta:
-              title: {app_id}
             artifacts:
               - src: ./*
                 dest: ./


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

Updating `snow app setup` to no longer emit `meta:` / `title:` in the generated `snowflake.yml`
