### PR TITLE
ci: [NOSNOW] gate docs-only PRs at step level so matrix required checks post

### DIFF
--- a/.github/workflows/changes.yaml
+++ b/.github/workflows/changes.yaml
@@ -1,10 +1,12 @@
 name: detect changes
 
 # Determines whether a PR changes anything that requires running the heavy test
-# matrix. The required-status-check jobs that consume `outputs.code` always run
-# (so the required check posts to the PR), but skip their expensive steps when
-# only docs/CODEOWNERS/etc. changed. This avoids the "skipped but required"
-# branch-protection deadlock that `paths-ignore` causes.
+# matrix. Callers gate their **steps** (not the job) on `outputs.code` so the
+# matrix expands and every per-cell required check name (e.g.
+# `tests (ubuntu-latest, 3.10)`, `e2e-trusted (...) / tests-trusted`) is posted
+# to the PR. A job-level `if:` would short-circuit matrix expansion and leave
+# those required checks stuck at "Expected — Waiting for status to be reported"
+# — the same branch-protection deadlock `paths-ignore` used to cause.
 
 on:
   workflow_call:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,13 @@ jobs:
     uses: ./.github/workflows/matrix.yaml
   changes:
     uses: ./.github/workflows/changes.yaml
+  # Required check `tests (<os>, <py>)` must report on every PR, including
+  # docs/CODEOWNERS-only ones. A job-level `if:` on a matrix job prevents the
+  # matrix from expanding, so the per-cell required checks are never posted
+  # and the PR sits BLOCKED. Keep the gate at the step level instead — the
+  # matrix still expands and each cell posts a (no-op) success.
   tests:
     needs: [define-matrix, changes]
-    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -35,17 +39,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Python ${{ matrix.python-version }}
+      - if: needs.changes.outputs.code == 'true'
+        name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install hatch
+      - if: needs.changes.outputs.code == 'true'
+        name: Install hatch
         run: |
           pip install -U click==8.2.1 hatch==1.15.1 virtualenv==20.39.1
           hatch env create default
-      - name: Test with hatch
+      - if: needs.changes.outputs.code == 'true'
+        name: Test with hatch
         run: hatch run test-cov
-      - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
+      - if: needs.changes.outputs.code == 'true'
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
 
   # Temporarily disabled; re-enable once config v2 (NG) is ready.
   # tests-config-ng:

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -29,6 +29,11 @@ jobs:
   changes:
     uses: ./.github/workflows/changes.yaml
 
+  # Required check `e2e-trusted (<os>, <py>) / tests-trusted` must report on
+  # every same-repo PR. The job-level `if:` only filters out fork events (the
+  # secret-handling trust gate); the docs-only short-circuit is pushed down
+  # via `should-run` so the matrix still expands when changes.code == 'false'
+  # and each per-cell required check is posted.
   e2e-trusted:
     needs: [define-matrix, changes]
     strategy:
@@ -37,17 +42,15 @@ jobs:
         os: ${{ fromJSON(needs.define-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     if: |
-      (
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/main')
-      ) &&
-      (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: ./.github/workflows/test_trusted.yaml
     with:
       runs-on: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       python-env: e2e
       hatch-run: e2e:test
+      should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     secrets: inherit
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request

--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -29,7 +29,12 @@ jobs:
   changes:
     uses: ./.github/workflows/changes.yaml
 
-  # Branch-based pull request
+  # Branch-based pull request.
+  # Required check `integration-trusted (<os>, <py>) / tests-trusted` must
+  # report on every same-repo PR. The job-level `if:` only filters out fork
+  # events (the secret-handling trust gate); the docs-only short-circuit is
+  # pushed down via `should-run` so the matrix still expands when
+  # changes.code == 'false' and each per-cell required check is posted.
   integration-trusted:
     needs: [define-matrix, changes]
     strategy:
@@ -38,17 +43,15 @@ jobs:
         os: ${{ fromJSON(needs.define-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     if: |
-      (
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/main')
-      ) &&
-      (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: ./.github/workflows/test_trusted.yaml
     with:
       runs-on: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       python-env: integration
       hatch-run: integration:test
+      should-run: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     secrets: inherit
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request

--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -15,6 +15,14 @@ on:
       hatch-run:
         required: true
         type: string
+      should-run:
+        # Posts the required check as success but skips the heavy steps when
+        # the PR only touches paths that don't affect tests. Kept at the step
+        # level so the matrix in the calling workflow still expands and each
+        # per-cell required check name is reported.
+        required: false
+        type: string
+        default: "true"
 
 permissions:
   contents: none
@@ -28,15 +36,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up Python
+      - if: inputs.should-run == 'true'
+        name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
-      - name: Install dependencies
+      - if: inputs.should-run == 'true'
+        name: Install dependencies
         run: |
           python -m pip install --upgrade pip click==8.2.1 hatch==1.15.1 virtualenv==20.39.1
           python -m hatch env create ${{ inputs.python-env }}
-      - name: Run integration tests
+      - if: inputs.should-run == 'true'
+        name: Run integration tests
         env:
           GH_TOKEN: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }}
           TERM: unknown


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand — N/A, CI-only.
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase — N/A, CI-only.
   * [x] I've added or updated unit tests to verify correctness of my new code — N/A, GitHub Actions YAML, validated end-to-end on this PR's own checks.
   * [x] I've added or updated integration tests to verify correctness of my new code — N/A, GitHub Actions YAML.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` — `skip-release-notes` (CI plumbing only, no user-facing change).
   * [x] I've updated documentation if behavior changed — refreshed the header comment in `changes.yaml`.

### Changes description

Follow-up to #3064. That PR moved the docs-only short-circuit from `paths-ignore` to a job-level `if: needs.changes.outputs.code == 'true'` on the matrix-bearing jobs. That works for the un-expanded job name (e.g. `tests`) but GitHub evaluates job-level `if:` **before** matrix expansion, so the per-cell required check names branch protection wants — `tests (ubuntu-latest, 3.10)`, `tests (windows-latest, 3.10)`, `e2e-trusted (...) / tests-trusted`, `integration-trusted (...) / tests-trusted` — are never posted. Docs-only PRs (e.g. CODEOWNERS-only #3032) end up stuck at *"Expected — Waiting for status to be reported"*, the same deadlock #3064 was supposed to fix.

This PR pushes the gate down to the **step** level so the matrix expands and every per-cell check posts as a (no-op) success when `changes.code == 'false'`:

- `test.yaml`: drop the job-level `if:` on `tests`; gate every step (except `actions/checkout`) on `needs.changes.outputs.code == 'true'`.
- `test_trusted.yaml`: reintroduce the `should-run` input (string, default `"true"`) and gate the heavy steps on it.
- `test_e2e.yaml` / `test_integration.yaml`: keep only the trust gate at job level (so fork events still bypass the secret-using path) and pass the docs-only condition into the reusable workflow as `should-run`.
- `changes.yaml`: rewrite the header comment to spell out why the gate has to live at the step level — to avoid the "moved back to job-level" regression that produced this bug.

The `actions/checkout` step still always runs so each per-cell job has at least one step and reports a green check. Other workflows (Build, Code quality, CodeQL, Release notes check) are unaffected.

### Verification

Will be visible directly on this PR's checks: `tests (ubuntu-latest, 3.10)`, `tests (windows-latest, 3.10)`, and the `*-trusted (...) / tests-trusted` rows should all post (running the heavy path here, since this PR touches workflow files which are not in the ignore set). To verify the docs-only path, the next CODEOWNERS-only PR after this lands should see all of them as green skipped checks rather than `Expected — Waiting`.