### PR TITLE
docs: clarify --prune scope for streamlit deploy

### DIFF
--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -630,7 +630,7 @@ NoInteractiveOption = typer.Option(False, "--no-interactive", help="Disable prom
 PruneOption = OverrideableOption(
     False,
     "--prune/--no-prune",
-    help=f"Delete files that exist in the stage, but not in the local filesystem.",
+    help="Delete files that exist in the app's stage directory but not in the local filesystem. When multiple apps share the same stage, only the deployed app's files are affected.",
     show_default=True,
 )
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -23654,8 +23654,11 @@
   |                                    exists. It only uploads new and           |
   |                                    overwrites existing files, but does not   |
   |                                    remove any files already on the stage.    |
-  | --prune        --no-prune          Delete files that exist in the stage, but |
-  |                                    not in the local filesystem.              |
+  | --prune        --no-prune          Delete files that exist in the app's      |
+  |                                    stage directory but not in the local      |
+  |                                    filesystem. When multiple apps share the  |
+  |                                    same stage, only the deployed app's files |
+  |                                    are affected.                             |
   |                                    [default: no-prune]                       |
   | --open                             Whether to open the Streamlit app in a    |
   |                                    browser.                                  |


### PR DESCRIPTION
### Pre-review checklist
   * [ ] ~~If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).~~
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description

`snow streamlit deploy --prune` help text says "Delete files that exist in the stage, but not in the local filesystem." This is ambiguous — it implies the entire stage is pruned, when in fact pruning is scoped to the individual app's subdirectory (`@<stage>/<app-name>/`) … as far as I can tell. I used Cortex Code to inspect the code paths, and here was its explanation:

> Each app gets its own subdirectory within the shared streamlit stage, and --prune is scoped to that
> subdirectory. Here's the chain:
> 
> Default stage path per app (streamlit_entity.py):
> 
>   ```
>   stage_root = f"{self.model.stage}/{name}"
>   # → @streamlit/ccs_dashboard/
>   # → @streamlit/cr_timeliness/
>   # → @streamlit/mso_waitlist/
>   ```
> 
> `--prune` scope (`api/entities/utils.py` → `stage/diff.py`):
> 
>   ```
>   remote_files = stage_manager.list_files(stage_path.full_path)
>   # LIST @streamlit/ccs_dashboard  ← never sees other apps' files
>   ```
> 
> Deletions are also scoped to that same prefix, so app_b/ files are never listed, compared, or deleted
> when deploying app_a.
> 
> Bottom line: Your three apps are isolated by subdirectory, so --prune won't clobber them. My original
> answer was correct, just for the wrong stated reason — it's not a dedicated stage per app, it's a
> dedicated subdirectory within the shared streamlit stage.

Slightly difficult to troubleshoot, so **would love verification on this**.

This matters when multiple apps share the same default `streamlit` stage: users may avoid `--prune` unnecessarily, fearing it will delete other apps' files.

There could/should be tests for this, but to be honest, I don't have time to dig into that.

Thanks!