### PR TITLE
Add snow dcm analyze-errors command with severity-driven output

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -531,7 +531,7 @@ def raw_analyze(
     requires_connection=True,
     hidden=not FeatureFlag.ENABLE_DCM_EARLY_ACCESS.is_enabled(),
 )
-def analyze(
+def analyze_errors(
     identifier: Optional[FQN] = optional_dcm_identifier,
     from_location: SecurePath = from_option,
     variables: Optional[List[str]] = variables_flag,
@@ -542,7 +542,7 @@ def analyze(
     """
     Analyzes a DCM Project and prints a formatted list of errors found.
     """
-    clear_command_artifacts("analyze")
+    clear_command_artifacts("analyze-errors")
 
     context = _resolve_context_with_required_manifest(from_location, identifier, target)
     project_id = context.project_identifier
@@ -562,7 +562,7 @@ def analyze(
                 from_stage=effective_stage,
                 variables=variables,
                 save_output=save_output,
-                command_name="analyze",
+                command_name="analyze-errors",
             ),
             phase_name="ANALYZE",
         )

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -548,7 +548,7 @@ def analyze_errors(
     project_id = context.project_identifier
 
     manager = DCMProjectManager()
-    tracker = DeployProgressTracker(conn=manager.connection, operation="analyze")
+    tracker = DeployProgressTracker(conn=manager.connection, operation="compile")
     with tracker.session():
         effective_stage = manager.sync_local_files(
             project_identifier=project_id,
@@ -564,7 +564,8 @@ def analyze_errors(
                 save_output=save_output,
                 command_name="analyze-errors",
             ),
-            phase_name="ANALYZE",
+            phase_name="COMPILE",
+            simulated_phases=["RENDER"],
         )
 
     reporter = AnalyzeErrorsReporter(save_output=save_output)

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -25,6 +25,7 @@ from snowflake.cli._plugins.dcm.manager import DCMProjectManager
 from snowflake.cli._plugins.dcm.models import DCMManifest, DCMTarget, TargetContext
 from snowflake.cli._plugins.dcm.progress import DeployProgressTracker
 from snowflake.cli._plugins.dcm.reporters import (
+    AnalyzeErrorsReporter,
     AnalyzeReporter,
     PlanReporter,
     RefreshReporter,
@@ -523,6 +524,50 @@ def raw_analyze(
         )
 
     reporter = AnalyzeReporter(save_output=save_output)
+    return reporter.process(result)
+
+
+@app.command(
+    requires_connection=True,
+    hidden=not FeatureFlag.ENABLE_DCM_EARLY_ACCESS.is_enabled(),
+)
+def analyze(
+    identifier: Optional[FQN] = optional_dcm_identifier,
+    from_location: SecurePath = from_option,
+    variables: Optional[List[str]] = variables_flag,
+    target: Optional[str] = target_option,
+    save_output: bool = save_output_option,
+    **options,
+):
+    """
+    Analyzes a DCM Project and prints a formatted list of errors found.
+    """
+    clear_command_artifacts("analyze")
+
+    context = _resolve_context_with_required_manifest(from_location, identifier, target)
+    project_id = context.project_identifier
+
+    manager = DCMProjectManager()
+    tracker = DeployProgressTracker(conn=manager.connection, operation="analyze")
+    with tracker.session():
+        effective_stage = manager.sync_local_files(
+            project_identifier=project_id,
+            source_directory=str(from_location.path),
+            progress=tracker,
+        )
+        result = tracker.run_loader_phase(
+            lambda: manager.raw_analyze(
+                project_identifier=project_id,
+                configuration=context.configuration,
+                from_stage=effective_stage,
+                variables=variables,
+                save_output=save_output,
+                command_name="analyze",
+            ),
+            phase_name="ANALYZE",
+        )
+
+    reporter = AnalyzeErrorsReporter(save_output=save_output)
     return reporter.process(result)
 
 

--- a/src/snowflake/cli/_plugins/dcm/manager.py
+++ b/src/snowflake/cli/_plugins/dcm/manager.py
@@ -142,9 +142,11 @@ class DCMProjectManager(SqlExecutionMixin):
         configuration: str | None = None,
         variables: List[str] | None = None,
         save_output: bool = False,
+        command_name: str = "raw-analyze",
     ):
         log.info(
-            "Running DCM raw-analyze manager operation (project_identifier=%s, has_configuration=%s, variables_count=%d, save_output=%s).",
+            "Running DCM analyze manager operation (command_name=%s, project_identifier=%s, has_configuration=%s, variables_count=%d, save_output=%s).",
+            command_name,
             project_identifier,
             bool(configuration),
             len(variables or []),
@@ -156,7 +158,7 @@ class DCMProjectManager(SqlExecutionMixin):
 
         if save_output:
             with collect_output(
-                project_identifier, command_name="raw-analyze"
+                project_identifier, command_name=command_name
             ) as output_stage:
                 query += f" OUTPUT_PATH {output_stage}"
                 result = self.execute_query(query=query)

--- a/src/snowflake/cli/_plugins/dcm/progress.py
+++ b/src/snowflake/cli/_plugins/dcm/progress.py
@@ -457,14 +457,14 @@ class DeployProgressTracker:
         in_progress = 0 < filled < _BAR_WIDTH
 
         if in_progress:
-            out.append(_BAR_CELL * filled + _BAR_LEADING_EDGE, style="blue")
+            out.append(_BAR_CELL * filled + _BAR_LEADING_EDGE, style=styles.BLUE)
             out.append(_BAR_CELL * (_BAR_WIDTH - filled - 1), style="dim")
         elif filled == 0:
             out.append(_BAR_CELL * _BAR_WIDTH, style="dim")
         else:
-            out.append(_BAR_CELL * _BAR_WIDTH, style="blue")
+            out.append(_BAR_CELL * _BAR_WIDTH, style=styles.BLUE)
 
-        out.append(f" {progress:>3}%", style="blue")
+        out.append(f" {progress:>3}%", style=styles.BLUE)
 
     def _append_upload_details(self, out: Text) -> None:
         """Render the stage-creation message and folder counters indented
@@ -509,7 +509,7 @@ class DeployProgressTracker:
                 # Blue matches the active-indicator color used by the
                 # pip-style progress bar so all "this phase is in flight"
                 # signals share the same hue.
-                out.append(_spinner_glyph(), style="blue")
+                out.append(_spinner_glyph(), style=styles.BLUE)
             out.append(duration_str + "\n", style="dim")
         else:  # PENDING
             out.append(name_col + "·\n", style="dim")

--- a/src/snowflake/cli/_plugins/dcm/reporters/__init__.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/__init__.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from snowflake.cli._plugins.dcm.reporters.analyze import AnalyzeReporter
+from snowflake.cli._plugins.dcm.reporters.analyze import (
+    AnalyzeErrorsReporter,
+    AnalyzeReporter,
+)
 from snowflake.cli._plugins.dcm.reporters.base import Reporter
 from snowflake.cli._plugins.dcm.reporters.plan import PlanReporter
 from snowflake.cli._plugins.dcm.reporters.refresh import RefreshReporter
 from snowflake.cli._plugins.dcm.reporters.test import TestReporter
 
 __all__ = [
+    "AnalyzeErrorsReporter",
     "AnalyzeReporter",
     "Reporter",
     "PlanReporter",

--- a/src/snowflake/cli/_plugins/dcm/reporters/analyze.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/analyze.py
@@ -322,7 +322,7 @@ class AnalyzeErrorsReporter(Reporter[_FileFindings]):
 
     def __init__(self, save_output: bool = False):
         super().__init__(save_output=save_output)
-        self.command_name = "analyze"
+        self.command_name = "analyze-errors"
         self._error_count = 0
         self._warning_count = 0
         self._info_count = 0
@@ -389,7 +389,18 @@ class AnalyzeErrorsReporter(Reporter[_FileFindings]):
         indent = self._INDENT * depth
         style = _SEVERITY_STYLE[finding.severity]
         message = sanitize_for_terminal(_clean_finding_message(finding.message))
-        for line in message.splitlines() or [""]:
+        lines = message.splitlines() or [""]
+
+        # Prepend "line N:M: " (or "line N: " when column is absent) to the
+        # first line so users can jump directly to the offending position.
+        if finding.line is not None:
+            if finding.column is not None:
+                location_prefix = f"line {finding.line}:{finding.column}: "
+            else:
+                location_prefix = f"line {finding.line}: "
+            lines[0] = location_prefix + lines[0]
+
+        for line in lines:
             cli_console.styled_message(f"{indent}{line}", style=style)
             cli_console.styled_message("\n")
 

--- a/src/snowflake/cli/_plugins/dcm/reporters/analyze.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/analyze.py
@@ -12,17 +12,256 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Any, Dict, Iterator, List
+from collections import Counter
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterator, List, Optional
 
+import typer
 from rich.text import Text
+from snowflake.cli._plugins.dcm import styles
 from snowflake.cli._plugins.dcm.reporters.base import Reporter, cli_console
 from snowflake.cli.api.exceptions import CliError
+from snowflake.cli.api.sanitizers import sanitize_for_terminal
 
 log = logging.getLogger(__name__)
 
+_FILES_KEY = "files"
+
+
+def _files_from_response(result_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+    files = result_json.get(_FILES_KEY, [])
+    if not isinstance(files, list):
+        log.info('Unexpected response format. Expected "files" to be a list: %s', files)
+        raise CliError("Could not process response.")
+    return files
+
+
+class Severity(Enum):
+    """Severity levels reported by ``EXECUTE DCM PROJECT ... ANALYZE``."""
+
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    INFO = "INFO"
+
+
+# Map each severity to its presentation style. Errors are red and fail the run;
+# warnings are yellow; info is plain blue (distinct from the bold-blue source
+# file headers).
+_SEVERITY_STYLE = {
+    Severity.ERROR: styles.FAIL_STYLE,
+    Severity.WARNING: styles.WARNING_STYLE,
+    Severity.INFO: styles.INFO_STYLE,
+}
+
+
+def _normalize_severity(raw: Any) -> Severity:
+    """Coerce a free-form ``severity`` value to a :class:`Severity` enum.
+
+    Unknown / missing values are treated as ERROR so a buggy server payload
+    never silently downgrades a real problem to a warning or info.
+    """
+    if isinstance(raw, str):
+        value = raw.strip().upper()
+        if value in ("ERROR", "ERR", "FATAL"):
+            return Severity.ERROR
+        if value in ("WARN", "WARNING"):
+            return Severity.WARNING
+        if value == "INFO":
+            return Severity.INFO
+    return Severity.ERROR
+
+
+@dataclass
+class _AnalyzeFinding:
+    """A single issue pulled from the analyze response."""
+
+    severity: Severity
+    message: str
+    line: Optional[int] = None
+    column: Optional[int] = None
+    code: Optional[str] = None
+
+
+@dataclass
+class _DefinitionFindings:
+    """Findings attached to a single definition inside a file."""
+
+    definition_id: Optional[str]
+    definition_domain: Optional[str]
+    findings: List[_AnalyzeFinding] = field(default_factory=list)
+
+
+@dataclass
+class _FileFindings:
+    """All findings collected for a single source file."""
+
+    source_path: str
+    file_findings: List[_AnalyzeFinding] = field(default_factory=list)
+    definition_findings: List[_DefinitionFindings] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.file_findings) + sum(
+            len(group.findings) for group in self.definition_findings
+        )
+
+
+def _to_finding(raw: Any) -> _AnalyzeFinding:
+    """Build a :class:`_AnalyzeFinding` from one entry in an ``issues[]`` array."""
+    if isinstance(raw, str):
+        return _AnalyzeFinding(severity=Severity.ERROR, message=raw)
+    if not isinstance(raw, dict):
+        return _AnalyzeFinding(severity=Severity.ERROR, message="Unknown issue")
+
+    severity = _normalize_severity(raw.get("severity"))
+
+    message = raw.get("message")
+    if not isinstance(message, str) or not message:
+        message = "Unknown issue"
+
+    position = raw.get("source_position")
+    if not isinstance(position, dict):
+        position = {}
+
+    line = position.get("line") if isinstance(position.get("line"), int) else None
+    column = position.get("column") if isinstance(position.get("column"), int) else None
+
+    code = raw.get("code")
+    if code is not None and not isinstance(code, str):
+        code = str(code)
+
+    return _AnalyzeFinding(
+        severity=severity, message=message, line=line, column=column, code=code
+    )
+
+
+def _format_definition_identifier(definition: Dict[str, Any]) -> Optional[str]:
+    """Build a dotted identifier from a definition's `id` (or legacy `name`)."""
+    definition_id = definition.get("id")
+    if isinstance(definition_id, dict):
+        name = definition_id.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        parts: List[str] = []
+        database = definition_id.get("database")
+        schema = definition_id.get("schema")
+        if isinstance(database, str) and database:
+            parts.append(database)
+        if isinstance(schema, str) and schema:
+            parts.append(schema)
+        parts.append(name)
+        return ".".join(parts)
+    legacy_name = definition.get("name")
+    if isinstance(legacy_name, str) and legacy_name:
+        return legacy_name
+    return None
+
+
+def _format_definition_domain(definition: Dict[str, Any]) -> Optional[str]:
+    refined = definition.get("refined_domain")
+    if isinstance(refined, str) and refined:
+        return refined.upper()
+    definition_id = definition.get("id")
+    if isinstance(definition_id, dict):
+        domain = definition_id.get("domain")
+        if isinstance(domain, str) and domain:
+            return domain.upper()
+    return None
+
+
+def _collect_file_findings(file_entry: Dict[str, Any]) -> _FileFindings:
+    source_path = file_entry.get("source_path") or file_entry.get("sourcePath")
+    if not isinstance(source_path, str) or not source_path:
+        source_path = "<unknown>"
+    collected = _FileFindings(source_path=source_path)
+
+    for raw in file_entry.get("issues") or []:
+        collected.file_findings.append(_to_finding(raw))
+
+    for definition in file_entry.get("definitions") or []:
+        findings: List[_AnalyzeFinding] = []
+        for raw in definition.get("issues") or []:
+            findings.append(_to_finding(raw))
+        if not findings:
+            continue
+        collected.definition_findings.append(
+            _DefinitionFindings(
+                definition_id=_format_definition_identifier(definition),
+                definition_domain=_format_definition_domain(definition),
+                findings=findings,
+            )
+        )
+
+    return collected
+
+
+# Noise prefixes the server prepends to analyze issue messages. We strip them
+# so the user sees only the actual diagnostic text.
+_NOISE_PREFIXES = ("DCM project ANALYZE error: ",)
+
+
+def _clean_finding_message(message: str) -> str:
+    cleaned = message
+    while True:
+        for prefix in _NOISE_PREFIXES:
+            if cleaned.startswith(prefix):
+                cleaned = cleaned[len(prefix) :]
+                break
+        else:
+            return cleaned
+
+
+def _iter_findings(result_json: Dict[str, Any]) -> Iterator[_AnalyzeFinding]:
+    """Yield every issue in the response as an :class:`_AnalyzeFinding`.
+
+    Walks the top-level ``issues[]``, every file's ``issues[]``, and every
+    definition's ``issues[]`` once each. This is the single source of truth
+    for "how many findings, and at what severity?" — both reporters tally
+    off the same stream so their totals can't drift apart.
+    """
+
+    def _yield_from(raw_iter: Any) -> Iterator[_AnalyzeFinding]:
+        if not isinstance(raw_iter, list):
+            return
+        for raw in raw_iter:
+            yield _to_finding(raw)
+
+    yield from _yield_from(result_json.get("issues"))
+
+    files = result_json.get(_FILES_KEY)
+    if not isinstance(files, list):
+        return
+
+    for file_entry in files:
+        if not isinstance(file_entry, dict):
+            continue
+        yield from _yield_from(file_entry.get("issues"))
+        for definition in file_entry.get("definitions") or []:
+            if isinstance(definition, dict):
+                yield from _yield_from(definition.get("issues"))
+
+
+def _tally_by_severity(
+    findings: Iterator[_AnalyzeFinding],
+) -> Counter:
+    """Return a Counter keyed by :class:`Severity` (one entry per bucket).
+
+    The Counter always has explicit zero entries for ERROR/WARNING/INFO so
+    callers can read ``counts[Severity.ERROR]`` without a KeyError.
+    """
+    counts: Counter = Counter({s: 0 for s in Severity})
+    for finding in findings:
+        counts[finding.severity] += 1
+    return counts
+
 
 class AnalyzeReporter(Reporter[Dict[str, Any]]):
-    _FILES_KEY = "files"
+    """Reports the raw JSON returned by ``EXECUTE DCM PROJECT ... ANALYZE``.
+
+    The body is dumped verbatim; only the trailing summary line and the exit
+    code react to severity=ERROR findings.
+    """
 
     def __init__(self, save_output: bool = False):
         super().__init__(save_output=save_output)
@@ -30,22 +269,17 @@ class AnalyzeReporter(Reporter[Dict[str, Any]]):
         self._error_count = 0
 
     def extract_data(self, result_json: Dict[str, Any]) -> List[Dict[str, Any]]:
-        files = result_json.get(self._FILES_KEY, [])
-        if not isinstance(files, list):
-            log.info(
-                'Unexpected response format. Expected "files" to be a list: %s', files
-            )
-            raise CliError("Could not process response.")
-        return files
+        counts = _tally_by_severity(_iter_findings(result_json))
+        self._error_count = counts[Severity.ERROR]
+        return _files_from_response(result_json)
 
     def parse_data(self, data: List[Dict[str, Any]]) -> Iterator[Dict[str, Any]]:
-        for file_entry in data:
-            self._error_count += len(file_entry.get("errors", []))
-            for definition in file_entry.get("definitions", []):
-                self._error_count += len(definition.get("errors", []))
-            yield file_entry
+        yield from data
 
     def print_renderables(self, data: Iterator[Dict[str, Any]]) -> None:
+        # Drain so any side effects in ``parse_data`` run, but don't print
+        # anything per-file: the raw JSON body has already been emitted by
+        # the framework via ``result_raw_data``.
         for _ in data:
             pass
         if self.result_raw_data is not None:
@@ -54,8 +288,157 @@ class AnalyzeReporter(Reporter[Dict[str, Any]]):
 
     def _generate_summary_renderables(self) -> List[Text]:
         if self._error_count == 0:
-            return [Text("Analysis completed successfully.")]
-        return [Text(f"Analysis found {self._error_count} error(s).")]
+            return [
+                Text(
+                    "Static analysis of DCM Project files found no errors.",
+                    styles.PASS_STYLE,
+                )
+            ]
+        errors_word = "error" if self._error_count == 1 else "errors"
+        return [
+            Text("Static analysis of DCM Project files found "),
+            Text(f"{self._error_count} {errors_word}", styles.FAIL_STYLE),
+            Text("."),
+        ]
 
     def _is_success(self) -> bool:
         return self._error_count == 0
+
+
+class AnalyzeErrorsReporter(Reporter[_FileFindings]):
+    """Prints a formatted list of issues returned by ``EXECUTE DCM PROJECT ... ANALYZE``.
+
+    Each issue is color-coded by its ``severity`` field:
+
+    * ``ERROR`` — red; triggers a non-zero exit code.
+    * ``WARN`` / ``WARNING`` — yellow; informational, exit code unchanged.
+    * ``INFO`` — blue; informational, exit code unchanged.
+
+    Unknown severity values are treated as ``ERROR`` so a buggy server payload
+    cannot silently downgrade a real problem.
+    """
+
+    _INDENT = "  "
+
+    def __init__(self, save_output: bool = False):
+        super().__init__(save_output=save_output)
+        self.command_name = "analyze"
+        self._error_count = 0
+        self._warning_count = 0
+        self._info_count = 0
+        self._top_level_issues: List[_AnalyzeFinding] = []
+
+    def extract_data(self, result_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+        # Tally severities off the shared ``_iter_findings`` stream so this
+        # reporter and :class:`AnalyzeReporter` can never disagree on the
+        # numbers — both walk the response the same way.
+        counts = _tally_by_severity(_iter_findings(result_json))
+        self._error_count = counts[Severity.ERROR]
+        self._warning_count = counts[Severity.WARNING]
+        self._info_count = counts[Severity.INFO]
+
+        for raw in result_json.get("issues") or []:
+            self._top_level_issues.append(_to_finding(raw))
+        return _files_from_response(result_json)
+
+    def parse_data(self, data: List[Dict[str, Any]]) -> Iterator[_FileFindings]:
+        for file_entry in data:
+            file_findings = _collect_file_findings(file_entry)
+            if file_findings.total == 0:
+                continue
+            yield file_findings
+
+    def print_renderables(self, data: Iterator[_FileFindings]) -> None:
+        first = True
+        for file_findings in data:
+            if not first:
+                cli_console.styled_message("\n")
+            first = False
+
+            cli_console.styled_message(
+                sanitize_for_terminal(file_findings.source_path),
+                style=styles.FILE_PATH_STYLE,
+            )
+            cli_console.styled_message("\n")
+
+            for finding in file_findings.file_findings:
+                self._print_finding(finding, depth=1)
+
+            for group in file_findings.definition_findings:
+                self._print_definition_header(group)
+                for finding in group.findings:
+                    self._print_finding(finding, depth=2)
+
+        for finding in self._top_level_issues:
+            if not first:
+                cli_console.styled_message("\n")
+            first = False
+            cli_console.styled_message("(project-level issue)", style=styles.BOLD_STYLE)
+            cli_console.styled_message("\n")
+            self._print_finding(finding, depth=1)
+
+    def _print_definition_header(self, group: _DefinitionFindings) -> None:
+        identifier = group.definition_id or "<unnamed definition>"
+        header = sanitize_for_terminal(identifier)
+        if group.definition_domain:
+            header = f"{header} ({sanitize_for_terminal(group.definition_domain)})"
+        cli_console.styled_message(self._INDENT + header)
+        cli_console.styled_message("\n")
+
+    def _print_finding(self, finding: _AnalyzeFinding, depth: int) -> None:
+        indent = self._INDENT * depth
+        style = _SEVERITY_STYLE[finding.severity]
+        message = sanitize_for_terminal(_clean_finding_message(finding.message))
+        for line in message.splitlines() or [""]:
+            cli_console.styled_message(f"{indent}{line}", style=style)
+            cli_console.styled_message("\n")
+
+    def _generate_summary_renderables(self) -> List[Text]:
+        total = self._error_count + self._warning_count + self._info_count
+        if total == 0:
+            return [
+                Text(
+                    "Static analysis of DCM Project files found no errors.",
+                    styles.PASS_STYLE,
+                )
+            ]
+
+        # Build (count, label, style) tuples in severity order; only buckets
+        # with a non-zero count are included so the summary stays terse.
+        segments: List[tuple[int, str, Any]] = []
+        if self._error_count > 0:
+            label = "error" if self._error_count == 1 else "errors"
+            segments.append((self._error_count, label, styles.FAIL_STYLE))
+        if self._warning_count > 0:
+            label = "warning" if self._warning_count == 1 else "warnings"
+            segments.append((self._warning_count, label, styles.WARNING_STYLE))
+        if self._info_count > 0:
+            label = "info" if self._info_count == 1 else "infos"
+            segments.append((self._info_count, label, styles.INFO_STYLE))
+
+        result: List[Text] = [Text("Static analysis of DCM Project files found ")]
+        for index, (count, label, style) in enumerate(segments):
+            if index > 0:
+                # "A and B" for two segments, "A, B, and C" for three (Oxford comma).
+                if index == len(segments) - 1:
+                    result.append(Text(", and " if len(segments) > 2 else " and "))
+                else:
+                    result.append(Text(", "))
+            result.append(Text(f"{count} {label}", style))
+        result.append(Text("."))
+        return result
+
+    def _is_success(self) -> bool:
+        # Always treat the run as "success" from the base reporter's perspective
+        # so that `print_summary()` is always called — we want the styled
+        # summary rendered at the end of every run (cf. `snow dcm plan`). The
+        # exit code is set separately by ``process_payload``.
+        return True
+
+    def process_payload(self, result_json: Dict[str, Any]) -> None:
+        super().process_payload(result_json)
+        if self._error_count > 0:
+            # Errors fail the command, but the styled summary is already on
+            # screen — exit silently so we don't double-render the message in
+            # an "Error" box.
+            raise typer.Exit(code=1)

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 from rich.style import Style
 
-_COLOR_BLUE = "#a0a8fe"
+# Single source of truth for the DCM "blue" hue. Use the terminal-default
+# named color (not a fixed hex) so it respects the user's theme and stays
+# identical everywhere it's used: progress spinner/bar, running phase,
+# analyze INFO findings / file headers, refresh status, and unknown rows.
+BLUE = "blue"
 
 DOMAIN_STYLE = Style(color="cyan")
 BOLD_STYLE = Style(bold=True)
 
 # Refresh
-STATUS_STYLE = Style(color=_COLOR_BLUE)
+STATUS_STYLE = Style(color=BLUE)
 REMOVED_STYLE = Style(color="red", italic=True)
 INSERTED_STYLE = Style(color="green", italic=True)
 
@@ -28,18 +32,18 @@ PASS_STYLE = Style(color="green")
 FAIL_STYLE = Style(color="red")
 WARNING_STYLE = Style(color="yellow")
 # INFO-severity analyze findings: plain blue (distinct from bold-blue file headers).
-INFO_STYLE = Style(color="blue")
+INFO_STYLE = Style(color=BLUE)
 
 # Plan
 CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
-UNKNOWN_STYLE = Style(color=_COLOR_BLUE)
+UNKNOWN_STYLE = Style(color=BLUE)
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)
-PHASE_RUNNING_STYLE = Style(color="blue", bold=True)
+PHASE_RUNNING_STYLE = Style(color=BLUE, bold=True)
 PHASE_FAILED_STYLE = Style(color="red", bold=True)
 
 # Analyze (file/source path headers stand out in bold blue).
-FILE_PATH_STYLE = Style(color="blue", bold=True)
+FILE_PATH_STYLE = Style(color=BLUE, bold=True)

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -23,9 +23,12 @@ STATUS_STYLE = Style(color=_COLOR_BLUE)
 REMOVED_STYLE = Style(color="red", italic=True)
 INSERTED_STYLE = Style(color="green", italic=True)
 
-# Test
+# Test / Analyze
 PASS_STYLE = Style(color="green")
 FAIL_STYLE = Style(color="red")
+WARNING_STYLE = Style(color="yellow")
+# INFO-severity analyze findings: plain blue (distinct from bold-blue file headers).
+INFO_STYLE = Style(color="blue")
 
 # Plan
 CREATE_STYLE = Style(color="green")
@@ -37,3 +40,6 @@ UNKNOWN_STYLE = Style(color=_COLOR_BLUE)
 PHASE_DONE_STYLE = Style(color="green", bold=True)
 PHASE_RUNNING_STYLE = Style(color="blue", bold=True)
 PHASE_FAILED_STYLE = Style(color="red", bold=True)
+
+# Analyze (file/source path headers stand out in bold blue).
+FILE_PATH_STYLE = Style(color="blue", bold=True)

--- a/src/snowflake/cli/_plugins/dcm/utils.py
+++ b/src/snowflake/cli/_plugins/dcm/utils.py
@@ -152,7 +152,12 @@ def _load_debug_data(command_name: str, file_number: int):
         data = json.load(f)
 
     if isinstance(data, list) and len(data) > 0:
-        if command_name in ("test", "refresh", "analyze"):
+        if command_name in (
+            "test",
+            "refresh",
+            "analyze",
+            "analyze-errors",
+        ):
             data = data[0]
 
     return data

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -1493,6 +1493,293 @@ class TestDCMRawAnalyze:
         _assert_format_result(payload, json.loads(analyze_response), format_name)
 
 
+class TestDCMAnalyze:
+    def test_analyze_basic_no_errors(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_dcm_manager().raw_analyze.return_value = mock_cursor(
+            rows=[(_analyze_response(),)], columns=("result",)
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "analyze", "fooBar"])
+
+        assert result.exit_code == 0, result.output
+        assert "Static analysis of DCM Project files found no errors." in result.output
+
+        mock_dcm_manager().raw_analyze.assert_called_once_with(
+            project_identifier=FQN.from_string("fooBar"),
+            configuration=None,
+            from_stage="TMP_STAGE",
+            variables=None,
+            save_output=False,
+            command_name="analyze",
+        )
+
+    def test_analyze_with_errors_exits_with_formatted_output(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        error_response = _analyze_response(
+            files=[
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [
+                        {
+                            "id": {
+                                "name": "MY_TABLE",
+                                "schema": "PUBLIC",
+                                "database": "MY_DB",
+                                "domain": "TABLE",
+                            },
+                            "refined_domain": "table",
+                            "issues": [
+                                {
+                                    "source_position": {"line": 3, "column": 0},
+                                    "message": "column FOO not found",
+                                    "code": "001632",
+                                    "type": "syntax_error",
+                                    "severity": "ERROR",
+                                }
+                            ],
+                        }
+                    ],
+                    "issues": [
+                        {
+                            "source_position": {"line": 1, "column": 0},
+                            "message": "file-level syntax error",
+                            "code": "001597",
+                            "type": "syntax_error",
+                            "severity": "ERROR",
+                        }
+                    ],
+                },
+                {
+                    "source_path": "sources/definitions/ok.sql",
+                    "definitions": [
+                        {"id": {"name": "OK", "domain": "TABLE"}, "issues": []}
+                    ],
+                    "issues": [],
+                },
+            ]
+        )
+        mock_dcm_manager().raw_analyze.return_value = mock_cursor(
+            rows=[(error_response,)], columns=("result",)
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "analyze", "fooBar"])
+
+        assert result.exit_code == 1, result.output
+        assert "sources/definitions/bad.sql" in result.output
+        assert "file-level syntax error" in result.output
+        assert "MY_DB.PUBLIC.MY_TABLE (TABLE)" in result.output
+        assert "column FOO not found" in result.output
+        # No per-finding header (code / line / column / "error" label) is rendered.
+        assert "[001597]" not in result.output
+        assert "[001632]" not in result.output
+        assert "line 1:0" not in result.output
+        assert "line 3:0" not in result.output
+        assert "Static analysis of DCM Project files found 2 errors." in result.output
+        assert "sources/definitions/ok.sql" not in result.output
+
+    def test_analyze_with_variables(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_dcm_manager().raw_analyze.return_value = mock_cursor(
+            rows=[(_analyze_response(),)], columns=("result",)
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "analyze", "fooBar", "-D", "key=value"])
+
+        assert result.exit_code == 0, result.output
+        mock_dcm_manager().raw_analyze.assert_called_once_with(
+            project_identifier=FQN.from_string("fooBar"),
+            configuration=None,
+            from_stage="TMP_STAGE",
+            variables=["key=value"],
+            save_output=False,
+            command_name="analyze",
+        )
+
+    def test_analyze_with_target(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_dcm_manager().raw_analyze.return_value = mock_cursor(
+            rows=[(_analyze_response(),)], columns=("result",)
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = DCMManifest.from_dict(
+            {
+                "manifest_version": 2,
+                "type": "dcm_project",
+                "default_target": "dev",
+                "targets": {
+                    "dev": {
+                        "project_name": "my_project",
+                        "templating_config": "dev_config",
+                        **_DEFAULT_TARGET_FIELDS,
+                    }
+                },
+                "templating": {"configurations": {"dev_config": {}}},
+            }
+        )
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "analyze", "--target", "dev"])
+
+        assert result.exit_code == 0, result.output
+        mock_dcm_manager().raw_analyze.assert_called_once_with(
+            project_identifier=FQN.from_string("my_project"),
+            configuration="DEV_CONFIG",
+            from_stage="TMP_STAGE",
+            variables=None,
+            save_output=False,
+            command_name="analyze",
+        )
+
+    def test_analyze_with_save_output(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        project_directory,
+        mock_cursor,
+        mock_connect,
+    ):
+        mock_dcm_manager().raw_analyze.return_value = mock_cursor(
+            rows=[(_analyze_response(),)], columns=("result",)
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(["dcm", "analyze", "fooBar", "--save-output"])
+
+        assert result.exit_code == 0, result.output
+        mock_dcm_manager().raw_analyze.assert_called_once_with(
+            project_identifier=FQN.from_string("fooBar"),
+            configuration=None,
+            from_stage="TMP_STAGE",
+            variables=None,
+            save_output=True,
+            command_name="analyze",
+        )
+
+    def test_analyze_with_save_output_saves_response(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        mock_cursor,
+        mock_connect,
+        tmp_path,
+    ):
+        analyze_response = {
+            "files": [
+                {
+                    "source_path": "sources/definitions/ok.sql",
+                    "definitions": [
+                        {
+                            "id": {"name": "OK", "domain": "TABLE"},
+                            "refined_domain": "table",
+                            "issues": [],
+                        }
+                    ],
+                    "issues": [],
+                }
+            ]
+        }
+        mock_dcm_manager().raw_analyze.return_value = mock_cursor(
+            rows=[(json.dumps(analyze_response),)], columns=("result",)
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["dcm", "analyze", "fooBar", "--save-output"])
+
+            assert result.exit_code == 0, result.output
+            _assert_json_dumped("analyze", analyze_response, tmp_path)
+
+    def test_analyze_from_stage_fails(
+        self, mock_dcm_manager, runner, project_directory
+    ):
+        result = runner.invoke(["dcm", "analyze", "fooBar", "--from", "@my_stage"])
+        assert result.exit_code == 1, result.output
+        assert "Stage paths are not supported" in result.output
+
+    def test_analyze_hidden_from_help_without_early_access(self, runner):
+        """The analyze command is gated on ENABLE_DCM_EARLY_ACCESS and hidden by default."""
+        result = runner.invoke(["dcm", "--help"])
+        assert result.exit_code == 0
+        assert "analyze" not in result.output
+
+    @pytest.mark.parametrize("format_name", ["json", "json_ext"])
+    def test_analyze_with_json_formats_returns_response(
+        self,
+        mock_dcm_manager,
+        mock_deploy_tracker,
+        mock_manifest_load,
+        runner,
+        mock_cursor,
+        mock_connect,
+        project_directory,
+        format_name,
+    ):
+        analyze_response = _analyze_response()
+        mock_dcm_manager().raw_analyze.return_value = _mock_cursor_for_format(
+            mock_cursor, json.loads(analyze_response), format_name
+        )
+        mock_dcm_manager().sync_local_files.return_value = "TMP_STAGE"
+        mock_manifest_load.return_value = _manifest_without_config()
+
+        with project_directory("dcm_project"):
+            result = runner.invoke(
+                ["dcm", "analyze", "fooBar", "--format", format_name]
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        _assert_format_result(payload, json.loads(analyze_response), format_name)
+
+
 class TestDCMList:
     def test_list_command_alias(self, mock_connect, runner):
         result = runner.invoke(

--- a/tests/dcm/test_commands.py
+++ b/tests/dcm/test_commands.py
@@ -1511,7 +1511,7 @@ class TestDCMAnalyze:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "analyze", "fooBar"])
+            result = runner.invoke(["dcm", "analyze-errors", "fooBar"])
 
         assert result.exit_code == 0, result.output
         assert "Static analysis of DCM Project files found no errors." in result.output
@@ -1522,7 +1522,7 @@ class TestDCMAnalyze:
             from_stage="TMP_STAGE",
             variables=None,
             save_output=False,
-            command_name="analyze",
+            command_name="analyze-errors",
         )
 
     def test_analyze_with_errors_exits_with_formatted_output(
@@ -1585,18 +1585,18 @@ class TestDCMAnalyze:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "analyze", "fooBar"])
+            result = runner.invoke(["dcm", "analyze-errors", "fooBar"])
 
         assert result.exit_code == 1, result.output
         assert "sources/definitions/bad.sql" in result.output
         assert "file-level syntax error" in result.output
         assert "MY_DB.PUBLIC.MY_TABLE (TABLE)" in result.output
         assert "column FOO not found" in result.output
-        # No per-finding header (code / line / column / "error" label) is rendered.
+        # Error codes are not rendered; line:col positions are.
         assert "[001597]" not in result.output
         assert "[001632]" not in result.output
-        assert "line 1:0" not in result.output
-        assert "line 3:0" not in result.output
+        assert "line 1:0:" in result.output
+        assert "line 3:0:" in result.output
         assert "Static analysis of DCM Project files found 2 errors." in result.output
         assert "sources/definitions/ok.sql" not in result.output
 
@@ -1617,7 +1617,9 @@ class TestDCMAnalyze:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "analyze", "fooBar", "-D", "key=value"])
+            result = runner.invoke(
+                ["dcm", "analyze-errors", "fooBar", "-D", "key=value"]
+            )
 
         assert result.exit_code == 0, result.output
         mock_dcm_manager().raw_analyze.assert_called_once_with(
@@ -1626,7 +1628,7 @@ class TestDCMAnalyze:
             from_stage="TMP_STAGE",
             variables=["key=value"],
             save_output=False,
-            command_name="analyze",
+            command_name="analyze-errors",
         )
 
     def test_analyze_with_target(
@@ -1660,7 +1662,7 @@ class TestDCMAnalyze:
         )
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "analyze", "--target", "dev"])
+            result = runner.invoke(["dcm", "analyze-errors", "--target", "dev"])
 
         assert result.exit_code == 0, result.output
         mock_dcm_manager().raw_analyze.assert_called_once_with(
@@ -1669,7 +1671,7 @@ class TestDCMAnalyze:
             from_stage="TMP_STAGE",
             variables=None,
             save_output=False,
-            command_name="analyze",
+            command_name="analyze-errors",
         )
 
     def test_analyze_with_save_output(
@@ -1689,7 +1691,7 @@ class TestDCMAnalyze:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with project_directory("dcm_project"):
-            result = runner.invoke(["dcm", "analyze", "fooBar", "--save-output"])
+            result = runner.invoke(["dcm", "analyze-errors", "fooBar", "--save-output"])
 
         assert result.exit_code == 0, result.output
         mock_dcm_manager().raw_analyze.assert_called_once_with(
@@ -1698,7 +1700,7 @@ class TestDCMAnalyze:
             from_stage="TMP_STAGE",
             variables=None,
             save_output=True,
-            command_name="analyze",
+            command_name="analyze-errors",
         )
 
     def test_analyze_with_save_output_saves_response(
@@ -1733,15 +1735,17 @@ class TestDCMAnalyze:
         mock_manifest_load.return_value = _manifest_without_config()
 
         with change_directory(tmp_path):
-            result = runner.invoke(["dcm", "analyze", "fooBar", "--save-output"])
+            result = runner.invoke(["dcm", "analyze-errors", "fooBar", "--save-output"])
 
             assert result.exit_code == 0, result.output
-            _assert_json_dumped("analyze", analyze_response, tmp_path)
+            _assert_json_dumped("analyze-errors", analyze_response, tmp_path)
 
     def test_analyze_from_stage_fails(
         self, mock_dcm_manager, runner, project_directory
     ):
-        result = runner.invoke(["dcm", "analyze", "fooBar", "--from", "@my_stage"])
+        result = runner.invoke(
+            ["dcm", "analyze-errors", "fooBar", "--from", "@my_stage"]
+        )
         assert result.exit_code == 1, result.output
         assert "Stage paths are not supported" in result.output
 
@@ -1772,7 +1776,7 @@ class TestDCMAnalyze:
 
         with project_directory("dcm_project"):
             result = runner.invoke(
-                ["dcm", "analyze", "fooBar", "--format", format_name]
+                ["dcm", "analyze-errors", "fooBar", "--format", format_name]
             )
 
         assert result.exit_code == 0, result.output

--- a/tests/dcm/test_reporters/test_analyze_reporter.py
+++ b/tests/dcm/test_reporters/test_analyze_reporter.py
@@ -267,10 +267,10 @@ class TestAnalyzeErrorsReporter:
 
         output = capture_reporter_output(reporter, cursor)
         assert "sources/definitions/bad.sql" in output
-        # Noise prefix is stripped, and we never render per-finding code/position.
+        # Noise prefix is stripped; error code is not rendered; position IS shown.
         assert "DCM project ANALYZE error:" not in output
         assert "[001597]" not in output
-        assert "line 10:0" not in output
+        assert "line 10:0:" in output
         assert "SQL compilation error: syntax error line 10" in output
         assert "Static analysis of DCM Project files found 1 error." in output
 
@@ -564,6 +564,65 @@ class TestAnalyzeErrorsReporter:
         output = capture_reporter_output(reporter, cursor)
         assert "first line" in output
         assert "second line" in output
+
+    def test_position_prefix_shown_when_line_and_column_present(self):
+        """Findings with line+column show 'line N:M: ' before the message."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/pos.sql",
+                    "definitions": [],
+                    "issues": [
+                        _issue("type mismatch", severity="ERROR", line=7, column=3)
+                    ],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "line 7:3: type mismatch" in output
+
+    def test_position_prefix_line_only_when_column_absent(self):
+        """Findings with only a line number show 'line N: ' before the message."""
+        issue = {
+            "message": "missing ref",
+            "severity": "ERROR",
+            "source_position": {"line": 5},
+        }
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/pos.sql",
+                    "definitions": [],
+                    "issues": [issue],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "line 5: missing ref" in output
+
+    def test_no_position_prefix_when_line_absent(self):
+        """Findings without source_position show just the message with no prefix."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/pos.sql",
+                    "definitions": [],
+                    "issues": [_issue("no location info", severity="WARNING")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "no location info" in output
+        assert "line " not in output
 
     def test_process_empty_files(self):
         reporter = AnalyzeErrorsReporter()

--- a/tests/dcm/test_reporters/test_analyze_reporter.py
+++ b/tests/dcm/test_reporters/test_analyze_reporter.py
@@ -14,8 +14,13 @@
 from unittest import mock
 
 import pytest
+import typer
+from snowflake.cli._plugins.dcm import styles
 from snowflake.cli._plugins.dcm.reporters.analyze import (
+    AnalyzeErrorsReporter,
     AnalyzeReporter,
+    Severity,
+    _normalize_severity,
 )
 from snowflake.cli.api.exceptions import CliError
 
@@ -26,17 +31,72 @@ from tests.dcm.test_reporters.utils import (
 )
 
 
+def _issue(message, severity="ERROR", line=None, column=0, code=None):
+    """Build a single issue dict in the new server response shape."""
+    issue: dict = {"message": message, "severity": severity}
+    if line is not None:
+        issue["source_position"] = {"line": line, "column": column}
+    if code is not None:
+        issue["code"] = code
+    return issue
+
+
+def _definition(name, issues, domain="TABLE", schema=None, database=None):
+    """Build a single definition entry with the given issues."""
+    definition_id: dict = {"name": name, "domain": domain}
+    if schema is not None:
+        definition_id["schema"] = schema
+    if database is not None:
+        definition_id["database"] = database
+    return {
+        "id": definition_id,
+        "refined_domain": domain.lower(),
+        "issues": issues,
+    }
+
+
+class TestNormalizeSeverity:
+    """Coverage for severity string normalization."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("ERROR", Severity.ERROR),
+            ("error", Severity.ERROR),
+            ("Err", Severity.ERROR),
+            ("FATAL", Severity.ERROR),
+            ("WARN", Severity.WARNING),
+            ("warning", Severity.WARNING),
+            (" Warning ", Severity.WARNING),
+            ("INFO", Severity.INFO),
+            ("info", Severity.INFO),
+        ],
+    )
+    def test_known_values(self, raw, expected):
+        assert _normalize_severity(raw) == expected
+
+    @pytest.mark.parametrize("raw", [None, "", "BOGUS", 42, [], {}])
+    def test_unknown_values_default_to_error(self, raw):
+        """Unknown / missing severity must NOT silently downgrade the finding."""
+        assert _normalize_severity(raw) == Severity.ERROR
+
+
 class TestAnalyzeReporter:
-    def _make_response(self, files):
-        return {"files": files}
+    """Raw-analyze reporter: dumps JSON body and counts ERROR-severity issues."""
+
+    def _make_response(self, files, top_level_issues=None):
+        response = {"files": files}
+        if top_level_issues is not None:
+            response["issues"] = top_level_issues
+        return response
 
     def test_process_no_errors(self):
         data = self._make_response(
             [
                 {
-                    "sourcePath": "sources/definitions/customers.sql",
-                    "definitions": [{"name": "CUSTOMERS", "errors": []}],
-                    "errors": [],
+                    "source_path": "sources/definitions/customers.sql",
+                    "definitions": [_definition("CUSTOMERS", [])],
+                    "issues": [],
                 }
             ]
         )
@@ -46,13 +106,13 @@ class TestAnalyzeReporter:
         with mock.patch(CLI_CONSOLE_PATH):
             reporter.process(cursor)  # Should not raise
 
-    def test_process_with_file_errors(self):
+    def test_process_with_file_level_error(self):
         data = self._make_response(
             [
                 {
-                    "sourcePath": "sources/definitions/bad.sql",
+                    "source_path": "sources/definitions/bad.sql",
                     "definitions": [],
-                    "errors": [{"message": "syntax error"}],
+                    "issues": [_issue("syntax error", severity="ERROR")],
                 }
             ]
         )
@@ -63,23 +123,23 @@ class TestAnalyzeReporter:
             with pytest.raises(CliError) as exc_info:
                 reporter.process(cursor)
 
-        assert "1 error(s)" in exc_info.value.message
+        assert "1 error" in exc_info.value.message
 
-    def test_process_with_definition_errors(self):
+    def test_process_with_definition_level_errors(self):
         data = self._make_response(
             [
                 {
-                    "sourcePath": "sources/definitions/customers.sql",
+                    "source_path": "sources/definitions/customers.sql",
                     "definitions": [
-                        {
-                            "name": "CUSTOMERS",
-                            "errors": [
-                                {"message": "column not found"},
-                                {"message": "type mismatch"},
+                        _definition(
+                            "CUSTOMERS",
+                            [
+                                _issue("column not found", severity="ERROR"),
+                                _issue("type mismatch", severity="ERROR"),
                             ],
-                        }
+                        )
                     ],
-                    "errors": [],
+                    "issues": [],
                 }
             ]
         )
@@ -90,22 +150,13 @@ class TestAnalyzeReporter:
             with pytest.raises(CliError) as exc_info:
                 reporter.process(cursor)
 
-        assert "2 error(s)" in exc_info.value.message
+        assert "2 errors" in exc_info.value.message
 
-    def test_process_with_mixed_errors(self):
+    def test_process_with_top_level_errors(self):
+        """Top-level issues are also counted in the raw-analyze summary."""
         data = self._make_response(
-            [
-                {
-                    "sourcePath": "sources/definitions/a.sql",
-                    "definitions": [{"name": "A", "errors": [{"message": "err1"}]}],
-                    "errors": [{"message": "file err"}],
-                },
-                {
-                    "sourcePath": "sources/definitions/b.sql",
-                    "definitions": [{"name": "B", "errors": []}],
-                    "errors": [],
-                },
-            ]
+            files=[],
+            top_level_issues=[_issue("project-wide failure", severity="ERROR")],
         )
         reporter = AnalyzeReporter()
         cursor = FakeCursor(data)
@@ -114,12 +165,31 @@ class TestAnalyzeReporter:
             with pytest.raises(CliError) as exc_info:
                 reporter.process(cursor)
 
-        assert "2 error(s)" in exc_info.value.message
+        assert "1 error" in exc_info.value.message
+
+    def test_warnings_and_infos_do_not_fail_raw_analyze(self):
+        """Only severity=ERROR triggers exit code 1; WARN/INFO are ignored here."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/note.sql",
+                    "definitions": [],
+                    "issues": [
+                        _issue("style nit", severity="WARN"),
+                        _issue("hint", severity="INFO"),
+                    ],
+                }
+            ]
+        )
+        reporter = AnalyzeReporter()
+        cursor = FakeCursor(data)
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            reporter.process(cursor)  # Should not raise
 
     def test_process_empty_files(self):
-        data = self._make_response([])
         reporter = AnalyzeReporter()
-        cursor = FakeCursor(data)
+        cursor = FakeCursor(self._make_response([]))
 
         with mock.patch(CLI_CONSOLE_PATH):
             reporter.process(cursor)  # Should not raise
@@ -135,9 +205,9 @@ class TestAnalyzeReporter:
         data = self._make_response(
             [
                 {
-                    "sourcePath": "sources/definitions/ok.sql",
-                    "definitions": [{"name": "OK", "errors": []}],
-                    "errors": [],
+                    "source_path": "sources/definitions/ok.sql",
+                    "definitions": [_definition("OK", [])],
+                    "issues": [],
                 }
             ]
         )
@@ -146,3 +216,438 @@ class TestAnalyzeReporter:
 
         output = capture_reporter_output(reporter, cursor)
         assert "sources/definitions/ok.sql" in output
+
+
+class TestAnalyzeErrorsReporter:
+    """User-facing analyze reporter: prints per-file findings color-coded by severity."""
+
+    def _make_response(self, files, top_level_issues=None):
+        response = {"files": files}
+        if top_level_issues is not None:
+            response["issues"] = top_level_issues
+        return response
+
+    def test_no_issues_renders_green_success_message(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/customers.sql",
+                    "definitions": [_definition("CUSTOMERS", [])],
+                    "issues": [],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "Static analysis of DCM Project files found no errors." in output
+
+    def test_file_level_error_is_reported_and_fails(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [],
+                    "issues": [
+                        _issue(
+                            "DCM project ANALYZE error: SQL compilation error: "
+                            "syntax error line 10 at position 0 unexpected 'defineX'.",
+                            severity="ERROR",
+                            line=10,
+                            column=0,
+                            code="001597",
+                        )
+                    ],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "sources/definitions/bad.sql" in output
+        # Noise prefix is stripped, and we never render per-finding code/position.
+        assert "DCM project ANALYZE error:" not in output
+        assert "[001597]" not in output
+        assert "line 10:0" not in output
+        assert "SQL compilation error: syntax error line 10" in output
+        assert "Static analysis of DCM Project files found 1 error." in output
+
+    def test_definition_level_errors(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/analytics.sql",
+                    "definitions": [
+                        _definition(
+                            "ENRICHED_ORDER_DETAILS",
+                            [
+                                _issue(
+                                    "Could not analyze lineage",
+                                    severity="ERROR",
+                                    line=3,
+                                    code="001634",
+                                ),
+                                _issue(
+                                    "Unresolved or ambiguous dependency",
+                                    severity="ERROR",
+                                    line=3,
+                                    code="001632",
+                                ),
+                            ],
+                            domain="TABLE",
+                            schema="ANALYTICS",
+                            database="DCM_DEMO_1_DEV3",
+                        )
+                    ],
+                    "issues": [],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "sources/definitions/analytics.sql" in output
+        assert "DCM_DEMO_1_DEV3.ANALYTICS.ENRICHED_ORDER_DETAILS (TABLE)" in output
+        assert "Could not analyze lineage" in output
+        assert "Unresolved or ambiguous dependency" in output
+        assert "Static analysis of DCM Project files found 2 errors." in output
+
+    def test_mixed_severities_renders_three_segment_summary(self):
+        """Two errors, one warning, three infos → all three buckets shown."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/mixed.sql",
+                    "definitions": [
+                        _definition(
+                            "T",
+                            [
+                                _issue("err A", severity="ERROR"),
+                                _issue("err B", severity="ERROR"),
+                                _issue("warn", severity="WARN"),
+                                _issue("info A", severity="INFO"),
+                                _issue("info B", severity="INFO"),
+                                _issue("info C", severity="INFO"),
+                            ],
+                        )
+                    ],
+                    "issues": [],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert (
+            "Static analysis of DCM Project files found 2 errors, 1 warning, "
+            "and 3 infos." in output
+        )
+
+    def test_two_segment_summary_uses_and_not_oxford(self):
+        """Exactly two non-zero buckets join with ' and ', no Oxford comma."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/mixed.sql",
+                    "definitions": [
+                        _definition(
+                            "T",
+                            [
+                                _issue("err", severity="ERROR"),
+                                _issue("warn", severity="WARN"),
+                            ],
+                        )
+                    ],
+                    "issues": [],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert (
+            "Static analysis of DCM Project files found 1 error and 1 warning."
+            in output
+        )
+
+    def test_only_warnings_does_not_fail_command(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/style.sql",
+                    "definitions": [],
+                    "issues": [_issue("style nit", severity="WARN")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            reporter.process(cursor)  # Should not raise
+
+    def test_only_infos_does_not_fail_command(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/hints.sql",
+                    "definitions": [],
+                    "issues": [_issue("hint", severity="INFO")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            reporter.process(cursor)  # Should not raise
+
+        output = capture_reporter_output(AnalyzeErrorsReporter(), FakeCursor(data))
+        assert "Static analysis of DCM Project files found 1 info." in output
+
+    def test_error_present_exits_with_code_1(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [],
+                    "issues": [_issue("syntax error", severity="ERROR")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            with pytest.raises(typer.Exit) as exc_info:
+                reporter.process(cursor)
+
+        assert exc_info.value.exit_code == 1
+
+    def test_mixed_error_and_warning_exits_with_code_1(self):
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [],
+                    "issues": [
+                        _issue("syntax error", severity="ERROR"),
+                        _issue("style nit", severity="WARN"),
+                    ],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            with pytest.raises(typer.Exit) as exc_info:
+                reporter.process(cursor)
+        assert exc_info.value.exit_code == 1
+
+    def test_unknown_severity_is_treated_as_error(self):
+        """A buggy server payload must not downgrade a real problem."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/odd.sql",
+                    "definitions": [],
+                    "issues": [_issue("weird", severity="BOGUS")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            with pytest.raises(typer.Exit):
+                reporter.process(cursor)
+
+    def test_top_level_issues_are_reported(self):
+        data = self._make_response(
+            files=[],
+            top_level_issues=[
+                _issue("deprecated syntax used", severity="WARN", line=5, column=2)
+            ],
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "deprecated syntax used" in output
+        assert "(project-level issue)" in output
+        assert "Static analysis of DCM Project files found 1 warning." in output
+
+    def test_process_handles_issue_string(self):
+        """Bare strings inside ``issues[]`` are treated as ERROR-severity messages."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [],
+                    "issues": ["bare error string"],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "bare error string" in output
+        assert "Static analysis of DCM Project files found 1 error." in output
+
+    def test_process_handles_legacy_definition_name(self):
+        """Definitions without an `id` dict fall back to the legacy `name` field."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/legacy.sql",
+                    "definitions": [
+                        {
+                            "name": "LEGACY_TABLE",
+                            "issues": [_issue("oops", severity="ERROR", line=2)],
+                        }
+                    ],
+                    "issues": [],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "LEGACY_TABLE" in output
+
+    def test_process_handles_legacy_source_path(self):
+        """`sourcePath` (camelCase) is accepted as a fallback for `source_path`."""
+        data = self._make_response(
+            [
+                {
+                    "sourcePath": "sources/definitions/legacy.sql",
+                    "definitions": [],
+                    "issues": [_issue("oops", severity="ERROR")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "sources/definitions/legacy.sql" in output
+
+    def test_process_multiline_message(self):
+        """Multi-line issue messages are indented under their parent."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [],
+                    "issues": [
+                        _issue(
+                            "first line\nsecond line",
+                            severity="ERROR",
+                            line=1,
+                            code="001597",
+                        )
+                    ],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "first line" in output
+        assert "second line" in output
+
+    def test_process_empty_files(self):
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(self._make_response([]))
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "Static analysis of DCM Project files found no errors." in output
+
+    def test_process_no_data(self):
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(None)
+
+        output = capture_reporter_output(reporter, cursor)
+        assert "No data." in output
+
+    def test_process_invalid_response_shape(self):
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor({"files": "not-a-list"})
+
+        with mock.patch(CLI_CONSOLE_PATH):
+            with pytest.raises(CliError) as exc_info:
+                reporter.process(cursor)
+
+        assert "Could not process response." in exc_info.value.message
+
+    def test_source_path_header_uses_file_path_style(self):
+        """Source-file headers render in bold blue for visibility."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/bad.sql",
+                    "definitions": [],
+                    "issues": [_issue("syntax error", severity="ERROR")],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+        calls = []
+
+        def record(text, style=""):
+            calls.append((str(text), style))
+
+        with mock.patch(CLI_CONSOLE_PATH, side_effect=record):
+            with pytest.raises(typer.Exit):
+                reporter.process(cursor)
+
+        path_call = next(c for c in calls if "sources/definitions/bad.sql" in c[0])
+        assert path_call[1] == styles.FILE_PATH_STYLE
+
+    @pytest.mark.parametrize(
+        "severity, expected_style",
+        [
+            ("ERROR", styles.FAIL_STYLE),
+            ("WARN", styles.WARNING_STYLE),
+            ("WARNING", styles.WARNING_STYLE),
+            ("INFO", styles.INFO_STYLE),
+        ],
+    )
+    def test_finding_lines_use_severity_specific_style(self, severity, expected_style):
+        """Each finding's message line is styled according to its severity."""
+        data = self._make_response(
+            [
+                {
+                    "source_path": "sources/definitions/x.sql",
+                    "definitions": [],
+                    "issues": [
+                        _issue("the diagnostic text", severity=severity, line=3)
+                    ],
+                }
+            ]
+        )
+        reporter = AnalyzeErrorsReporter()
+        cursor = FakeCursor(data)
+        calls = []
+
+        def record(text, style=""):
+            calls.append((str(text), style))
+
+        with mock.patch(CLI_CONSOLE_PATH, side_effect=record):
+            try:
+                reporter.process(cursor)
+            except typer.Exit:
+                pass
+
+        message_call = next(c for c in calls if "the diagnostic text" in c[0])
+        assert message_call[1] == expected_style

--- a/tests/dcm/test_reporters/utils.py
+++ b/tests/dcm/test_reporters/utils.py
@@ -15,6 +15,7 @@ import json
 from io import StringIO
 from unittest import mock
 
+import typer
 from snowflake.cli.api.exceptions import CliError
 
 CLI_CONSOLE_PATH = (
@@ -57,6 +58,10 @@ def capture_reporter_output(reporter, cursor, cli_console_path=""):
             reporter.process(cursor)
         except CliError as e:
             error_message = e.message
+        except typer.Exit:
+            # AnalyzeErrorsReporter exits with code 1 when errors are found.
+            # Swallow it so callers can inspect the captured output.
+            pass
 
     result = output.getvalue()
     if error_message:


### PR DESCRIPTION
Adds a user-facing `snow dcm analyze-errors` command (hidden without the early-access feature flag) that runs `EXECUTE DCM PROJECT ANALYZE` and formats the findings by file and severity. (The next PR in the stack, #3082, renames this command to `compile`.)

- `AnalyzeErrorsReporter`: groups findings by source file, renders each file path in bold-blue, then lists errors/warnings/infos with colored severity labels and the line/column position of each finding; exits non-zero when errors are found
- Severity enum (ERROR/WARNING/INFO) with color mapping via `styles.py`
- Summary line: `"Static analysis of DCM Project files found N error(s), M warning(s)."` printed after the per-file details
- analyze-errors command: wraps `sync_local_files` + `raw_analyze` inside a `DeployProgressTracker` session, showing UPLOAD → RENDER → COMPILE (the server-side ANALYZE is an implementation detail and is not shown as a phase)
- `raw_analyze` gains a `command_name` parameter for artifact collection
- `styles.py`: add `WARNING_STYLE`, `INFO_STYLE`, `FILE_PATH_STYLE`

### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
...
