### PR TITLE
Snowflake Apps: preserve case of personal database name

### DIFF
--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -496,6 +496,15 @@ class SnowflakeAppManager(SqlExecutionMixin):
         Runs ``SELECT 'USER$' || CURRENT_USER() AS personal_database`` and
         returns the result.  Returns ``None`` when the query fails or the
         current user is not set (e.g. in unauthenticated contexts).
+
+        The case returned by ``CURRENT_USER()`` is preserved verbatim:
+        Snowflake folds unquoted usernames to upper case at creation,
+        but users created as quoted identifiers (e.g.
+        ``"first.last@domain.com"``) keep their original case, and so do
+        their personal databases (``USER$first.last@domain.com``). Since
+        :func:`app_fqn` later wraps this value in a case-sensitive quoted
+        identifier, normalizing case here would silently target the
+        wrong database for those users.
         """
         try:
             cursor = self.execute_query(
@@ -503,7 +512,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
             )
             row = cursor.fetchone()
             if row and row[0] and not row[0].endswith("$"):
-                return str(row[0]).upper()
+                return str(row[0])
         except Exception:
             log.warning("Could not resolve personal database.", exc_info=True)
         return None

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -860,6 +860,51 @@ class TestAppFqn:
 
 class TestSnowflakeAppManager:
     @patch(EXECUTE_QUERY)
+    def test_get_personal_database_preserves_case(self, mock_execute):
+        """Snowflake users created as quoted identifiers (e.g.
+        ``"first.last@domain.com"``) keep their original case, and so do
+        their personal databases (``USER$first.last@domain.com``). Because
+        :func:`app_fqn` later wraps the database in a *case-sensitive*
+        quoted identifier, ``get_personal_database`` must return the
+        value from ``CURRENT_USER()`` verbatim — folding it to upper case
+        would silently target a non-existent database for these users.
+        """
+        cursor = Mock()
+        cursor.fetchone.return_value = ("USER$guy.bloom@snowflake.com",)
+        mock_execute.return_value = cursor
+
+        assert (
+            SnowflakeAppManager().get_personal_database()
+            == "USER$guy.bloom@snowflake.com"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_get_personal_database_returns_uppercase_users_unchanged(
+        self, mock_execute
+    ):
+        """Unquoted Snowflake usernames are folded to upper case at
+        creation, so ``CURRENT_USER()`` already returns them in upper
+        case. Verify the normal path still works after dropping the
+        defensive ``.upper()`` call.
+        """
+        cursor = Mock()
+        cursor.fetchone.return_value = ("USER$ADMIN",)
+        mock_execute.return_value = cursor
+
+        assert SnowflakeAppManager().get_personal_database() == "USER$ADMIN"
+
+    @patch(EXECUTE_QUERY)
+    def test_get_personal_database_returns_none_when_user_missing(self, mock_execute):
+        """``CURRENT_USER()`` returns an empty string in unauthenticated
+        contexts, producing a bare ``USER$`` which is not a real database.
+        """
+        cursor = Mock()
+        cursor.fetchone.return_value = ("USER$",)
+        mock_execute.return_value = cursor
+
+        assert SnowflakeAppManager().get_personal_database() is None
+
+    @patch(EXECUTE_QUERY)
     def test_stage_exists_returns_true(self, mock_execute):
         fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
         assert SnowflakeAppManager().stage_exists(fqn) is True


### PR DESCRIPTION
### Pre-review checklist
  * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
  * [x] I've added or updated unit tests to verify correctness of my new code.
  * [ ] I've added or updated integration tests to verify correctness of my new code.
  * [x] Manually tested on macOS
  * [ ] Manually tested on Windows
  * [x] I've confirmed my changes are up-to-date with the target branch.
  * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
  * [ ] I've updated documentation if behavior changed.

### Changes description

`SnowflakeAppManager.get_personal_database` returned `('USER$' || CURRENT_USER()).upper()`, which silently breaks any Snowflake user whose login was created as a quoted, mixed/lower-case identifier (e.g. `"first.last@domain.com"`). For those users:

- The real personal database is `USER$first.last@domain.com`.
- `app_fqn` later wraps the value in a **case-sensitive** quoted identifier (`"USER$FIRST.LAST@DOMAIN.COM"`).
- As a result, every deploy-time statement that defaults to the personal DB — `CREATE WORKSPACE`, `USE DATABASE`, the artifact-repo `IDENTIFIER(...)` calls, etc. — silently targets a non-existent database and fails (or worse, creates a brand-new wrongly-cased database).

`CURRENT_USER()` already returns the value in whatever case Snowflake stores: uppercase-folded for unquoted users, original case for quoted users. The defensive `.upper()` is unnecessary for the common case and actively wrong for quoted-identifier users.
