### PR TITLE
ci: [NOSNOW] unblock doc-only PRs by replacing paths-ignore with a should-run gate

### DIFF
--- a/.github/workflows/changes.yaml
+++ b/.github/workflows/changes.yaml
@@ -1,0 +1,39 @@
+name: detect changes
+
+# Determines whether a PR changes anything that requires running the heavy test
+# matrix. The required-status-check jobs that consume `outputs.code` always run
+# (so the required check posts to the PR), but skip their expensive steps when
+# only docs/CODEOWNERS/etc. changed. This avoids the "skipped but required"
+# branch-protection deadlock that `paths-ignore` causes.
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: "true when the PR touches files that require running tests"
+        value: ${{ jobs.detect.outputs.code }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          # On push events paths-filter has nothing to compare against, so it
+          # falls back to "all changed" (i.e. true) which is the safe default.
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!.github/CODEOWNERS'

--- a/.github/workflows/changes.yaml
+++ b/.github/workflows/changes.yaml
@@ -14,8 +14,7 @@ on:
         value: ${{ jobs.detect.outputs.code }}
 
 permissions:
-  contents: read
-  pull-requests: read
+  contents: none
 
 jobs:
   detect:
@@ -26,14 +25,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          # On push events paths-filter has nothing to compare against, so it
-          # falls back to "all changed" (i.e. true) which is the safe default.
-          filters: |
-            code:
-              - '!**/*.md'
-              - '!docs/**'
-              - '!LICENSE'
-              - '!.github/CODEOWNERS'
+        # Anything other than pull_request (push, schedule, repository_dispatch,
+        # workflow_dispatch) gets code=true so the full pipeline runs as before.
+        # For pull_request events we diff against the PR base and check whether
+        # any changed file is outside the ignored set.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+          # code=true if any changed file falls outside the ignored set.
+          # Ignored: **/*.md, docs/**, LICENSE, .github/CODEOWNERS
+          if echo "$changed" | grep -Ev '(\.md$|^docs/|^LICENSE$|^\.github/CODEOWNERS$)' > /dev/null; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: ./.github/workflows/changes.yaml
   tests:
     needs: [define-matrix, changes]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -34,21 +35,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - if: needs.changes.outputs.code == 'true'
-        name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - if: needs.changes.outputs.code == 'true'
-        name: Install hatch
+      - name: Install hatch
         run: |
           pip install -U click==8.2.1 hatch==1.15.1 virtualenv==20.39.1
           hatch env create default
-      - if: needs.changes.outputs.code == 'true'
-        name: Test with hatch
+      - name: Test with hatch
         run: hatch run test-cov
-      - if: needs.changes.outputs.code == 'true'
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
+      - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
 
   # Temporarily disabled; re-enable once config v2 (NG) is ready.
   # tests-config-ng:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".github/CODEOWNERS"
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -25,8 +20,10 @@ permissions:
 jobs:
   define-matrix:
     uses: ./.github/workflows/matrix.yaml
+  changes:
+    uses: ./.github/workflows/changes.yaml
   tests:
-    needs: define-matrix
+    needs: [define-matrix, changes]
     strategy:
       fail-fast: true
       matrix:
@@ -37,17 +34,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Python ${{ matrix.python-version }}
+      - if: needs.changes.outputs.code == 'true'
+        name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install hatch
+      - if: needs.changes.outputs.code == 'true'
+        name: Install hatch
         run: |
           pip install -U click==8.2.1 hatch==1.15.1 virtualenv==20.39.1
           hatch env create default
-      - name: Test with hatch
+      - if: needs.changes.outputs.code == 'true'
+        name: Test with hatch
         run: hatch run test-cov
-      - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
+      - if: needs.changes.outputs.code == 'true'
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
 
   # Temporarily disabled; re-enable once config v2 (NG) is ready.
   # tests-config-ng:

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".github/CODEOWNERS"
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -31,9 +26,11 @@ permissions:
 jobs:
   define-matrix:
     uses: ./.github/workflows/matrix.yaml
+  changes:
+    uses: ./.github/workflows/changes.yaml
 
   e2e-trusted:
-    needs: define-matrix
+    needs: [define-matrix, changes]
     strategy:
       fail-fast: true
       matrix:
@@ -48,6 +45,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       python-env: e2e
       hatch-run: e2e:test
+      should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     secrets: inherit
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -37,15 +37,17 @@ jobs:
         os: ${{ fromJSON(needs.define-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      ) &&
+      (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
     uses: ./.github/workflows/test_trusted.yaml
     with:
       runs-on: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       python-env: e2e
       hatch-run: e2e:test
-      should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     secrets: inherit
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request

--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".github/CODEOWNERS"
   push:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -31,10 +26,12 @@ permissions:
 jobs:
   define-matrix:
     uses: ./.github/workflows/matrix.yaml
+  changes:
+    uses: ./.github/workflows/changes.yaml
 
   # Branch-based pull request
   integration-trusted:
-    needs: define-matrix
+    needs: [define-matrix, changes]
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +46,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       python-env: integration
       hatch-run: integration:test
+      should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     secrets: inherit
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request

--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -38,15 +38,17 @@ jobs:
         os: ${{ fromJSON(needs.define-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      ) &&
+      (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
     uses: ./.github/workflows/test_trusted.yaml
     with:
       runs-on: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       python-env: integration
       hatch-run: integration:test
-      should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     secrets: inherit
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request

--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -15,12 +15,6 @@ on:
       hatch-run:
         required: true
         type: string
-      should-run:
-        # Posts the required check as success but skips the heavy steps when
-        # the PR only touches paths that don't affect tests.
-        required: false
-        type: string
-        default: "true"
 
 permissions:
   contents: none
@@ -34,18 +28,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - if: inputs.should-run == 'true'
-        name: Set up Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
-      - if: inputs.should-run == 'true'
-        name: Install dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip click==8.2.1 hatch==1.15.1 virtualenv==20.39.1
           python -m hatch env create ${{ inputs.python-env }}
-      - if: inputs.should-run == 'true'
-        name: Run integration tests
+      - name: Run integration tests
         env:
           GH_TOKEN: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }}
           TERM: unknown

--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -15,6 +15,12 @@ on:
       hatch-run:
         required: true
         type: string
+      should-run:
+        # Posts the required check as success but skips the heavy steps when
+        # the PR only touches paths that don't affect tests.
+        required: false
+        type: string
+        default: "true"
 
 permissions:
   contents: none
@@ -28,15 +34,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Python
+      - if: inputs.should-run == 'true'
+        name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
-      - name: Install dependencies
+      - if: inputs.should-run == 'true'
+        name: Install dependencies
         run: |
           python -m pip install --upgrade pip click==8.2.1 hatch==1.15.1 virtualenv==20.39.1
           python -m hatch env create ${{ inputs.python-env }}
-      - name: Run integration tests
+      - if: inputs.should-run == 'true'
+        name: Run integration tests
         env:
           GH_TOKEN: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }}
           TERM: unknown


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
        * N/A — CI-only change with no user-visible effect.
   * [ ] I've updated documentation if behavior changed.

### Changes description

The `Testing`, `Integration testing` and `E2E testing` workflows use `paths-ignore` to skip PRs that only touch docs / `LICENSE` / `.github/CODEOWNERS`. The matrix-expanded jobs they produce (`tests (ubuntu-latest, 3.10)`, `integration-trusted (...) / tests-trusted`, `e2e-trusted (...) / tests-trusted`) are listed as **required** status checks on `main`. When a workflow is skipped via `paths-ignore`, GitHub does not post the matching required status check, so branch protection sees it as missing and `mergeStateStatus` stays `BLOCKED` forever.

Example: #3032 only modifies `.github/CODEOWNERS` and is unmergeable for this reason.

#### Approach

Drop `paths-ignore` from the trigger and replace it with an explicit `should-run` gate:

- New `changes.yaml` reusable workflow runs `dorny/paths-filter@v3.0.2` (pinned by SHA) and exposes a `code` output that is `true` whenever the PR touches anything that is **not** `**/*.md`, `docs/**`, `LICENSE`, or `.github/CODEOWNERS`.
- `test.yaml` always starts the `tests` matrix job, but each heavy step is gated by `if: needs.changes.outputs.code == 'true'`. The job still completes (and reports success), so the required check posts.
- `test_integration.yaml` and `test_e2e.yaml` always start their reusable callers and pass `should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}` to `test_trusted.yaml`. On non-PR events (`push`, `schedule`) the heavy work always runs, matching today's behavior.
- `test_trusted.yaml` gains a `should-run` input (default `"true"`) that gates Python setup / dependency install / test invocation.

#### What this means in practice

- Doc-only PRs (like #3032): required checks complete in seconds with no real work, PR becomes mergeable.
- Code PRs: behavior is unchanged — `paths-filter` returns `code=true`, all steps run.
- `push` / `schedule` runs: always run the full job, same as before.