### PR TITLE
ci: [SNOW-3595040] cancel in-progress Testing runs on new pushes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,10 @@ on:
 env:
   TERM: unknown # Disables colors in rich
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)). — N/A, CI-only
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code. — N/A, CI workflow change
   * [x] I've added or updated integration tests to verify correctness of my new code. — N/A, CI workflow change
   * [x] Manually tested on macOS — N/A, GitHub Actions only
   * [x] Manually tested on Windows — N/A, GitHub Actions only
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)). — N/A, no user-facing change ([NOSNOW])
   * [x] I've updated documentation if behavior changed. — N/A

### Changes description

Adds the standard `concurrency` block to `test.yaml` so that pushing a new commit to a PR cancels the previous in-progress run, matching the behaviour already configured in `lint.yaml`, `test_e2e.yaml`, `test_integration.yaml`, `test_integration_container_services.yaml`, and `build.yaml`.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

**Why:** Without this, force-pushes to a PR leave the previous Testing run continuing alongside the new one. `Testing` is one of the two longest-running required workflows (~18–20 min), so on iteratively-pushed PRs we currently waste runner-minutes on a run whose result we'll never look at.

**Risk:** None. The same pattern is already in production on five other workflows in this repo, including the matching `test_integration.yaml` which gates the same set of required checks. Cancellation only happens when a newer commit on the same PR/ref makes the older run obsolete.

**Verification:** Pre-commit hooks pass locally. There is no behavioural test for this — GitHub Actions consumes the new block on the first PR push.