### PR TITLE
Add live phase-checklist progress for snow dcm deploy and plan

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -425,15 +425,18 @@ def purge(
     if not force:
         _confirm_purge(project_id)
 
-    with cli_console.spinner() as spinner:
-        spinner.add_task(description=f"Purging dcm project {project_id}", total=None)
-        if skip_plan:
-            cli_console.warning("Skipping planning step")
-        result = DCMProjectManager().purge(
+    if skip_plan:
+        cli_console.warning("Skipping planning step")
+
+    manager = DCMProjectManager()
+    tracker = DeployProgressTracker(conn=manager.connection, operation="purge")
+    with tracker.session():
+        sfqid = manager.purge_async(
             project_identifier=project_id,
             alias=alias,
             skip_plan=skip_plan,
         )
+        result = tracker.run_deploy_poll(sfqid)
 
     reporter = PlanReporter(save_output=save_output, command_name="purge")
     return reporter.process(result)

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -23,6 +23,7 @@ from snowflake.cli._plugins.dcm.exceptions import (
 )
 from snowflake.cli._plugins.dcm.manager import DCMProjectManager
 from snowflake.cli._plugins.dcm.models import DCMManifest, DCMTarget, TargetContext
+from snowflake.cli._plugins.dcm.progress import DeployProgressTracker
 from snowflake.cli._plugins.dcm.reporters import (
     AnalyzeReporter,
     PlanReporter,
@@ -336,17 +337,18 @@ def deploy(
     context = _resolve_context_with_required_manifest(from_location, identifier, target)
     project_id = context.project_identifier
 
-    manager = DCMProjectManager()
-    effective_stage = manager.sync_local_files(
-        project_identifier=project_id,
-        source_directory=str(from_location.path),
-    )
+    if skip_plan:
+        cli_console.warning("Skipping planning step")
 
-    with cli_console.spinner() as spinner:
-        spinner.add_task(description=f"Deploying dcm project {project_id}", total=None)
-        if skip_plan:
-            cli_console.warning("Skipping planning step")
-        result = manager.deploy(
+    manager = DCMProjectManager()
+    tracker = DeployProgressTracker(conn=manager.connection)
+    with tracker.session():
+        effective_stage = manager.sync_local_files(
+            project_identifier=project_id,
+            source_directory=str(from_location.path),
+            progress=tracker,
+        )
+        sfqid = manager.deploy_async(
             project_identifier=project_id,
             configuration=context.configuration,
             from_stage=effective_stage,
@@ -354,6 +356,7 @@ def deploy(
             alias=alias,
             skip_plan=skip_plan,
         )
+        result = tracker.run_deploy_poll(sfqid)
 
     reporter = PlanReporter(save_output=save_output, command_name="deploy")
     return reporter.process(result)
@@ -461,20 +464,24 @@ def plan(
     project_id = context.project_identifier
 
     manager = DCMProjectManager()
-    effective_stage = manager.sync_local_files(
-        project_identifier=project_id,
-        source_directory=str(from_location.path),
-    )
-
-    with cli_console.spinner() as spinner:
-        spinner.add_task(description=f"Planning dcm project {project_id}", total=None)
-        result = manager.plan(
+    tracker = DeployProgressTracker(conn=manager.connection, operation="plan")
+    with tracker.session():
+        effective_stage = manager.sync_local_files(
             project_identifier=project_id,
-            configuration=context.configuration,
-            from_stage=effective_stage,
-            variables=variables,
-            save_output=save_output,
-            delta=delta,
+            source_directory=str(from_location.path),
+            progress=tracker,
+        )
+        result = tracker.run_loader_phase(
+            lambda: manager.plan(
+                project_identifier=project_id,
+                configuration=context.configuration,
+                from_stage=effective_stage,
+                variables=variables,
+                save_output=save_output,
+                delta=delta,
+            ),
+            phase_name="PLAN",
+            simulated_phases=("RENDER", "COMPILE"),
         )
 
     reporter = PlanReporter(save_output=save_output, command_name="plan")

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -59,6 +59,24 @@ class DCMProjectManager(SqlExecutionMixin):
         """Exposes the underlying Snowflake connection."""
         return self._conn
 
+    def _build_deploy_query(
+        self,
+        project_identifier: FQN,
+        from_stage: str,
+        configuration: str | None,
+        variables: List[str] | None,
+        alias: str | None,
+        skip_plan: bool,
+    ) -> str:
+        query = f"EXECUTE DCM PROJECT {project_identifier.sql_identifier} DEPLOY"
+        if alias:
+            query += f' AS "{alias}"'
+        query += self._get_configuration_and_variables_query(configuration, variables)
+        query += self._get_from_stage_query(from_stage)
+        if skip_plan:
+            query += " SKIP PLAN"
+        return query
+
     def deploy(
         self,
         project_identifier: FQN,
@@ -75,14 +93,43 @@ class DCMProjectManager(SqlExecutionMixin):
             len(variables or []),
             skip_plan,
         )
-        query = f"EXECUTE DCM PROJECT {project_identifier.sql_identifier} DEPLOY"
-        if alias:
-            query += f' AS "{alias}"'
-        query += self._get_configuration_and_variables_query(configuration, variables)
-        query += self._get_from_stage_query(from_stage)
-        if skip_plan:
-            query += f" SKIP PLAN"
+        query = self._build_deploy_query(
+            project_identifier, from_stage, configuration, variables, alias, skip_plan
+        )
         return self.execute_query(query=query)
+
+    def deploy_async(
+        self,
+        project_identifier: FQN,
+        from_stage: str,
+        configuration: str | None = None,
+        variables: List[str] | None = None,
+        alias: str | None = None,
+        skip_plan: bool = False,
+    ) -> str:
+        """
+        Submits a deploy query asynchronously and returns the Snowflake query ID (sfqid).
+        Use with :class:`~snowflake.cli._plugins.dcm.progress.DeployProgressTracker`
+        to poll progress and obtain the final result cursor.
+        """
+        log.info(
+            "Submitting DCM deploy async (project_identifier=%s, has_configuration=%s, variables_count=%d, skip_plan=%s).",
+            project_identifier,
+            bool(configuration),
+            len(variables or []),
+            skip_plan,
+        )
+        query = self._build_deploy_query(
+            project_identifier, from_stage, configuration, variables, alias, skip_plan
+        )
+        cursor = self._conn.cursor()
+        cursor.execute_async(query)
+        log.info(
+            "DCM deploy async submitted (project_identifier=%s, sfqid=%s).",
+            project_identifier,
+            cursor.sfqid,
+        )
+        return cursor.sfqid
 
     def raw_analyze(
         self,

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -270,12 +270,47 @@ class DCMProjectManager(SqlExecutionMixin):
             project_identifier,
             skip_plan,
         )
+        query = self._build_purge_query(project_identifier, alias, skip_plan)
+        return self.execute_query(query=query)
+
+    def purge_async(
+        self,
+        project_identifier: FQN,
+        alias: str | None = None,
+        skip_plan: bool = False,
+    ) -> str:
+        """
+        Submits a purge query asynchronously and returns the Snowflake query ID (sfqid).
+        Use with :class:`~snowflake.cli._plugins.dcm.progress.DeployProgressTracker`
+        to poll progress and obtain the final result cursor.
+        """
+        log.info(
+            "Submitting DCM purge async (project_identifier=%s, skip_plan=%s).",
+            project_identifier,
+            skip_plan,
+        )
+        query = self._build_purge_query(project_identifier, alias, skip_plan)
+        cursor = self._conn.cursor()
+        cursor.execute_async(query)
+        log.info(
+            "DCM purge async submitted (project_identifier=%s, sfqid=%s).",
+            project_identifier,
+            cursor.sfqid,
+        )
+        return cursor.sfqid
+
+    @staticmethod
+    def _build_purge_query(
+        project_identifier: FQN,
+        alias: str | None,
+        skip_plan: bool,
+    ) -> str:
         query = f"EXECUTE DCM PROJECT {project_identifier.sql_identifier} PURGE"
         if alias:
             query += f' AS "{alias}"'
         if skip_plan:
             query += " SKIP PLAN"
-        return self.execute_query(query=query)
+        return query
 
     def test(self, project_identifier: FQN) -> SnowflakeCursor:
         log.info(

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -122,14 +122,18 @@ class DCMProjectManager(SqlExecutionMixin):
         query = self._build_deploy_query(
             project_identifier, from_stage, configuration, variables, alias, skip_plan
         )
-        cursor = self._conn.cursor()
-        cursor.execute_async(query)
+        # Closing the cursor does not cancel the async query; it keeps running
+        # server-side and its results are fetched later via the sfqid (see
+        # DeployProgressTracker.run_deploy_poll -> get_results_from_sfqid).
+        with self._conn.cursor() as cursor:
+            cursor.execute_async(query)
+            sfqid = cursor.sfqid
         log.info(
             "DCM deploy async submitted (project_identifier=%s, sfqid=%s).",
             project_identifier,
-            cursor.sfqid,
+            sfqid,
         )
-        return cursor.sfqid
+        return sfqid
 
     def raw_analyze(
         self,
@@ -290,14 +294,17 @@ class DCMProjectManager(SqlExecutionMixin):
             skip_plan,
         )
         query = self._build_purge_query(project_identifier, alias, skip_plan)
-        cursor = self._conn.cursor()
-        cursor.execute_async(query)
+        # Closing the cursor does not cancel the async query; results are
+        # fetched later via the sfqid (see run_deploy_poll).
+        with self._conn.cursor() as cursor:
+            cursor.execute_async(query)
+            sfqid = cursor.sfqid
         log.info(
             "DCM purge async submitted (project_identifier=%s, sfqid=%s).",
             project_identifier,
-            cursor.sfqid,
+            sfqid,
         )
-        return cursor.sfqid
+        return sfqid
 
     @staticmethod
     def _build_purge_query(

--- a/src/snowflake/cli/_plugins/dcm/progress.py
+++ b/src/snowflake/cli/_plugins/dcm/progress.py
@@ -457,14 +457,14 @@ class DeployProgressTracker:
         in_progress = 0 < filled < _BAR_WIDTH
 
         if in_progress:
-            out.append(_BAR_CELL * filled + _BAR_LEADING_EDGE, style="blue")
+            out.append(_BAR_CELL * filled + _BAR_LEADING_EDGE, style=styles.BLUE)
             out.append(_BAR_CELL * (_BAR_WIDTH - filled - 1), style="dim")
         elif filled == 0:
             out.append(_BAR_CELL * _BAR_WIDTH, style="dim")
         else:
-            out.append(_BAR_CELL * _BAR_WIDTH, style="blue")
+            out.append(_BAR_CELL * _BAR_WIDTH, style=styles.BLUE)
 
-        out.append(f" {progress:>3}%", style="blue")
+        out.append(f" {progress:>3}%", style=styles.BLUE)
 
     def _append_upload_details(self, out: Text) -> None:
         """Render the stage-creation message and folder counters indented
@@ -509,7 +509,7 @@ class DeployProgressTracker:
                 # Blue matches the active-indicator color used by the
                 # pip-style progress bar so all "this phase is in flight"
                 # signals share the same hue.
-                out.append(_spinner_glyph(), style="blue")
+                out.append(_spinner_glyph(), style=styles.BLUE)
             out.append(duration_str + "\n", style="dim")
         else:  # PENDING
             out.append(name_col + "·\n", style="dim")

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 from rich.style import Style
 
-_COLOR_BLUE = "#a0a8fe"
+# Single source of truth for the DCM "blue" hue. Use the terminal-default
+# named color (not a fixed hex) so it respects the user's theme and stays
+# identical everywhere it's used: progress spinner/bar, running phase,
+# refresh status, and unknown rows.
+BLUE = "blue"
 
 DOMAIN_STYLE = Style(color="cyan")
 BOLD_STYLE = Style(bold=True)
 
 # Refresh
-STATUS_STYLE = Style(color=_COLOR_BLUE)
+STATUS_STYLE = Style(color=BLUE)
 REMOVED_STYLE = Style(color="red", italic=True)
 INSERTED_STYLE = Style(color="green", italic=True)
 
@@ -31,9 +35,9 @@ FAIL_STYLE = Style(color="red")
 CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
-UNKNOWN_STYLE = Style(color=_COLOR_BLUE)
+UNKNOWN_STYLE = Style(color=BLUE)
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)
-PHASE_RUNNING_STYLE = Style(color="blue", bold=True)
+PHASE_RUNNING_STYLE = Style(color=BLUE, bold=True)
 PHASE_FAILED_STYLE = Style(color="red", bold=True)

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -14,13 +14,17 @@ from snowflake.cli.api.utils.path_utils import change_directory
 
 
 def _analyze_response(files=None):
-    """Helper to create a JSON analyze response string."""
+    """Helper to create a JSON analyze response string.
+
+    Uses the new server response shape: ``issues[]`` arrays with a ``severity``
+    field at each level (file / definition / top-level).
+    """
     if files is None:
         files = [
             {
                 "sourcePath": "sources/definitions/ok.sql",
-                "definitions": [{"name": "OK", "errors": []}],
-                "errors": [],
+                "definitions": [{"name": "OK", "issues": []}],
+                "issues": [],
             }
         ]
     return json.dumps({"files": files})
@@ -73,6 +77,22 @@ def mock_manifest_load():
 @pytest.fixture
 def mock_object_manager():
     with mock.patch("snowflake.cli._plugins.dcm.commands.ObjectManager") as _fixture:
+        yield _fixture
+
+
+@pytest.fixture
+def mock_deploy_tracker():
+    with mock.patch(
+        "snowflake.cli._plugins.dcm.commands.DeployProgressTracker"
+    ) as _fixture:
+        # ``run_loader_phase`` is expected to invoke its first-arg callable
+        # (the SQL execution closure) and return its result. The real
+        # implementation does that around a live spinner; in tests we just
+        # call the closure directly so ``manager.raw_analyze`` / ``manager.plan``
+        # actually runs and downstream assertions still hold.
+        _fixture.return_value.run_loader_phase.side_effect = (
+            lambda execute_fn, **_kwargs: execute_fn()
+        )
         yield _fixture
 
 
@@ -188,13 +208,17 @@ class TestDCMDeploy:
     def test_deploy_project(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = _manifest_without_config()
 
@@ -203,7 +227,7 @@ class TestDCMDeploy:
 
         assert result.exit_code == 0, result.output
 
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("fooBar"),
             configuration=None,
             from_stage="TMP_STAGE",
@@ -215,13 +239,17 @@ class TestDCMDeploy:
     def test_deploy_project_with_variables(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = _manifest_without_config()
 
@@ -229,7 +257,7 @@ class TestDCMDeploy:
             result = runner.invoke(["dcm", "deploy", "fooBar", "-D", "key=value"])
         assert result.exit_code == 0, result.output
 
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("fooBar"),
             configuration=None,
             from_stage="TMP_STAGE",
@@ -241,13 +269,17 @@ class TestDCMDeploy:
     def test_deploy_project_with_alias(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = _manifest_without_config()
 
@@ -255,7 +287,7 @@ class TestDCMDeploy:
             result = runner.invoke(["dcm", "deploy", "fooBar", "--alias", "my_alias"])
         assert result.exit_code == 0, result.output
 
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("fooBar"),
             configuration=None,
             from_stage="TMP_STAGE",
@@ -269,13 +301,17 @@ class TestDCMDeploy:
         self,
         _mock_create,
         mock_dcm_manager,
+        mock_deploy_tracker,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
         """Test that files are synced to project stage when from_stage is not provided."""
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = (
             "MockDatabase.MockSchema.DCM_FOOBAR_1234567890_TMP_STAGE"
         )
@@ -284,13 +320,14 @@ class TestDCMDeploy:
             result = runner.invoke(["dcm", "deploy", "my_project"])
             assert result.exit_code == 0, result.output
 
-        call_args = mock_dcm_manager().deploy.call_args
+        call_args = mock_dcm_manager().deploy_async.call_args
         assert "DCM_FOOBAR" in call_args.kwargs["from_stage"]
         assert call_args.kwargs["from_stage"].endswith("_TMP_STAGE")
 
     def test_deploy_project_with_from_local_directory(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
@@ -298,7 +335,10 @@ class TestDCMDeploy:
         mock_connect,
         tmp_path,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = (
             "MockDatabase.MockSchema.DCM_FOOBAR_1234567890_TMP_STAGE"
         )
@@ -319,21 +359,26 @@ class TestDCMDeploy:
         mock_dcm_manager().sync_local_files.assert_called_once_with(
             project_identifier=FQN.from_string("my_project"),
             source_directory=str(source_dir),
+            progress=mock_deploy_tracker.return_value,
         )
 
-        call_args = mock_dcm_manager().deploy.call_args
+        call_args = mock_dcm_manager().deploy_async.call_args
         assert call_args.kwargs["from_stage"].endswith("_TMP_STAGE")
 
     def test_deploy_with_target_flag(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = DCMManifest.from_dict(
             {
@@ -350,7 +395,7 @@ class TestDCMDeploy:
             result = runner.invoke(["dcm", "deploy", "--target", "dev"])
 
         assert result.exit_code == 0, result.output
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("my_project"),
             configuration=None,
             from_stage="TMP_STAGE",
@@ -362,13 +407,17 @@ class TestDCMDeploy:
     def test_deploy_with_default_target(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = DCMManifest.from_dict(
             {
@@ -385,7 +434,7 @@ class TestDCMDeploy:
             result = runner.invoke(["dcm", "deploy"])
 
         assert result.exit_code == 0, result.output
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("my_project"),
             configuration=None,
             from_stage="TMP_STAGE",
@@ -397,6 +446,7 @@ class TestDCMDeploy:
     def test_deploy_explicit_identifier_still_uses_target_config(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
@@ -405,7 +455,10 @@ class TestDCMDeploy:
     ):
         """When explicit identifier is provided, it overrides target's project_name
         but configuration from target should still be applied."""
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = DCMManifest.from_dict(
             {
@@ -429,7 +482,7 @@ class TestDCMDeploy:
             )
 
         assert result.exit_code == 0, result.output
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("explicit_project"),
             configuration="DEV_CONFIG",
             from_stage="TMP_STAGE",
@@ -441,13 +494,17 @@ class TestDCMDeploy:
     def test_deploy_with_target_uses_configuration(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = DCMManifest.from_dict(
             {
@@ -469,7 +526,7 @@ class TestDCMDeploy:
             result = runner.invoke(["dcm", "deploy", "--target", "dev"])
 
         assert result.exit_code == 0, result.output
-        mock_dcm_manager().deploy.assert_called_once_with(
+        mock_dcm_manager().deploy_async.assert_called_once_with(
             project_identifier=FQN.from_string("my_project"),
             configuration="DEV_CONFIG",
             from_stage="TMP_STAGE",
@@ -481,6 +538,7 @@ class TestDCMDeploy:
     def test_deploy_with_save_output(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         mock_cursor,
@@ -488,7 +546,8 @@ class TestDCMDeploy:
         tmp_path,
     ):
         plan_response = {"version": 2, "changeset": []}
-        mock_dcm_manager().deploy.return_value = _plan_cursor(
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
             mock_cursor, json.dumps(plan_response)
         )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
@@ -504,6 +563,7 @@ class TestDCMDeploy:
     def test_deploy_with_json_formats_returns_response(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         mock_cursor,
@@ -512,8 +572,9 @@ class TestDCMDeploy:
         format_name,
     ):
         plan_response = {"version": 2, "changeset": []}
-        mock_dcm_manager().deploy.return_value = _mock_cursor_for_format(
-            mock_cursor, plan_response, format_name
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = (
+            _mock_cursor_for_format(mock_cursor, plan_response, format_name)
         )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = _manifest_without_config()
@@ -979,6 +1040,7 @@ class TestDCMPlan:
         mock_dcm_manager().sync_local_files.assert_called_once_with(
             project_identifier=FQN.from_string("my_project"),
             source_directory=str(source_dir),
+            progress=mock.ANY,
         )
 
         call_args = mock_dcm_manager().plan.call_args
@@ -1078,7 +1140,7 @@ class TestDCMRawAnalyze:
                 {
                     "sourcePath": "sources/definitions/bad.sql",
                     "definitions": [],
-                    "errors": [{"message": "syntax error"}],
+                    "issues": [{"message": "syntax error", "severity": "ERROR"}],
                 }
             ]
         )
@@ -1091,7 +1153,7 @@ class TestDCMRawAnalyze:
         with project_directory("dcm_project"):
             result = runner.invoke(["dcm", "raw-analyze", "fooBar"])
         assert result.exit_code == 1, result.output
-        assert "1 error(s)" in result.output
+        assert "Static analysis of DCM Project files found 1 error." in result.output
 
     def test_raw_analyze_with_variables(
         self,
@@ -1347,8 +1409,8 @@ class TestDCMRawAnalyze:
             "files": [
                 {
                     "sourcePath": "sources/definitions/ok.sql",
-                    "definitions": [{"name": "OK", "errors": []}],
-                    "errors": [],
+                    "definitions": [{"name": "OK", "issues": []}],
+                    "issues": [],
                 }
             ]
         }
@@ -2154,6 +2216,7 @@ class TestAccountIdentifierValidationForCommands:
     def test_deploy_calls_check_account_identifier(
         self,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         mock_check_account_identifier,
         runner,
@@ -2161,7 +2224,10 @@ class TestAccountIdentifierValidationForCommands:
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().deploy.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().deploy_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
         mock_manifest_load.return_value = _manifest_without_config()
 

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -615,6 +615,7 @@ class TestDCMPurge:
         user_inputs,
         expected_prompt_count,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
@@ -622,7 +623,10 @@ class TestDCMPurge:
         mock_connect,
     ):
         mock_prompt.side_effect = user_inputs
-        mock_dcm_manager().purge.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
@@ -632,7 +636,7 @@ class TestDCMPurge:
 
         assert result.exit_code == 0, result.output
         assert mock_prompt.call_count == expected_prompt_count
-        mock_dcm_manager().purge.assert_called_once_with(
+        mock_dcm_manager().purge_async.assert_called_once_with(
             project_identifier=FQN.from_string(project_identifier),
             alias=None,
             skip_plan=False,
@@ -645,13 +649,17 @@ class TestDCMPurge:
         self,
         mock_prompt,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().purge.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
@@ -661,7 +669,7 @@ class TestDCMPurge:
 
         assert result.exit_code == 0, result.output
 
-        mock_dcm_manager().purge.assert_called_once_with(
+        mock_dcm_manager().purge_async.assert_called_once_with(
             project_identifier=FQN.from_string("fooBar"),
             alias="my_alias",
             skip_plan=False,
@@ -686,7 +694,7 @@ class TestDCMPurge:
             result = runner.invoke(["dcm", "purge", "fooBar", "--interactive"])
 
         assert result.exit_code != 0
-        mock_dcm_manager().purge.assert_not_called()
+        mock_dcm_manager().purge_async.assert_not_called()
 
     @mock.patch(
         "snowflake.cli._plugins.dcm.commands.typer.prompt",
@@ -696,13 +704,17 @@ class TestDCMPurge:
         self,
         mock_prompt,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().purge.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_manifest_load.return_value = DCMManifest.from_dict(
             {
                 "manifest_version": 2,
@@ -718,7 +730,7 @@ class TestDCMPurge:
             result = runner.invoke(["dcm", "purge", "--target", "dev", "--interactive"])
 
         assert result.exit_code == 0, result.output
-        mock_dcm_manager().purge.assert_called_once_with(
+        mock_dcm_manager().purge_async.assert_called_once_with(
             project_identifier=FQN.from_string("my_project"),
             alias=None,
             skip_plan=False,
@@ -732,13 +744,17 @@ class TestDCMPurge:
         self,
         mock_prompt,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().purge.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
@@ -748,7 +764,7 @@ class TestDCMPurge:
         assert "  Project identifier mismatch" in result.output
         assert "Expected: fooBar" in result.output
         assert "provided: wrong_project" in result.output
-        mock_dcm_manager().purge.assert_called_once()
+        mock_dcm_manager().purge_async.assert_called_once()
 
     @mock.patch(
         "snowflake.cli._plugins.dcm.commands.typer.prompt", return_value="purge fooBar"
@@ -757,6 +773,7 @@ class TestDCMPurge:
         self,
         mock_prompt,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         mock_cursor,
@@ -764,7 +781,8 @@ class TestDCMPurge:
         tmp_path,
     ):
         plan_response = {"version": 2, "changeset": []}
-        mock_dcm_manager().purge.return_value = _plan_cursor(
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
             mock_cursor, json.dumps(plan_response)
         )
         mock_manifest_load.return_value = _manifest_without_config()
@@ -784,13 +802,17 @@ class TestDCMPurge:
         mock_confirm_purge,
         extra_args,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().purge.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
@@ -798,7 +820,7 @@ class TestDCMPurge:
 
         assert result.exit_code == 0, result.output
         mock_confirm_purge.assert_not_called()
-        mock_dcm_manager().purge.assert_called_once_with(
+        mock_dcm_manager().purge_async.assert_called_once_with(
             project_identifier=FQN.from_string("fooBar"),
             alias=None,
             skip_plan=False,
@@ -823,7 +845,7 @@ class TestDCMPurge:
             "Cannot purge the DCM project non-interactively without --force"
             in result.output
         )
-        mock_dcm_manager().purge.assert_not_called()
+        mock_dcm_manager().purge_async.assert_not_called()
 
     @mock.patch(
         "snowflake.cli.api.commands.flags.is_tty_interactive", return_value=False
@@ -848,7 +870,7 @@ class TestDCMPurge:
             "Cannot purge the DCM project non-interactively without --force"
             in result.output
         )
-        mock_dcm_manager().purge.assert_not_called()
+        mock_dcm_manager().purge_async.assert_not_called()
 
     @mock.patch(
         "snowflake.cli.api.commands.flags.is_tty_interactive", return_value=True
@@ -861,13 +883,17 @@ class TestDCMPurge:
         mock_prompt,
         mock_is_tty,
         mock_dcm_manager,
+        mock_deploy_tracker,
         mock_manifest_load,
         runner,
         project_directory,
         mock_cursor,
         mock_connect,
     ):
-        mock_dcm_manager().purge.return_value = _plan_cursor(mock_cursor)
+        mock_dcm_manager().purge_async.return_value = "mock-sfqid"
+        mock_deploy_tracker.return_value.run_deploy_poll.return_value = _plan_cursor(
+            mock_cursor
+        )
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
@@ -875,7 +901,7 @@ class TestDCMPurge:
 
         assert result.exit_code == 0, result.output
         mock_prompt.assert_called()
-        mock_dcm_manager().purge.assert_called_once()
+        mock_dcm_manager().purge_async.assert_called_once()
 
 
 class TestDCMPlan:

--- a/tests/dcm/test_progress.py
+++ b/tests/dcm/test_progress.py
@@ -148,6 +148,20 @@ class TestUploadDetailsLayout:
         # neither are the later PLAN/DEPLOY phases.
         assert all(not line.startswith(("PLAN", "DEPLOY", "ANALYZE")) for line in lines)
 
+    def test_purge_mode_plan_and_purge_show_progress_bar(self):
+        """In purge mode, PLAN and the PURGE-labelled DEPLOY phase must render
+        a pip-style bar (not a spinner), mirroring the deploy-mode behaviour."""
+        tracker = DeployProgressTracker(conn=MagicMock(), operation="purge")
+        # The internal phase name remains DEPLOY (server-reported); only the
+        # rendered label changes to PURGE.
+        tracker._get_phase("DEPLOY").observe_running(50, datetime.now())  # noqa: SLF001
+
+        rendered = tracker._render().plain  # noqa: SLF001
+        purge_line = next(line for line in rendered.split("\n") if "PURGE" in line)
+
+        assert "━" in purge_line
+        assert " 50%" in purge_line
+
     def test_no_details_block_when_context_is_unset(self):
         tracker = self._tracker(with_context=False)
 


### PR DESCRIPTION
Deploy and plan now show a live `RENDER → COMPILE → PLAN → DEPLOY` phase checklist as the server processes the operation, with a pip-style progress bar for the PLAN and DEPLOY phases and a braille spinner for RENDER/COMPILE. (The phase model itself lives in #3068; this PR wires the commands to it.)

- deploy switches to `deploy_async` + `DeployProgressTracker.run_deploy_poll` so the phase display updates in real time while the query runs
- plan uses `tracker.run_loader_phase` with simulated RENDER/COMPILE phases followed by the synchronous PLAN call
- manager: extract `_build_deploy_query` helper, add `deploy_async` method that submits the SQL with `execute_async` and returns the sfqid
- commands: both deploy and plan wrap `sync_local_files` and the backend call inside a `tracker.session()` context for a unified UI

#### purge
`snow dcm purge` shows the same live phase checklist. Purge runs PLAN and DEPLOY entirely server-side (it never syncs local files), so it has no UPLOAD phase and polls `SYSTEM$GET_DCM_PROJECT_PROGRESS` just like deploy; the server-reported DEPLOY phase is displayed as `PURGE` (the `purge` operation mode and the display-name override are defined in #3068).

- manager: extract `_build_purge_query` helper, add `purge_async` method that submits the SQL with `execute_async` and returns the sfqid
- commands: purge wraps `purge_async` + `run_deploy_poll` inside a `tracker.session()` context (replacing the old static spinner)

#### Resource cleanup
- `deploy_async` / `purge_async` now run `execute_async` inside a `with self._conn.cursor()` block so the cursor is released immediately. Closing the cursor does not cancel the query — it keeps running server-side and its results are still fetched later via the sfqid in `run_deploy_poll`.

### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
...
