### PR TITLE
Render ALTER rows as a tree with per-change details in plan/deploy ou…

### DIFF
--- a/src/snowflake/cli/_plugins/dcm/progress.py
+++ b/src/snowflake/cli/_plugins/dcm/progress.py
@@ -457,14 +457,14 @@ class DeployProgressTracker:
         in_progress = 0 < filled < _BAR_WIDTH
 
         if in_progress:
-            out.append(_BAR_CELL * filled + _BAR_LEADING_EDGE, style="blue")
+            out.append(_BAR_CELL * filled + _BAR_LEADING_EDGE, style=styles.BLUE)
             out.append(_BAR_CELL * (_BAR_WIDTH - filled - 1), style="dim")
         elif filled == 0:
             out.append(_BAR_CELL * _BAR_WIDTH, style="dim")
         else:
-            out.append(_BAR_CELL * _BAR_WIDTH, style="blue")
+            out.append(_BAR_CELL * _BAR_WIDTH, style=styles.BLUE)
 
-        out.append(f" {progress:>3}%", style="blue")
+        out.append(f" {progress:>3}%", style=styles.BLUE)
 
     def _append_upload_details(self, out: Text) -> None:
         """Render the stage-creation message and folder counters indented
@@ -509,7 +509,7 @@ class DeployProgressTracker:
                 # Blue matches the active-indicator color used by the
                 # pip-style progress bar so all "this phase is in flight"
                 # signals share the same hue.
-                out.append(_spinner_glyph(), style="blue")
+                out.append(_spinner_glyph(), style=styles.BLUE)
             out.append(duration_str + "\n", style="dim")
         else:  # PENDING
             out.append(name_col + "·\n", style="dim")

--- a/src/snowflake/cli/_plugins/dcm/reporters/plan.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/plan.py
@@ -159,16 +159,40 @@ class PlanDetail:
     kind: str
     desc: str
     is_last_chain: Tuple[bool, ...] = ()
+    # The property-name prefix of ``desc`` (uppercased) when this row describes
+    # a property change, else ``None``. The renderer colors just this portion.
+    attr: Optional[str] = None
 
     @property
     def depth(self) -> int:
         return len(self.is_last_chain)
 
 
+# Maximum rendered length of a single attribute value (previous or new).
+# Property values such as view / function SQL bodies can be multi-line and
+# very long; rendering them verbatim would break the tree layout and flood
+# the output, so they're collapsed to one line and cut to this width.
+_MAX_VALUE_LEN = 50
+
+
+def _truncate_inline(text: str) -> str:
+    """Collapse all whitespace (incl. newlines) to single spaces and truncate.
+
+    ``sanitize_for_terminal`` only strips ANSI escapes, so a multi-line value
+    would still contain newlines that break the single-line tree layout. We
+    squash runs of whitespace to one space and cap the result at
+    :data:`_MAX_VALUE_LEN`, appending an ellipsis when truncated.
+    """
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= _MAX_VALUE_LEN:
+        return collapsed
+    return collapsed[:_MAX_VALUE_LEN].rstrip() + "…"
+
+
 def _format_scalar_value(value: Any) -> Optional[str]:
     """Render a JSON-decoded value compactly, or ``None`` for complex types.
 
-    Used to render the right-hand side of ``set <attr> = <value>`` lines.
+    Used to render attribute values on ``set`` / modified-property lines.
     Dicts and lists are skipped (they'd blow up the output).
     """
     if value is None:
@@ -188,29 +212,47 @@ def _format_change_desc(
     item_id: Any,
     attribute_name: Optional[str],
     value: Any,
-) -> str:
+    prev_value: Any = None,
+) -> Tuple[Optional[str], str]:
     """Build the human-readable description for a single change entry.
 
+    Returns ``(attr, desc)`` where ``desc`` is the full one-line description and
+    ``attr`` is the property name prefix (already uppercased) when the entry
+    describes a property change, else ``None``. The renderer uses ``attr`` to
+    color just the property name; ``desc`` always *starts with* ``attr`` when it
+    is set, so the two stay in sync.
+
     Handles every observed shape:
-    - ``item_id`` is a dict with ``desc`` → use ``desc``.
-    - ``item_id`` is a bare string → use it directly.
+    - ``item_id`` is a dict with ``desc`` → use ``desc`` (no property name).
+    - ``item_id`` is a bare string → use it directly (no property name).
+    - a modified property carrying both a previous and a new value →
+      ``<attribute_name>: <prev> → <new>`` (each value collapsed to one line
+      and truncated).
     - ``set`` → ``<attribute_name> = <value>`` (scalar values only).
-    - ``unset`` → ``<attribute_name>``.
+    - ``unset`` (only a previous value) → ``<attribute_name>``.
     """
     if isinstance(item_id, dict):
         desc_val = item_id.get("desc")
         if isinstance(desc_val, str):
-            return sanitize_for_terminal(desc_val)
+            return None, sanitize_for_terminal(desc_val)
     if isinstance(item_id, str):
-        return sanitize_for_terminal(item_id)
+        return None, sanitize_for_terminal(item_id)
     if isinstance(attribute_name, str) and attribute_name:
-        attr = sanitize_for_terminal(attribute_name)
-        if kind == "set":
-            scalar = _format_scalar_value(value)
-            if scalar is not None:
-                return f"{attr} = {scalar}"
-        return attr
-    return ""
+        # Uppercase the property name so it stands out (e.g. WAREHOUSE_SIZE,
+        # COMMENT); the value(s) keep their original casing.
+        attr = sanitize_for_terminal(attribute_name).upper()
+        new_scalar = _format_scalar_value(value)
+        prev_scalar = _format_scalar_value(prev_value)
+        new_str = _truncate_inline(new_scalar) if new_scalar is not None else None
+        prev_str = _truncate_inline(prev_scalar) if prev_scalar is not None else None
+        # A modified property reports both the old and the new value; show the
+        # transition so the change is self-explanatory.
+        if prev_str is not None and new_str is not None:
+            return attr, f"{attr}: {prev_str} → {new_str}"
+        if new_str is not None:
+            return attr, f"{attr} = {new_str}"
+        return attr, attr
+    return None, ""
 
 
 @dataclass(frozen=True)
@@ -227,6 +269,7 @@ class _ChangeReader:
     get_item_id: Callable[[Any], Any]
     get_attribute_name: Callable[[Any], Any]
     get_value: Callable[[Any], Any]
+    get_prev_value: Callable[[Any], Any]
     get_children: Callable[[Any], List[Any]]
 
 
@@ -240,6 +283,7 @@ _MODEL_READER = _ChangeReader(
     get_item_id=lambda c: c.item_id,
     get_attribute_name=lambda c: c.attribute_name,
     get_value=lambda c: c.value,
+    get_prev_value=lambda c: c.prev_value,
     get_children=lambda c: c.changes,
 )
 
@@ -248,6 +292,7 @@ _RAW_READER = _ChangeReader(
     get_item_id=lambda c: c.get("item_id"),
     get_attribute_name=lambda c: c.get("attribute_name"),
     get_value=lambda c: c.get("value"),
+    get_prev_value=lambda c: c.get("prev_value"),
     get_children=_raw_children,
 )
 
@@ -286,30 +331,33 @@ def _flatten_via(
     expanded = _expand_collections(items, reader)
     # Pre-render to filter out leaves that would produce empty rows, so the
     # ``is_last`` computation reflects only what's actually displayed.
-    renderable: List[Tuple[Any, str, str]] = []
+    renderable: List[Tuple[Any, str, Optional[str], str]] = []
     for item in expanded:
         kind = reader.get_kind(item).lower()
-        desc = _format_change_desc(
+        attr, desc = _format_change_desc(
             kind,
             reader.get_item_id(item),
             reader.get_attribute_name(item),
             reader.get_value(item),
+            reader.get_prev_value(item),
         )
         sanitized_kind = sanitize_for_terminal(kind)
         if not sanitized_kind and not desc:
             continue
-        renderable.append((item, sanitized_kind, desc))
+        renderable.append((item, sanitized_kind, attr, desc))
 
     # Stable sort: group siblings by kind category so users see all
     # creations, then modifications, then deletions in a predictable order.
-    renderable.sort(key=lambda triple: _kind_info(triple[1]).sort_key)
+    renderable.sort(key=lambda entry: _kind_info(entry[1]).sort_key)
 
     out: List[PlanDetail] = []
     total = len(renderable)
-    for index, (item, sanitized_kind, desc) in enumerate(renderable):
+    for index, (item, sanitized_kind, attr, desc) in enumerate(renderable):
         is_last = index == total - 1
         chain = ancestor_is_last + (is_last,)
-        out.append(PlanDetail(kind=sanitized_kind, desc=desc, is_last_chain=chain))
+        out.append(
+            PlanDetail(kind=sanitized_kind, desc=desc, is_last_chain=chain, attr=attr)
+        )
         children = reader.get_children(item)
         if children:
             out.extend(_flatten_via(children, reader, ancestor_is_last=chain))
@@ -518,7 +566,17 @@ class PlanReporter(Reporter[PlanRow]):
                 style=self._style_for_change_kind(detail.kind),
             )
         if detail.desc:
-            cli_console.styled_message(" " + detail.desc)
+            # When the row describes a property change, color just the property
+            # name (the leading ``attr`` portion of ``desc``) so it stands out
+            # from its value(s); everything else renders default.
+            if detail.attr and detail.desc.startswith(detail.attr):
+                cli_console.styled_message(" ")
+                cli_console.styled_message(detail.attr, style=styles.PROPERTY_STYLE)
+                rest = detail.desc[len(detail.attr) :]
+                if rest:
+                    cli_console.styled_message(rest)
+            else:
+                cli_console.styled_message(" " + detail.desc)
         cli_console.styled_message("\n")
 
     def _generate_summary_renderables(self) -> List[Text]:

--- a/src/snowflake/cli/_plugins/dcm/reporters/plan.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/plan.py
@@ -57,7 +57,8 @@ _KIND_INFO: Dict[str, _KindInfo] = {
     "added": _KindInfo((0, 0), styles.CREATE_STYLE),
     "set": _KindInfo((0, 1), styles.CREATE_STYLE),
     "modified": _KindInfo((1, 0), styles.ALTER_STYLE),
-    "renamed": _KindInfo((1, 1), styles.ALTER_STYLE),
+    "changed": _KindInfo((1, 1), styles.ALTER_STYLE),
+    "renamed": _KindInfo((1, 2), styles.ALTER_STYLE),
     "removed": _KindInfo((2, 0), styles.DROP_STYLE),
     "unset": _KindInfo((2, 1), styles.DROP_STYLE),
 }

--- a/src/snowflake/cli/_plugins/dcm/reporters/plan.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/plan.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import logging
 from collections import namedtuple
-from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field, ValidationError
 from rich.style import Style
@@ -30,6 +30,68 @@ log = logging.getLogger(__name__)
 
 _OPERATION_WIDTH = 8
 _DOMAIN_WIDTH = 20
+_COLLECTION_KIND = "collection"
+
+
+@dataclass(frozen=True)
+class _KindInfo:
+    """Per-kind metadata: how to sort siblings, and how to color them.
+
+    Keeping sort key and style in one row means a new kind only ever has
+    to be added in one place — and the sort buckets stay aligned with the
+    semantic CREATE / ALTER / DROP color scheme by construction.
+    """
+
+    sort_key: Tuple[int, int]
+    style: Style
+
+
+# Display order + style for sibling sub-changes under an ALTER row.
+# Mirrors the top-level CREATE → ALTER → DROP ordering so the eye scans
+# the same way whether it's an entity row or one of its indented
+# children. Within a category the sub-keys group together ("added" and
+# "set" both create things; "removed" and "unset" both destroy things);
+# Python's ``list.sort`` is stable, so siblings sharing the same key
+# preserve the server-supplied order.
+_KIND_INFO: Dict[str, _KindInfo] = {
+    "added": _KindInfo((0, 0), styles.CREATE_STYLE),
+    "set": _KindInfo((0, 1), styles.CREATE_STYLE),
+    "modified": _KindInfo((1, 0), styles.ALTER_STYLE),
+    "renamed": _KindInfo((1, 1), styles.ALTER_STYLE),
+    "removed": _KindInfo((2, 0), styles.DROP_STYLE),
+    "unset": _KindInfo((2, 1), styles.DROP_STYLE),
+}
+_UNKNOWN_KIND_INFO = _KindInfo((3, 0), styles.UNKNOWN_STYLE)
+
+
+def _kind_info(kind: str) -> _KindInfo:
+    return _KIND_INFO.get((kind or "").lower(), _UNKNOWN_KIND_INFO)
+
+
+# Tree-prefix cell glyphs (each cell is 3 columns wide so the tree column
+# stays narrow and aligned regardless of depth). Box-drawing characters
+# render in any UTF-8 terminal; the cells render with the default style
+# so the colored kind keyword that follows is what catches the eye.
+_TREE_BRANCH = "├─ "  # non-last sibling at this level
+_TREE_LAST = "└─ "  # last sibling at this level
+_TREE_PIPE = "│  "  # ancestor still has siblings to come
+_TREE_GAP = "   "  # ancestor was the last sibling (no pipe)
+
+
+def _render_tree_prefix(is_last_chain: Tuple[bool, ...]) -> str:
+    """Render a tree-style leading prefix from ``is_last_chain``.
+
+    Each element in the chain describes one ancestor level (ending with
+    the node itself). ``True`` means "this node / ancestor was the last
+    sibling at its level". The last element decides the current node's
+    connector (└─ vs ├─); preceding elements decide whether each ancestor
+    column shows a vertical continuation (│) or a blank gap.
+    """
+    if not is_last_chain:
+        return ""
+    parts = [_TREE_GAP if was_last else _TREE_PIPE for was_last in is_last_chain[:-1]]
+    parts.append(_TREE_LAST if is_last_chain[-1] else _TREE_BRANCH)
+    return "".join(parts)
 
 
 class PlanObjectId(BaseModel):
@@ -39,11 +101,38 @@ class PlanObjectId(BaseModel):
     fqn: str
 
 
+class PlanChange(BaseModel):
+    """One entry inside an entity-level ``changes`` array.
+
+    Observed shapes in v2 changesets:
+    - ``kind == "collection"`` — grouping wrapper: ``collection_name`` + nested ``changes``.
+    - ``kind in ("added", "removed", "modified")`` — carries ``item_id``, which may be
+      either a dict (with a ``desc`` and other metadata) or a bare string identifier
+      (e.g. a column name).
+    - ``kind == "set"`` — attribute change: ``attribute_name`` + ``value``.
+    - ``kind == "unset"`` — attribute reset: ``attribute_name`` + ``prev_value``.
+
+    ``modified`` (and sometimes ``added``) entries may additionally carry their own
+    nested ``changes`` describing the sub-modifications.
+    """
+
+    kind: Optional[str] = None
+    item_id: Optional[Union[Dict[str, Any], str]] = None
+    attribute_name: Optional[str] = None
+    value: Any = None
+    prev_value: Any = None
+    changes: List["PlanChange"] = Field(default_factory=list)
+
+
+PlanChange.model_rebuild()
+
+
 class PlanEntityChange(BaseModel):
     """Top-level entity change in the changeset."""
 
     type_: str = Field(None, alias="type")
     object_id: PlanObjectId
+    changes: List[PlanChange] = Field(default_factory=list)
 
 
 class PlanResponse(BaseModel):
@@ -57,12 +146,205 @@ _OPERATION_ORDER = {"CREATE": 0, "ALTER": 1, "DROP": 2}
 
 
 @dataclass
+class PlanDetail:
+    """One indented sub-line under an entity row, e.g. ``added <desc>``.
+
+    ``is_last_chain`` carries one boolean per ancestor level, ending with
+    the node itself. ``True`` means "this node (or ancestor) was the last
+    sibling at its level"; the renderer uses this to draw tree connectors
+    (├─ / └─ / │ / blank) without needing to keep a nested tree around.
+    """
+
+    kind: str
+    desc: str
+    is_last_chain: Tuple[bool, ...] = ()
+
+    @property
+    def depth(self) -> int:
+        return len(self.is_last_chain)
+
+
+def _format_scalar_value(value: Any) -> Optional[str]:
+    """Render a JSON-decoded value compactly, or ``None`` for complex types.
+
+    Used to render the right-hand side of ``set <attr> = <value>`` lines.
+    Dicts and lists are skipped (they'd blow up the output).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        sanitized = sanitize_for_terminal(value)
+        return "''" if sanitized == "" else sanitized
+    return None
+
+
+def _format_change_desc(
+    kind: str,
+    item_id: Any,
+    attribute_name: Optional[str],
+    value: Any,
+) -> str:
+    """Build the human-readable description for a single change entry.
+
+    Handles every observed shape:
+    - ``item_id`` is a dict with ``desc`` → use ``desc``.
+    - ``item_id`` is a bare string → use it directly.
+    - ``set`` → ``<attribute_name> = <value>`` (scalar values only).
+    - ``unset`` → ``<attribute_name>``.
+    """
+    if isinstance(item_id, dict):
+        desc_val = item_id.get("desc")
+        if isinstance(desc_val, str):
+            return sanitize_for_terminal(desc_val)
+    if isinstance(item_id, str):
+        return sanitize_for_terminal(item_id)
+    if isinstance(attribute_name, str) and attribute_name:
+        attr = sanitize_for_terminal(attribute_name)
+        if kind == "set":
+            scalar = _format_scalar_value(value)
+            if scalar is not None:
+                return f"{attr} = {scalar}"
+        return attr
+    return ""
+
+
+@dataclass(frozen=True)
+class _ChangeReader:
+    """Field-access adapter so one flattener handles both shapes.
+
+    The strict path operates on validated :class:`PlanChange` Pydantic
+    models; the fallback path operates on the raw decoded dict from the
+    server. Both have the same conceptual fields, so we abstract field
+    access behind these callables and share a single walker.
+    """
+
+    get_kind: Callable[[Any], str]
+    get_item_id: Callable[[Any], Any]
+    get_attribute_name: Callable[[Any], Any]
+    get_value: Callable[[Any], Any]
+    get_children: Callable[[Any], List[Any]]
+
+
+def _raw_children(change: Dict[str, Any]) -> List[Dict[str, Any]]:
+    nested = change.get("changes") or []
+    return [c for c in nested if isinstance(c, dict)]
+
+
+_MODEL_READER = _ChangeReader(
+    get_kind=lambda c: c.kind or "",
+    get_item_id=lambda c: c.item_id,
+    get_attribute_name=lambda c: c.attribute_name,
+    get_value=lambda c: c.value,
+    get_children=lambda c: c.changes,
+)
+
+_RAW_READER = _ChangeReader(
+    get_kind=lambda c: str(c.get("kind", "")),
+    get_item_id=lambda c: c.get("item_id"),
+    get_attribute_name=lambda c: c.get("attribute_name"),
+    get_value=lambda c: c.get("value"),
+    get_children=_raw_children,
+)
+
+
+def _expand_collections(items: List[Any], reader: _ChangeReader) -> List[Any]:
+    """Inline ``collection``-kind wrappers so their children become real siblings.
+
+    Collection wrappers don't produce a line of their own, so for tree
+    rendering we need to know the *displayed* sibling list at each level.
+    Flattening collections in advance lets us compute ``is_last`` against
+    the siblings the user will actually see.
+    """
+    out: List[Any] = []
+    for item in items:
+        if reader.get_kind(item).lower() == _COLLECTION_KIND:
+            out.extend(_expand_collections(reader.get_children(item) or [], reader))
+        else:
+            out.append(item)
+    return out
+
+
+def _flatten_via(
+    items: List[Any],
+    reader: _ChangeReader,
+    ancestor_is_last: Tuple[bool, ...] = (),
+) -> List[PlanDetail]:
+    """Walk a changes tree producing indented detail lines with tree metadata.
+
+    ``kind == "collection"`` wrappers are unwrapped (no line emitted); their
+    children take their place in the displayed sibling list at the current
+    depth. Every other kind produces one line; if it carries nested
+    ``changes``, those are emitted one level deeper. ``ancestor_is_last``
+    records, for each ancestor level, whether the ancestor was the last
+    sibling at its level — which the renderer turns into tree connectors.
+    """
+    expanded = _expand_collections(items, reader)
+    # Pre-render to filter out leaves that would produce empty rows, so the
+    # ``is_last`` computation reflects only what's actually displayed.
+    renderable: List[Tuple[Any, str, str]] = []
+    for item in expanded:
+        kind = reader.get_kind(item).lower()
+        desc = _format_change_desc(
+            kind,
+            reader.get_item_id(item),
+            reader.get_attribute_name(item),
+            reader.get_value(item),
+        )
+        sanitized_kind = sanitize_for_terminal(kind)
+        if not sanitized_kind and not desc:
+            continue
+        renderable.append((item, sanitized_kind, desc))
+
+    # Stable sort: group siblings by kind category so users see all
+    # creations, then modifications, then deletions in a predictable order.
+    renderable.sort(key=lambda triple: _kind_info(triple[1]).sort_key)
+
+    out: List[PlanDetail] = []
+    total = len(renderable)
+    for index, (item, sanitized_kind, desc) in enumerate(renderable):
+        is_last = index == total - 1
+        chain = ancestor_is_last + (is_last,)
+        out.append(PlanDetail(kind=sanitized_kind, desc=desc, is_last_chain=chain))
+        children = reader.get_children(item)
+        if children:
+            out.extend(_flatten_via(children, reader, ancestor_is_last=chain))
+    return out
+
+
+def _flatten_changes(
+    changes: List[PlanChange],
+    ancestor_is_last: Tuple[bool, ...] = (),
+) -> List[PlanDetail]:
+    """Strict-mode flattener over validated :class:`PlanChange` models."""
+    return _flatten_via(list(changes), _MODEL_READER, ancestor_is_last)
+
+
+def _flatten_changes_from_raw(
+    raw: Any,
+    ancestor_is_last: Tuple[bool, ...] = (),
+) -> List[PlanDetail]:
+    """Best-effort flattener over the raw ``changes`` payload.
+
+    Used by the fallback parser when the strict pydantic model can't validate
+    the entry; we still surface as many sub-change lines as possible, with
+    correct tree metadata.
+    """
+    items = [c for c in (raw or []) if isinstance(c, dict)]
+    return _flatten_via(items, _RAW_READER, ancestor_is_last)
+
+
+@dataclass
 class PlanRow:
     """Parsed entry ready for display"""
 
     operation: str
     domain: str
     fqn: Optional[FQN] = None
+    details: List[PlanDetail] = field(default_factory=list)
 
     @property
     def sort_key(self) -> tuple:
@@ -81,6 +363,7 @@ class PlanRow:
             domain = sanitize_for_terminal(entity.object_id.domain.upper())
             sanitized_fqn = sanitize_for_terminal(entity.object_id.fqn)
             fqn = FQN.from_string(sanitized_fqn)
+            details = _flatten_changes(entity.changes) if operation == "ALTER" else []
         except (ValidationError, FQNNameError) as e:
             # Forward-compatible fallback: if a future version changes the
             # changeset entry shape, the CLI degrades gracefully instead of crashing.
@@ -106,11 +389,17 @@ class PlanRow:
                     e,
                 )
                 fqn = None
+            details = (
+                _flatten_changes_from_raw(entry_dict.get("changes"))
+                if operation == "ALTER"
+                else []
+            )
 
         return cls(
             operation=operation,
             domain=domain,
             fqn=fqn,
+            details=details,
         )
 
     def display_fqn(self) -> str:
@@ -158,6 +447,11 @@ class PlanReporter(Reporter[PlanRow]):
             return styles.DROP_STYLE
         return styles.UNKNOWN_STYLE
 
+    @staticmethod
+    def _style_for_change_kind(kind: str) -> Style:
+        """Return the style for a sub-change kind (added/removed/modified/set/…)."""
+        return _kind_info(kind).style
+
     def extract_data(self, result_json: Dict[str, Any]) -> List[PlanEntityChange]:
         if not isinstance(result_json, dict):
             log.info("Unexpected response type: %s, expected dict", type(result_json))
@@ -201,6 +495,30 @@ class PlanReporter(Reporter[PlanRow]):
             cli_console.styled_message(entry.domain.ljust(_DOMAIN_WIDTH) + " ")
             cli_console.styled_message(entry.display_fqn(), style=styles.DOMAIN_STYLE)
             cli_console.styled_message("\n")
+            for detail in entry.details:
+                self._print_detail(detail)
+
+    def _print_detail(self, detail: PlanDetail) -> None:
+        # Tree prefix renders dim so it recedes visually — the colored kind
+        # keyword that follows is what should catch the eye.
+        prefix = _render_tree_prefix(detail.is_last_chain)
+        if prefix:
+            cli_console.styled_message(prefix, style="dim")
+        if detail.kind:
+            # Only the operation keyword (added / removed / modified / set / …)
+            # is colored; the entity name / description that follows renders
+            # with the terminal default so the colored kind stands out. Unlike
+            # the top-level CREATE/ALTER/DROP row, child rows do NOT pad the
+            # keyword to a fixed column — the tree prefix already provides
+            # visual indentation, so a single space separator keeps the line
+            # compact.
+            cli_console.styled_message(
+                detail.kind,
+                style=self._style_for_change_kind(detail.kind),
+            )
+        if detail.desc:
+            cli_console.styled_message(" " + detail.desc)
+        cli_console.styled_message("\n")
 
     def _generate_summary_renderables(self) -> List[Text]:
         total = self._summary.total

--- a/src/snowflake/cli/_plugins/dcm/reporters/plan.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/plan.py
@@ -55,7 +55,9 @@ class _KindInfo:
 # preserve the server-supplied order.
 _KIND_INFO: Dict[str, _KindInfo] = {
     "added": _KindInfo((0, 0), styles.CREATE_STYLE),
-    "set": _KindInfo((0, 1), styles.CREATE_STYLE),
+    # "set" keeps the creation sort bucket (groups with "added") but renders
+    # neutral — assigning a property value shouldn't read as a creation.
+    "set": _KindInfo((0, 1), styles.NEUTRAL_STYLE),
     "modified": _KindInfo((1, 0), styles.ALTER_STYLE),
     "changed": _KindInfo((1, 1), styles.ALTER_STYLE),
     "renamed": _KindInfo((1, 2), styles.ALTER_STYLE),
@@ -174,6 +176,11 @@ class PlanDetail:
 # the output, so they're collapsed to one line and cut to this width.
 _MAX_VALUE_LEN = 50
 
+# Separator between a modified property's previous and new value. The arrow
+# glyph is rendered in the ALTER color so it visually splits old from new.
+_VALUE_ARROW = "→"
+_VALUE_TRANSITION = f" {_VALUE_ARROW} "
+
 
 def _truncate_inline(text: str) -> str:
     """Collapse all whitespace (incl. newlines) to single spaces and truncate.
@@ -248,7 +255,7 @@ def _format_change_desc(
         # A modified property reports both the old and the new value; show the
         # transition so the change is self-explanatory.
         if prev_str is not None and new_str is not None:
-            return attr, f"{attr}: {prev_str} → {new_str}"
+            return attr, f"{attr}: {prev_str}{_VALUE_TRANSITION}{new_str}"
         if new_str is not None:
             return attr, f"{attr} = {new_str}"
         return attr, attr
@@ -542,7 +549,9 @@ class PlanReporter(Reporter[PlanRow]):
                 style=style,
             )
             cli_console.styled_message(entry.domain.ljust(_DOMAIN_WIDTH) + " ")
-            cli_console.styled_message(entry.display_fqn(), style=styles.DOMAIN_STYLE)
+            cli_console.styled_message(
+                entry.display_fqn(), style=styles.OBJECT_NAME_STYLE
+            )
             cli_console.styled_message("\n")
             for detail in entry.details:
                 self._print_detail(detail)
@@ -566,18 +575,42 @@ class PlanReporter(Reporter[PlanRow]):
                 style=self._style_for_change_kind(detail.kind),
             )
         if detail.desc:
-            # When the row describes a property change, color just the property
-            # name (the leading ``attr`` portion of ``desc``) so it stands out
-            # from its value(s); everything else renders default.
+            # When the row describes a property change, the property name (the
+            # leading ``attr`` portion of ``desc``) renders neutral; only its
+            # value(s) are colored (see ``_print_detail_value``).
             if detail.attr and detail.desc.startswith(detail.attr):
                 cli_console.styled_message(" ")
-                cli_console.styled_message(detail.attr, style=styles.PROPERTY_STYLE)
+                cli_console.styled_message(detail.attr, style=styles.NEUTRAL_STYLE)
                 rest = detail.desc[len(detail.attr) :]
                 if rest:
-                    cli_console.styled_message(rest)
+                    self._print_detail_value(rest)
             else:
                 cli_console.styled_message(" " + detail.desc)
         cli_console.styled_message("\n")
+
+    @staticmethod
+    def _print_detail_value(rest: str) -> None:
+        """Render the value portion that follows a property name.
+
+        ``rest`` is one of ``": <prev> → <new>"`` (a modified property) or
+        ``" = <value>"`` (a set property). The value(s) render blue so they
+        stand out; the separators (``:``/``=``) stay neutral; and for a
+        modification the ``→`` is colored with the ALTER style to visually
+        split the previous and new value.
+        """
+        if rest.startswith(": ") and _VALUE_TRANSITION in rest:
+            prev_str, new_str = rest[2:].split(_VALUE_TRANSITION, 1)
+            cli_console.styled_message(": ")
+            cli_console.styled_message(prev_str, style=styles.VALUE_STYLE)
+            cli_console.styled_message(" ")
+            cli_console.styled_message(_VALUE_ARROW, style=styles.ALTER_STYLE)
+            cli_console.styled_message(" ")
+            cli_console.styled_message(new_str, style=styles.VALUE_STYLE)
+        elif rest.startswith(" = "):
+            cli_console.styled_message(" = ")
+            cli_console.styled_message(rest[3:], style=styles.VALUE_STYLE)
+        else:
+            cli_console.styled_message(rest)
 
     def _generate_summary_renderables(self) -> List[Text]:
         total = self._summary.total

--- a/src/snowflake/cli/_plugins/dcm/reporters/plan.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/plan.py
@@ -541,8 +541,13 @@ class PlanReporter(Reporter[PlanRow]):
         return iter(rows)
 
     def print_renderables(self, data: Iterator[PlanRow]) -> None:
-        for entry in data:
-            style = self._style_for_operation(entry.operation)
+        entries = list(data)
+        last_index = len(entries) - 1
+        for index, entry in enumerate(entries):
+            # The operation keyword (CREATE/ALTER/DROP) is bold so it anchors
+            # the row; the shared CREATE/ALTER/DROP styles stay non-bold for the
+            # sub-change keywords inside the tree.
+            style = self._style_for_operation(entry.operation) + styles.BOLD_STYLE
 
             cli_console.styled_message(
                 entry.operation.ljust(_OPERATION_WIDTH) + " ",
@@ -555,6 +560,11 @@ class PlanReporter(Reporter[PlanRow]):
             cli_console.styled_message("\n")
             for detail in entry.details:
                 self._print_detail(detail)
+            # Separate a rendered tree from whatever follows. The summary already
+            # emits its own leading blank line, so skip the separator after the
+            # final entity to avoid a doubled blank before the summary.
+            if entry.details and index != last_index:
+                cli_console.styled_message("\n")
 
     def _print_detail(self, detail: PlanDetail) -> None:
         # Tree prefix renders dim so it recedes visually — the colored kind

--- a/src/snowflake/cli/_plugins/dcm/reporters/refresh.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/refresh.py
@@ -204,7 +204,7 @@ class RefreshReporter(Reporter[RefreshRow]):
                 row.formatted_deleted.rjust(self.STATS_WIDTH) + " ",
                 style=styles.REMOVED_STYLE,
             )
-            cli_console.styled_message(row.table_name, style=styles.DOMAIN_STYLE)
+            cli_console.styled_message(row.table_name, style=styles.OBJECT_NAME_STYLE)
             cli_console.styled_message("\n")
 
     def _generate_summary_renderables(self) -> List[Text]:

--- a/src/snowflake/cli/_plugins/dcm/reporters/test.py
+++ b/src/snowflake/cli/_plugins/dcm/reporters/test.py
@@ -136,7 +136,7 @@ class TestReporter(Reporter[TestRow]):
                 status_text.ljust(self.STATUS_WIDTH) + " ",
                 style=style,
             )
-            cli_console.styled_message(row.table_name, style=styles.DOMAIN_STYLE)
+            cli_console.styled_message(row.table_name, style=styles.OBJECT_NAME_STYLE)
             cli_console.styled_message(f" ({row.expectation_name})")
             cli_console.styled_message("\n")
 

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 from rich.style import Style
 
-_COLOR_BLUE = "#a0a8fe"
+# Single source of truth for the DCM "blue" hue. Use the terminal-default
+# named color (not a fixed hex) so it respects the user's theme and stays
+# identical everywhere it's used: progress spinner/bar, running phase,
+# analyze INFO findings / file headers, refresh status, and unknown rows.
+BLUE = "blue"
 
 DOMAIN_STYLE = Style(color="cyan")
 BOLD_STYLE = Style(bold=True)
 
 # Refresh
-STATUS_STYLE = Style(color=_COLOR_BLUE)
+STATUS_STYLE = Style(color=BLUE)
 REMOVED_STYLE = Style(color="red", italic=True)
 INSERTED_STYLE = Style(color="green", italic=True)
 
@@ -28,18 +32,18 @@ PASS_STYLE = Style(color="green")
 FAIL_STYLE = Style(color="red")
 WARNING_STYLE = Style(color="yellow")
 # INFO-severity analyze findings: plain blue (distinct from bold-blue file headers).
-INFO_STYLE = Style(color="blue")
+INFO_STYLE = Style(color=BLUE)
 
 # Plan
 CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
-UNKNOWN_STYLE = Style(color=_COLOR_BLUE)
+UNKNOWN_STYLE = Style(color=BLUE)
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)
-PHASE_RUNNING_STYLE = Style(color="blue", bold=True)
+PHASE_RUNNING_STYLE = Style(color=BLUE, bold=True)
 PHASE_FAILED_STYLE = Style(color="red", bold=True)
 
 # Analyze (file/source path headers stand out in bold blue).
-FILE_PATH_STYLE = Style(color="blue", bold=True)
+FILE_PATH_STYLE = Style(color=BLUE, bold=True)

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -19,8 +19,13 @@ from rich.style import Style
 # analyze INFO findings / file headers, refresh status, and unknown rows.
 BLUE = "blue"
 
-DOMAIN_STYLE = Style(color="cyan")
 BOLD_STYLE = Style(bold=True)
+
+# Object names (FQNs / table names) across all DCM commands — the top-level
+# CREATE/ALTER/DROP row in plan/deploy and the table column in refresh/test.
+# Named "magenta" (the ANSI purple) rather than a fixed hex so it follows the
+# user's terminal theme, consistent with BLUE above.
+OBJECT_NAME_STYLE = Style(color="magenta")
 
 # Refresh
 STATUS_STYLE = Style(color=BLUE)
@@ -45,10 +50,6 @@ UNKNOWN_STYLE = Style(color=BLUE)
 # Property values that are set / changed in ALTER detail rows render blue so
 # they stand out from the (neutral) property name and the operation keyword.
 VALUE_STYLE = Style(color=BLUE)
-# Top-level operation object names (the FQN on a CREATE/ALTER/DROP row). Named
-# "magenta" (the ANSI purple) rather than a fixed hex so it follows the user's
-# terminal theme, consistent with BLUE above.
-OBJECT_NAME_STYLE = Style(color="magenta")
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -35,14 +35,20 @@ WARNING_STYLE = Style(color="yellow")
 INFO_STYLE = Style(color=BLUE)
 
 # Plan
+# Terminal-default (no color). Used for the "set" sub-change keyword, which
+# assigns a property value and shouldn't read as a creation (green).
+NEUTRAL_STYLE = Style()
 CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
 UNKNOWN_STYLE = Style(color=BLUE)
-# Property names in ALTER detail rows (e.g. WAREHOUSE_SIZE, COMMENT). Named
+# Property values that are set / changed in ALTER detail rows render blue so
+# they stand out from the (neutral) property name and the operation keyword.
+VALUE_STYLE = Style(color=BLUE)
+# Top-level operation object names (the FQN on a CREATE/ALTER/DROP row). Named
 # "magenta" (the ANSI purple) rather than a fixed hex so it follows the user's
 # terminal theme, consistent with BLUE above.
-PROPERTY_STYLE = Style(color="magenta")
+OBJECT_NAME_STYLE = Style(color="magenta")
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -47,9 +47,10 @@ CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
 UNKNOWN_STYLE = Style(color=BLUE)
-# Property values that are set / changed in ALTER detail rows render blue so
-# they stand out from the (neutral) property name and the operation keyword.
-VALUE_STYLE = Style(color=BLUE)
+# Property values that are set / changed in ALTER detail rows. Uses the cyan
+# hue that object names previously used (now magenta) so values stand out from
+# the (neutral) property name and the operation keyword.
+VALUE_STYLE = Style(color="cyan")
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)

--- a/src/snowflake/cli/_plugins/dcm/styles.py
+++ b/src/snowflake/cli/_plugins/dcm/styles.py
@@ -39,6 +39,10 @@ CREATE_STYLE = Style(color="green")
 ALTER_STYLE = Style(color="yellow")
 DROP_STYLE = Style(color="red")
 UNKNOWN_STYLE = Style(color=BLUE)
+# Property names in ALTER detail rows (e.g. WAREHOUSE_SIZE, COMMENT). Named
+# "magenta" (the ANSI purple) rather than a fixed hex so it follows the user's
+# terminal theme, consistent with BLUE above.
+PROPERTY_STYLE = Style(color="magenta")
 
 # Deploy progress phases
 PHASE_DONE_STYLE = Style(color="green", bold=True)

--- a/tests/dcm/test_reporters/__snapshots__/test_plan_reporter.ambr
+++ b/tests/dcm/test_reporters/__snapshots__/test_plan_reporter.ambr
@@ -4,7 +4,7 @@
   ALTER    TABLE                DCM_DEMO_1_DEV3.ANALYTICS.ENRICHED_ORDER_DETAILS
   └─ added SNOWFLAKE.CORE.NULL_COUNT$V1(CUSTOMER_CITY)
      └─ added NO_MISSING_CITIES
-        └─ set expression = value = 0
+        └─ set EXPRESSION = value = 0
   
   Planned 1 entity (0 to create, 1 to alter, 0 to drop).
   ================================================================================

--- a/tests/dcm/test_reporters/__snapshots__/test_plan_reporter.ambr
+++ b/tests/dcm/test_reporters/__snapshots__/test_plan_reporter.ambr
@@ -1,4 +1,41 @@
 # serializer version: 1
+# name: TestPlanReporterTerse.test_alter_with_added_dmf_and_nested_expectation
+  '''
+  ALTER    TABLE                DCM_DEMO_1_DEV3.ANALYTICS.ENRICHED_ORDER_DETAILS
+  └─ added SNOWFLAKE.CORE.NULL_COUNT$V1(CUSTOMER_CITY)
+     └─ added NO_MISSING_CITIES
+        └─ set expression = value = 0
+  
+  Planned 1 entity (0 to create, 1 to alter, 0 to drop).
+  ================================================================================
+  
+  '''
+# ---
+# name: TestPlanReporterTerse.test_alter_with_modified_grants_nested
+  '''
+  ALTER    ROLE                 DCM_DEVELOPER
+  ├─ added DATABASE_ROLE DCM_DEMO_1_DEV3.ADMIN_DEV3
+  ├─ added ROLE TEST_TEAM_OWNER_DEV3
+  ├─ modified ON SCHEMA DCM_DEMO_1_DEV2.TEST_TEAM
+  │  └─ added OWNERSHIP
+  ├─ removed DATABASE_ROLE DCM_DEMO_1_DEV2.ADMIN_DEV2
+  └─ removed ROLE TEST_TEAM_OWNER_DEV2
+  
+  Planned 1 entity (0 to create, 1 to alter, 0 to drop).
+  ================================================================================
+  
+  '''
+# ---
+# name: TestPlanReporterTerse.test_alter_with_removed_data_metric_function
+  '''
+  ALTER    TABLE                DCM_DEMO_1_DEV2.ANALYTICS.ENRICHED_ORDER_DETAILS
+  └─ removed SNOWHOUSE_IMPORT.CORE.NULL_COUNT$V1(CUSTOMER_CITY)
+  
+  Planned 1 entity (0 to create, 1 to alter, 0 to drop).
+  ================================================================================
+  
+  '''
+# ---
 # name: TestPlanReporterTerse.test_full_ordering
   '''
   CREATE   DATABASE             D1
@@ -10,6 +47,7 @@
   DROP     TABLE                T_OLD
   
   Planned 7 entities (3 to create, 2 to alter, 2 to drop).
+  ================================================================================
   
   '''
 # ---
@@ -20,6 +58,7 @@
   DROP     ROLE                 OLD_ROLE
   
   Planned 3 entities (1 to create, 1 to alter, 1 to drop).
+  ================================================================================
   
   '''
 # ---
@@ -28,6 +67,7 @@
   CREATE   TABLE                DB.SCH.ORDERS
   
   Planned 1 entity (1 to create, 0 to alter, 0 to drop).
+  ================================================================================
   
   '''
 # ---

--- a/tests/dcm/test_reporters/test_plan_reporter.py
+++ b/tests/dcm/test_reporters/test_plan_reporter.py
@@ -548,7 +548,7 @@ class TestPlanReporterTerse:
 
         assert "added SNOWFLAKE.CORE.NULL_COUNT$V1(CUSTOMER_CITY)" in output
         assert "added NO_MISSING_CITIES" in output
-        assert "set expression = value = 0" in output
+        assert "set EXPRESSION = value = 0" in output
         assert output == snapshot
 
     def test_create_with_changes_does_not_render_details(self):

--- a/tests/dcm/test_reporters/test_plan_reporter.py
+++ b/tests/dcm/test_reporters/test_plan_reporter.py
@@ -633,7 +633,7 @@ class TestPlanReporterTerse:
         "kind, expected_style",
         [
             ("added", styles.CREATE_STYLE),
-            ("set", styles.CREATE_STYLE),
+            ("set", styles.NEUTRAL_STYLE),
             ("removed", styles.DROP_STYLE),
             ("unset", styles.DROP_STYLE),
             ("modified", styles.ALTER_STYLE),

--- a/tests/dcm/test_reporters/test_plan_reporter.py
+++ b/tests/dcm/test_reporters/test_plan_reporter.py
@@ -618,6 +618,7 @@ class TestPlanReporterTerse:
             ("removed", styles.DROP_STYLE),
             ("unset", styles.DROP_STYLE),
             ("modified", styles.ALTER_STYLE),
+            ("changed", styles.ALTER_STYLE),
             ("renamed", styles.ALTER_STYLE),
         ],
     )

--- a/tests/dcm/test_reporters/test_plan_reporter.py
+++ b/tests/dcm/test_reporters/test_plan_reporter.py
@@ -551,6 +551,53 @@ class TestPlanReporterTerse:
         assert "set EXPRESSION = value = 0" in output
         assert output == snapshot
 
+    def test_blank_line_separates_consecutive_trees(self):
+        """A rendered ALTER tree is followed by a blank line before the next
+        entity, but not before the trailing summary (which adds its own)."""
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "ALTER",
+                    "object_id": {
+                        "domain": "WAREHOUSE",
+                        "name": '"WH1"',
+                        "fqn": '"WH1"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "set",
+                            "attribute_name": "warehouse_size",
+                            "value": "SMALL",
+                        }
+                    ],
+                },
+                {
+                    "type": "ALTER",
+                    "object_id": {
+                        "domain": "WAREHOUSE",
+                        "name": '"WH2"',
+                        "fqn": '"WH2"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "set",
+                            "attribute_name": "warehouse_size",
+                            "value": "LARGE",
+                        }
+                    ],
+                },
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+
+        # First tree is separated from the next entity by a blank line.
+        assert "set WAREHOUSE_SIZE = SMALL\n\nALTER" in output
+        # The last tree is not double-spaced: only the summary's own blank line
+        # sits between it and the summary text.
+        assert "set WAREHOUSE_SIZE = LARGE\n\nPlanned" in output
+
     def test_create_with_changes_does_not_render_details(self):
         """CREATE rows must stay terse even when the payload includes ``changes``.
 

--- a/tests/dcm/test_reporters/test_plan_reporter.py
+++ b/tests/dcm/test_reporters/test_plan_reporter.py
@@ -16,9 +16,11 @@ from unittest import mock
 import pytest
 from snowflake.cli._plugins.dcm import styles
 from snowflake.cli._plugins.dcm.reporters.plan import (
+    _MAX_VALUE_LEN,
     PlanDetail,
     PlanReporter,
     PlanRow,
+    _truncate_inline,
 )
 from snowflake.cli.api.identifiers import FQN
 
@@ -34,6 +36,23 @@ def plan_entity_change_factory(operation: str, domain: str, name: str):
         "type": operation,
         "object_id": {"domain": domain, "name": f'"{name}"', "fqn": f'"{name}"'},
     }
+
+
+class TestTruncateInline:
+    def test_short_value_is_unchanged(self):
+        assert _truncate_inline("SMALL") == "SMALL"
+
+    def test_collapses_internal_whitespace_and_newlines(self):
+        assert _truncate_inline("a\n  b\t c") == "a b c"
+
+    def test_value_at_limit_is_not_truncated(self):
+        value = "x" * _MAX_VALUE_LEN
+        assert _truncate_inline(value) == value
+
+    def test_long_value_is_truncated_with_ellipsis(self):
+        result = _truncate_inline("y" * (_MAX_VALUE_LEN + 10))
+        assert result == "y" * _MAX_VALUE_LEN + "…"
+        assert len(result) == _MAX_VALUE_LEN + 1
 
 
 class TestPlanReporterTerse:
@@ -836,10 +855,23 @@ class TestPlanRow:
         # Three siblings at depth 1: only the last is_last=True.
         assert row.details == [
             PlanDetail(
-                kind="set", desc="warehouse_size = LARGE", is_last_chain=(False,)
+                kind="set",
+                desc="WAREHOUSE_SIZE = LARGE",
+                is_last_chain=(False,),
+                attr="WAREHOUSE_SIZE",
             ),
-            PlanDetail(kind="set", desc="auto_suspend = 60", is_last_chain=(False,)),
-            PlanDetail(kind="set", desc="auto_resume = true", is_last_chain=(True,)),
+            PlanDetail(
+                kind="set",
+                desc="AUTO_SUSPEND = 60",
+                is_last_chain=(False,),
+                attr="AUTO_SUSPEND",
+            ),
+            PlanDetail(
+                kind="set",
+                desc="AUTO_RESUME = true",
+                is_last_chain=(True,),
+                attr="AUTO_RESUME",
+            ),
         ]
 
     def test_from_dict_set_with_complex_value_drops_rhs(self):
@@ -859,7 +891,9 @@ class TestPlanRow:
         row = PlanRow.from_dict(entry)
 
         assert row.details == [
-            PlanDetail(kind="set", desc="columns", is_last_chain=(True,))
+            PlanDetail(
+                kind="set", desc="COLUMNS", is_last_chain=(True,), attr="COLUMNS"
+            )
         ]
 
     def test_from_dict_handles_unset(self):
@@ -878,8 +912,77 @@ class TestPlanRow:
         row = PlanRow.from_dict(entry)
 
         assert row.details == [
-            PlanDetail(kind="unset", desc="comment", is_last_chain=(True,))
+            PlanDetail(
+                kind="unset", desc="COMMENT", is_last_chain=(True,), attr="COMMENT"
+            )
         ]
+
+    def test_from_dict_modified_property_shows_prev_and_new(self):
+        """A changed property reports both values; render ``prev → new``."""
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "WAREHOUSE", "fqn": '"WH"'},
+            "changes": [
+                {
+                    "kind": "set",
+                    "attribute_name": "warehouse_size",
+                    "prev_value": "SMALL",
+                    "value": "LARGE",
+                },
+                {
+                    "kind": "modified",
+                    "attribute_name": "auto_suspend",
+                    "prev_value": 60,
+                    "value": 120,
+                },
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.details == [
+            PlanDetail(
+                kind="set",
+                desc="WAREHOUSE_SIZE: SMALL → LARGE",
+                is_last_chain=(False,),
+                attr="WAREHOUSE_SIZE",
+            ),
+            PlanDetail(
+                kind="modified",
+                desc="AUTO_SUSPEND: 60 → 120",
+                is_last_chain=(True,),
+                attr="AUTO_SUSPEND",
+            ),
+        ]
+
+    def test_from_dict_modified_property_truncates_long_multiline_values(self):
+        """Multi-line / long SQL bodies are collapsed to one line and cut."""
+        prev_body = "SELECT 1"
+        new_body = "SELECT\n  a,\n  b,\n  c\nFROM " + ("x" * 80)
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "VIEW", "fqn": '"V"'},
+            "changes": [
+                {
+                    "kind": "modified",
+                    "attribute_name": "text",
+                    "prev_value": prev_body,
+                    "value": new_body,
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert len(row.details) == 1
+        desc = row.details[0].desc
+        prev_rendered, new_rendered = desc.removeprefix("TEXT: ").split(" → ")
+        # Short previous value is shown verbatim; long new value is collapsed
+        # to a single line (no newlines) and truncated with an ellipsis.
+        assert prev_rendered == "SELECT 1"
+        assert "\n" not in new_rendered
+        assert new_rendered.endswith("…")
+        assert len(new_rendered) == _MAX_VALUE_LEN + 1
 
     def test_from_dict_create_skips_details(self):
         """Only ALTER rows render sub-changes; CREATE stays terse."""

--- a/tests/dcm/test_reporters/test_plan_reporter.py
+++ b/tests/dcm/test_reporters/test_plan_reporter.py
@@ -11,11 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import mock
+
 import pytest
-from snowflake.cli._plugins.dcm.reporters.plan import PlanReporter, PlanRow
+from snowflake.cli._plugins.dcm import styles
+from snowflake.cli._plugins.dcm.reporters.plan import (
+    PlanDetail,
+    PlanReporter,
+    PlanRow,
+)
 from snowflake.cli.api.identifiers import FQN
 
-from tests.dcm.test_reporters.utils import FakeCursor, capture_reporter_output
+from tests.dcm.test_reporters.utils import (
+    CLI_CONSOLE_PATH,
+    FakeCursor,
+    capture_reporter_output,
+)
 
 
 def plan_entity_change_factory(operation: str, domain: str, name: str):
@@ -229,6 +240,427 @@ class TestPlanReporterTerse:
         assert lines[0].startswith("CREATE")
         assert lines[1].startswith("WEIRD")
 
+    def test_alter_with_removed_data_metric_function(self, snapshot):
+        """Single nested collection wrapper around a single 'removed' leaf change.
+
+        Real payload shape from a TABLE ALTER that drops one data metric
+        function; the leaf's ``item_id.desc`` carries the human-readable
+        identifier we want to surface.
+        """
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "ALTER",
+                    "object_id": {
+                        "domain": "TABLE",
+                        "name": '"ENRICHED_ORDER_DETAILS"',
+                        "fqn": (
+                            '"DCM_DEMO_1_DEV2"."ANALYTICS"."ENRICHED_ORDER_DETAILS"'
+                        ),
+                        "database": '"DCM_DEMO_1_DEV2"',
+                        "schema": '"ANALYTICS"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "collection",
+                            "collection_name": "data_metric_functions",
+                            "changes": [
+                                {
+                                    "kind": "removed",
+                                    "item_id": {
+                                        "columns": ["CUSTOMER_CITY"],
+                                        "desc": (
+                                            "SNOWHOUSE_IMPORT.CORE.NULL_COUNT$V1"
+                                            "(CUSTOMER_CITY)"
+                                        ),
+                                        "metric_name": (
+                                            "SNOWHOUSE_IMPORT.CORE.NULL_COUNT$V1"
+                                            "(TABLE(VARCHAR))"
+                                        ),
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+        assert output == snapshot
+        assert "removed SNOWHOUSE_IMPORT.CORE.NULL_COUNT$V1(CUSTOMER_CITY)" in output
+
+    def test_alter_with_modified_grants_nested(self, snapshot):
+        """ROLE ALTER with mixed added/removed leaves plus a 'modified' parent.
+
+        Validates that:
+        - ``collection`` wrappers are unwrapped (no header line emitted).
+        - 5 leaf changes are surfaced under the ALTER row.
+        - The 'modified' entry's nested ``added OWNERSHIP`` renders deeper
+          (header_plus_indent rule).
+        """
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "ALTER",
+                    "object_id": {
+                        "domain": "ROLE",
+                        "name": '"DCM_DEVELOPER"',
+                        "fqn": '"DCM_DEVELOPER"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "collection",
+                            "collection_name": "grants",
+                            "changes": [
+                                {
+                                    "kind": "removed",
+                                    "item_id": {
+                                        "desc": (
+                                            "DATABASE_ROLE "
+                                            "DCM_DEMO_1_DEV2.ADMIN_DEV2"
+                                        ),
+                                        "securable_object_domain": "DATABASE_ROLE",
+                                        "securable_object_name": (
+                                            "DCM_DEMO_1_DEV2.ADMIN_DEV2"
+                                        ),
+                                    },
+                                },
+                                {
+                                    "kind": "added",
+                                    "item_id": {
+                                        "desc": (
+                                            "DATABASE_ROLE "
+                                            "DCM_DEMO_1_DEV3.ADMIN_DEV3"
+                                        ),
+                                        "securable_object_domain": "DATABASE_ROLE",
+                                        "securable_object_name": (
+                                            "DCM_DEMO_1_DEV3.ADMIN_DEV3"
+                                        ),
+                                    },
+                                },
+                                {
+                                    "kind": "modified",
+                                    "item_id": {
+                                        "desc": ("ON SCHEMA DCM_DEMO_1_DEV2.TEST_TEAM"),
+                                        "securable_object_domain": "SCHEMA",
+                                        "securable_object_name": (
+                                            "DCM_DEMO_1_DEV2.TEST_TEAM"
+                                        ),
+                                    },
+                                    "changes": [
+                                        {
+                                            "kind": "collection",
+                                            "collection_name": "privileges",
+                                            "changes": [
+                                                {
+                                                    "kind": "added",
+                                                    "item_id": {
+                                                        "desc": "OWNERSHIP",
+                                                        "privilege": "OWNERSHIP",
+                                                    },
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "kind": "removed",
+                                    "item_id": {
+                                        "desc": "ROLE TEST_TEAM_OWNER_DEV2",
+                                        "securable_object_domain": "ROLE",
+                                        "securable_object_name": (
+                                            "TEST_TEAM_OWNER_DEV2"
+                                        ),
+                                    },
+                                },
+                                {
+                                    "kind": "added",
+                                    "item_id": {
+                                        "desc": "ROLE TEST_TEAM_OWNER_DEV3",
+                                        "securable_object_domain": "ROLE",
+                                        "securable_object_name": (
+                                            "TEST_TEAM_OWNER_DEV3"
+                                        ),
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+
+        lines = [line for line in output.split("\n") if line.strip()]
+        assert lines[0].startswith("ALTER")
+        assert "ROLE" in lines[0] and "DCM_DEVELOPER" in lines[0]
+        # All 5 leaves at depth 1; nested OWNERSHIP at depth 2.
+        leaf_descs = [
+            "DATABASE_ROLE DCM_DEMO_1_DEV2.ADMIN_DEV2",
+            "DATABASE_ROLE DCM_DEMO_1_DEV3.ADMIN_DEV3",
+            "ON SCHEMA DCM_DEMO_1_DEV2.TEST_TEAM",
+            "ROLE TEST_TEAM_OWNER_DEV2",
+            "ROLE TEST_TEAM_OWNER_DEV3",
+        ]
+        for desc in leaf_descs:
+            assert desc in output
+        # Nested 'added OWNERSHIP' should be indented one level deeper than
+        # its parent 'modified ON SCHEMA …'. Compare the column where each
+        # kind keyword starts — that survives the tree-prefix characters
+        # without needing to strip them out.
+        modified_line = next(line for line in lines if " modified " in line)
+        owner_line = next(
+            line for line in lines if " added " in line and "OWNERSHIP" in line
+        )
+        assert owner_line.index("added") > modified_line.index("modified")
+
+        assert output == snapshot
+
+    def test_alter_summary_counts_entities_not_details(self):
+        """Sub-change leaves must not inflate the ALTER summary count."""
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "ALTER",
+                    "object_id": {
+                        "domain": "ROLE",
+                        "name": '"R"',
+                        "fqn": '"R"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "collection",
+                            "collection_name": "grants",
+                            "changes": [
+                                {
+                                    "kind": "added",
+                                    "item_id": {"desc": "ROLE A"},
+                                },
+                                {
+                                    "kind": "removed",
+                                    "item_id": {"desc": "ROLE B"},
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+
+        assert "Planned 1 entity (0 to create, 1 to alter, 0 to drop)." in output
+
+    def test_alter_with_added_dmf_and_nested_expectation(self, snapshot):
+        """Real-world ALTER adding a DMF with a nested expectation.
+
+        Exercises three previously-unhandled shapes in one entry:
+        - ``added`` with a dict ``item_id`` (DMF identifier).
+        - ``added`` with a string ``item_id`` (expectation name).
+        - ``set`` with ``attribute_name`` + scalar ``value``.
+        """
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "ALTER",
+                    "object_id": {
+                        "domain": "TABLE",
+                        "name": '"ENRICHED_ORDER_DETAILS"',
+                        "fqn": (
+                            '"DCM_DEMO_1_DEV3"."ANALYTICS"."ENRICHED_ORDER_DETAILS"'
+                        ),
+                        "database": '"DCM_DEMO_1_DEV3"',
+                        "schema": '"ANALYTICS"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "collection",
+                            "collection_name": "data_metric_functions",
+                            "changes": [
+                                {
+                                    "kind": "added",
+                                    "item_id": {
+                                        "columns": ["CUSTOMER_CITY"],
+                                        "desc": (
+                                            "SNOWFLAKE.CORE.NULL_COUNT$V1"
+                                            "(CUSTOMER_CITY)"
+                                        ),
+                                        "metric_name": (
+                                            "SNOWFLAKE.CORE.NULL_COUNT$V1"
+                                            "(TABLE(VARCHAR))"
+                                        ),
+                                    },
+                                    "changes": [
+                                        {
+                                            "kind": "collection",
+                                            "collection_name": "expectations",
+                                            "changes": [
+                                                {
+                                                    "kind": "added",
+                                                    "item_id": "NO_MISSING_CITIES",
+                                                    "changes": [
+                                                        {
+                                                            "kind": "set",
+                                                            "attribute_name": (
+                                                                "expression"
+                                                            ),
+                                                            "value": "value = 0",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+
+        assert "added SNOWFLAKE.CORE.NULL_COUNT$V1(CUSTOMER_CITY)" in output
+        assert "added NO_MISSING_CITIES" in output
+        assert "set expression = value = 0" in output
+        assert output == snapshot
+
+    def test_create_with_changes_does_not_render_details(self):
+        """CREATE rows must stay terse even when the payload includes ``changes``.
+
+        Real server payloads carry ``set``/``unset`` attribute dumps under
+        CREATE and DROP entries; surfacing those would balloon the output
+        with low-signal lines.
+        """
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "CREATE",
+                    "object_id": {
+                        "domain": "TABLE",
+                        "name": '"T"',
+                        "fqn": '"DB"."SCH"."T"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "set",
+                            "attribute_name": "comment",
+                            "value": "hello",
+                        },
+                        {
+                            "kind": "set",
+                            "attribute_name": "data_retention_time_in_days",
+                            "value": 1,
+                        },
+                    ],
+                }
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+
+        lines = [line for line in output.split("\n") if line.strip()]
+        assert lines[0].startswith("CREATE")
+        # No sub-lines under CREATE.
+        assert all(not line.startswith(" ") for line in lines)
+        assert "comment" not in output
+        assert "data_retention_time_in_days" not in output
+
+    def test_drop_with_changes_does_not_render_details(self):
+        """DROP rows must not surface their ``unset`` attribute dump."""
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "DROP",
+                    "object_id": {
+                        "domain": "SCHEMA",
+                        "name": '"S"',
+                        "fqn": '"DB"."S"',
+                    },
+                    "changes": [
+                        {
+                            "kind": "unset",
+                            "attribute_name": "data_retention_time_in_days",
+                            "prev_value": 1,
+                        },
+                        {
+                            "kind": "unset",
+                            "attribute_name": "log_level",
+                            "prev_value": "WARN",
+                        },
+                    ],
+                }
+            ],
+        }
+        output = capture_reporter_output(PlanReporter(), FakeCursor(data))
+
+        lines = [line for line in output.split("\n") if line.strip()]
+        assert lines[0].startswith("DROP")
+        assert all(not line.startswith(" ") for line in lines)
+        assert "data_retention_time_in_days" not in output
+        assert "log_level" not in output
+
+    @pytest.mark.parametrize(
+        "kind, expected_style",
+        [
+            ("added", styles.CREATE_STYLE),
+            ("set", styles.CREATE_STYLE),
+            ("removed", styles.DROP_STYLE),
+            ("unset", styles.DROP_STYLE),
+            ("modified", styles.ALTER_STYLE),
+            ("renamed", styles.ALTER_STYLE),
+        ],
+    )
+    def test_detail_kind_keyword_is_colored_desc_is_default(self, kind, expected_style):
+        """Only the operation keyword is colored; the description stays plain.
+
+        On indented sub-lines under an ALTER row we want the eye to land on
+        the verb (added/removed/modified/set/…) without coloring the whole
+        line, which would otherwise drown out the entity names that follow.
+        """
+        data = {
+            "version": 2,
+            "metadata": {},
+            "changeset": [
+                {
+                    "type": "ALTER",
+                    "object_id": {"domain": "TABLE", "fqn": '"T"'},
+                    "changes": [
+                        {
+                            "kind": kind,
+                            "item_id": {"desc": "SOME_DESC"},
+                            "attribute_name": "an_attr",
+                            "value": "v",
+                        }
+                    ],
+                }
+            ],
+        }
+        calls = []
+
+        def record(text, style=""):
+            calls.append((str(text), style))
+
+        with mock.patch(CLI_CONSOLE_PATH, side_effect=record):
+            PlanReporter().process(FakeCursor(data))
+
+        kind_call = next(c for c in calls if c[0].strip() == kind)
+        desc_call = next(c for c in calls if "SOME_DESC" in c[0])
+        assert kind_call[1] == expected_style
+        # The description part must render with the default style so the
+        # entity name doesn't pick up the kind color.
+        assert desc_call[1] == ""
+
 
 class TestPlanRow:
     def test_from_dict_valid_entry(self):
@@ -249,6 +681,267 @@ class TestPlanRow:
         assert row.domain == "TABLE"
         assert row.fqn is not None
         assert row.display_fqn() == "DB.SCH.ORDERS"
+        assert row.details == []
+
+    def test_from_dict_extracts_alter_details(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": {
+                "domain": "TABLE",
+                "name": '"T"',
+                "fqn": '"DB"."SCH"."T"',
+            },
+            "changes": [
+                {
+                    "kind": "collection",
+                    "collection_name": "data_metric_functions",
+                    "changes": [
+                        {
+                            "kind": "removed",
+                            "item_id": {
+                                "desc": "M.F$V1(C)",
+                                "columns": ["C"],
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        # Sole child at depth 1 → ``is_last_chain=(True,)``.
+        assert row.details == [
+            PlanDetail(kind="removed", desc="M.F$V1(C)", is_last_chain=(True,))
+        ]
+
+    def test_from_dict_recurses_into_modified_with_nested_changes(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "ROLE", "fqn": '"R"'},
+            "changes": [
+                {
+                    "kind": "collection",
+                    "collection_name": "grants",
+                    "changes": [
+                        {
+                            "kind": "modified",
+                            "item_id": {"desc": "ON SCHEMA S"},
+                            "changes": [
+                                {
+                                    "kind": "collection",
+                                    "collection_name": "privileges",
+                                    "changes": [
+                                        {
+                                            "kind": "added",
+                                            "item_id": {"desc": "OWNERSHIP"},
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        # The ``modified`` entry is the sole leaf at depth 1; its nested
+        # ``added`` is the sole leaf at depth 2 → both ``is_last`` chains end
+        # in ``True``.
+        assert row.details == [
+            PlanDetail(kind="modified", desc="ON SCHEMA S", is_last_chain=(True,)),
+            PlanDetail(kind="added", desc="OWNERSHIP", is_last_chain=(True, True)),
+        ]
+
+    def test_from_dict_details_sanitize_ansi_codes(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "ROLE", "fqn": '"R"'},
+            "changes": [
+                {
+                    "kind": "added\x1b[31m",
+                    "item_id": {"desc": "ROLE \x1b[0mX"},
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert len(row.details) == 1
+        detail = row.details[0]
+        assert "\x1b" not in detail.kind
+        assert "\x1b" not in detail.desc
+
+    def test_from_dict_empty_changes_yields_no_details(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "TABLE", "fqn": '"T"'},
+            "changes": [],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.details == []
+
+    def test_from_dict_handles_string_item_id(self):
+        """``item_id`` may be a bare string (e.g. a column or expectation name)."""
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "TABLE", "fqn": '"T"'},
+            "changes": [
+                {
+                    "kind": "collection",
+                    "collection_name": "expectations",
+                    "changes": [
+                        {"kind": "added", "item_id": "NO_MISSING_CITIES"},
+                    ],
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.details == [
+            PlanDetail(kind="added", desc="NO_MISSING_CITIES", is_last_chain=(True,)),
+        ]
+
+    def test_from_dict_handles_set_with_scalar_value(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "WAREHOUSE", "fqn": '"WH"'},
+            "changes": [
+                {
+                    "kind": "set",
+                    "attribute_name": "warehouse_size",
+                    "value": "LARGE",
+                },
+                {
+                    "kind": "set",
+                    "attribute_name": "auto_suspend",
+                    "value": 60,
+                },
+                {
+                    "kind": "set",
+                    "attribute_name": "auto_resume",
+                    "value": True,
+                },
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        # Three siblings at depth 1: only the last is_last=True.
+        assert row.details == [
+            PlanDetail(
+                kind="set", desc="warehouse_size = LARGE", is_last_chain=(False,)
+            ),
+            PlanDetail(kind="set", desc="auto_suspend = 60", is_last_chain=(False,)),
+            PlanDetail(kind="set", desc="auto_resume = true", is_last_chain=(True,)),
+        ]
+
+    def test_from_dict_set_with_complex_value_drops_rhs(self):
+        """Complex (dict/list) values are too verbose to inline; show attr only."""
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "TABLE", "fqn": '"T"'},
+            "changes": [
+                {
+                    "kind": "set",
+                    "attribute_name": "columns",
+                    "value": [{"name": "C", "datatype": "VARCHAR"}],
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.details == [
+            PlanDetail(kind="set", desc="columns", is_last_chain=(True,))
+        ]
+
+    def test_from_dict_handles_unset(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": {"domain": "WAREHOUSE", "fqn": '"WH"'},
+            "changes": [
+                {
+                    "kind": "unset",
+                    "attribute_name": "comment",
+                    "prev_value": "old",
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.details == [
+            PlanDetail(kind="unset", desc="comment", is_last_chain=(True,))
+        ]
+
+    def test_from_dict_create_skips_details(self):
+        """Only ALTER rows render sub-changes; CREATE stays terse."""
+        entry = {
+            "type": "CREATE",
+            "object_id": {"domain": "TABLE", "fqn": '"T"'},
+            "changes": [
+                {
+                    "kind": "set",
+                    "attribute_name": "comment",
+                    "value": "x",
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.operation == "CREATE"
+        assert row.details == []
+
+    def test_from_dict_drop_skips_details(self):
+        entry = {
+            "type": "DROP",
+            "object_id": {"domain": "SCHEMA", "fqn": '"S"'},
+            "changes": [
+                {
+                    "kind": "unset",
+                    "attribute_name": "comment",
+                    "prev_value": "x",
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.operation == "DROP"
+        assert row.details == []
+
+    def test_from_dict_fallback_still_extracts_details(self):
+        entry = {
+            "type": "ALTER",
+            "object_id": "not_a_dict",
+            "changes": [
+                {
+                    "kind": "collection",
+                    "collection_name": "grants",
+                    "changes": [
+                        {"kind": "added", "item_id": {"desc": "ROLE A"}},
+                        {"kind": "removed", "item_id": {"desc": "ROLE B"}},
+                    ],
+                }
+            ],
+        }
+
+        row = PlanRow.from_dict(entry)
+
+        assert row.operation == "ALTER"
+        assert row.domain == "UNKNOWN"
+        # Two siblings under the collection wrapper → is_last_chain (False,) then (True,).
+        assert row.details == [
+            PlanDetail(kind="added", desc="ROLE A", is_last_chain=(False,)),
+            PlanDetail(kind="removed", desc="ROLE B", is_last_chain=(True,)),
+        ]
 
     def test_from_dict_fallback_on_missing_required_fields(self):
         entry = {


### PR DESCRIPTION
…tput

Each ALTER row in `snow dcm plan` and `snow dcm deploy` output now expands into a child tree showing individual property changes, colored by operation (added/modified/removed) with only the keyword colored, not the full line. Children are sorted: added → modified → removed.

- Expand ALTER rows with per-change detail lines indented as a tree
- Color only the operation keyword on ALTER child lines
- Sort nested ALTER children by kind
- Drop kind-column padding on ALTER child rows (cleaner alignment)

### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
...
