### PR TITLE
chore: parallelize unit tests with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,10 @@ development = [
   "coverage==7.10.4",
   "factory-boy==3.3.3",
   "pre-commit>=3.5.0",
+  "pytest-cov==6.0.0",
   "pytest-httpserver==1.1.3",
   "pytest-randomly==3.16.0",
+  "pytest-xdist==3.6.1",
   "pytest==8.4.1",
   "syrupy==4.9.1",
   "uv==0.10.9",
@@ -104,10 +106,16 @@ python = "3.10"
 features = ["development"]
 
 [tool.hatch.envs.default.scripts]
-test = ["pytest tests/"]
+# Unit tests are parallelized with pytest-xdist. `loaded_modules` runs serially
+# in a fresh process because it asserts on `sys.modules` after CLI startup,
+# which is meaningless under a long-lived xdist worker.
+test = [
+  "pytest -n auto --dist=worksteal tests/",
+  "pytest -m loaded_modules tests/",
+]
 test-cov = [
-  "coverage run --source=snowflake.cli --module pytest tests/",
-  "coverage run --source=snowflake.cli --module pytest -m loaded_modules tests/",
+  "pytest --cov=snowflake.cli --cov-report= -n auto --dist=worksteal tests/",
+  "pytest --cov=snowflake.cli --cov-append --cov-report= -m loaded_modules tests/",
   "coverage report",
 ]
 legacy-pypi-build = [".compat/build_snowflake-cli-labs.sh"]


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

_(N/A items checked: no user-facing surface change, no doc/README impact, no new code under test, internal-tooling change so no release-notes entry — matching #3025/#3033 convention.)_

### Changes description

The `Test with hatch` step in `test.yaml` runs unit tests serially and takes ~40 min on each OS (Ubuntu and Windows) — observed on the latest main run (#26637680587: ubuntu 41 min, windows 39 min). Integration tests already run with `pytest-xdist -n5 --dist=worksteal` in `tool.hatch.envs.integration`; the unit env didn't.

This switches the `test` and `test-cov` hatch scripts to `pytest -n auto --dist=worksteal`. `worksteal` is the same scheduler used by the integration env — well-suited to a workload with very uneven per-test runtimes. `pytest-xdist` and `pytest-cov` are added to `[project.optional-dependencies] development`.

`loaded_modules` (`tests/test_loaded_modules.py`) still runs serially in a fresh process. It asserts that `git` is not imported during a CLI startup, which is meaningless under a long-lived xdist worker process that has accumulated imports from prior tests. It's split out as a second `pytest` invocation, just like before.

`test-cov` moves from `coverage run --module pytest` to `pytest --cov`, so coverage data from each xdist worker merges into a single `.coverage` file automatically. The second run uses `--cov-append` to fold the loaded_modules coverage in before `coverage report`.

#### Local timings (dev VM, ~40 cores)
* full unit suite (`pytest tests/`) was hitting CI's ~40 min wall on 1 worker
* with `-n auto --dist=worksteal`: **7548 passed in 1m57s** (user time 21m → ~11x parallelism)

#### Expected CI impact
GitHub-hosted `ubuntu-latest` and `windows-latest` runners have 4 cores. Even at a conservative 3-4x speedup, the unit-test step should drop from ~40 min to ~10-13 min per OS. Since the two OS jobs run concurrently, end-to-end PR time is gated on the slower one.

#### Compatibility notes
* No tests use `os.chdir` outside the `temporary_directory` fixture, which save/restores `cwd`. xdist workers are separate processes so cwd doesn't bleed across them.
* `pytest-randomly` already shuffles test order, so any latent state-sharing between tests would already have surfaced. xdist running them in different processes is strictly *more* isolated.
* `snowflake_home` and `temporary_directory` use unique tempdirs per test — already xdist-safe.
* `pylock.toml` is unchanged: it only tracks runtime deps (`uv pip compile` without `--extra development`), and the new packages are dev-only.