### PR TITLE
ci: [SNOW-3595039] cache pip / hatch envs / pre-commit hooks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install Snowflake CLI
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,6 +31,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
       - name: Install pre-commit
         run: python -m pip install pre-commit tomlkit click==8.2.1 hatch==1.15.1 virtualenv==20.39.1 uv
       - name: Check if pyproject.toml was changed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - if: needs.changes.outputs.code == 'true'
+        name: Cache hatch envs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/hatch
+            ~/Library/Application Support/hatch
+            ~\AppData\Local\hatch
+          key: hatch-default-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'pylock.toml') }}
+          restore-keys: |
+            hatch-default-${{ runner.os }}-py${{ matrix.python-version }}-
       - if: needs.changes.outputs.code == 'true'
         name: Install hatch
         run: |

--- a/.github/workflows/test_fork.yaml
+++ b/.github/workflows/test_fork.yaml
@@ -34,6 +34,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Cache hatch envs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/hatch
+            ~/Library/Application Support/hatch
+            ~\AppData\Local\hatch
+          key: hatch-${{ inputs.python-env }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'pylock.toml') }}
+          restore-keys: |
+            hatch-${{ inputs.python-env }}-${{ runner.os }}-py${{ inputs.python-version }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip click==8.2.1 hatch==1.15.1 virtualenv==20.39.1

--- a/.github/workflows/test_perfomance.yaml
+++ b/.github/workflows/test_perfomance.yaml
@@ -35,6 +35,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Cache hatch envs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/hatch
+            ~/Library/Application Support/hatch
+            ~\AppData\Local\hatch
+          key: hatch-performance-${{ runner.os }}-py3.10-${{ hashFiles('pyproject.toml', 'pylock.toml') }}
+          restore-keys: |
+            hatch-performance-${{ runner.os }}-py3.10-
       - name: Install hatch
         run: |
           pip install -U click==8.2.1 hatch==1.15.1 virtualenv==20.39.1

--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -41,6 +41,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - if: inputs.should-run == 'true'
+        name: Cache hatch envs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/hatch
+            ~/Library/Application Support/hatch
+            ~\AppData\Local\hatch
+          key: hatch-${{ inputs.python-env }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'pylock.toml') }}
+          restore-keys: |
+            hatch-${{ inputs.python-env }}-${{ runner.os }}-py${{ inputs.python-version }}-
       - if: inputs.should-run == 'true'
         name: Install dependencies
         run: |


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)). — N/A, CI-only
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code. — N/A, CI workflow change
   * [x] I've added or updated integration tests to verify correctness of my new code. — N/A, CI workflow change
   * [x] Manually tested on macOS — N/A, runs on GitHub Actions runners only
   * [x] Manually tested on Windows — N/A, runs on GitHub Actions runners only
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)). — N/A, no user-facing change ([NOSNOW])
   * [x] I've updated documentation if behavior changed. — N/A

### Changes description

There are **zero `cache:` references across the workflow files on main today**. Every PR rebuilds the hatch env from scratch and re-downloads pre-commit hook environments, which together add ~30–90 s of dead time to the critical-path matrix cells (Testing and Integration testing).

Adds three layers of caching using existing GitHub Actions primitives — no new dependencies, no infra changes:

1. **`cache: pip`** on every `actions/setup-python` invocation, keyed on `pyproject.toml`. Caches the small pip install of hatch / virtualenv / pre-commit themselves.
2. **`actions/cache@v4` for the hatch env directory** in `test.yaml`, `test_trusted.yaml`, `test_fork.yaml`, and `test_perfomance.yaml`, keyed on `(env name, OS, Python version, hashFiles('pyproject.toml', 'pylock.toml'))`. Lists all three platformdirs locations so the same step works on Linux, macOS, and Windows runners — `actions/cache` silently skips nonexistent paths:
   ```yaml
   path: |
     ~/.local/share/hatch
     ~/Library/Application Support/hatch
     ~\AppData\Local\hatch
   ```
3. **`actions/cache@v4` for `~/.cache/pre-commit`** in `lint.yaml`, keyed on `.pre-commit-config.yaml` hash. This is the standard recipe published on pre-commit.com.

#### Why this is safe

- `hatch env create` is idempotent: on a cache hit it sees the env already exists and returns immediately rather than reinstalling. On a miss the `restore-keys` provide a partial seed so only changed packages are re-downloaded.
- Cache key is fully scoped per `(env, OS, python-version, lockfile-hash)`. A poisoned cache in one cell can't affect another, and any change to `pyproject.toml`/`pylock.toml` produces a fresh key.
- No change to test execution paths, no change to required check names, no change to security/secrets handling.
- The same caching pattern is in widespread use across CPython, the uv project, the pre-commit project itself, and many other Python repos. References:
  - https://docs.astral.sh/uv/guides/integration/github/
  - https://pre-commit.com/ (Caching section)
  - https://github.com/actions/setup-python#caching-packages-dependencies

#### Expected impact

- Cold runs (first run on a branch, or after `pyproject.toml` changes): no slower than today (the caching steps add a few seconds when there's nothing to restore).
- Warm runs (typical iteration on a PR with no dep changes): setup time across cells drops from ~30–90 s to <10 s. Saves ~1–2 min per PR across the matrix.

#### Files changed

- `.github/workflows/lint.yaml` — pip cache + pre-commit cache
- `.github/workflows/test.yaml` — pip cache + hatch env cache (`default` env)
- `.github/workflows/test_trusted.yaml` — pip cache + hatch env cache (parametrised by `inputs.python-env`)
- `.github/workflows/test_fork.yaml` — pip cache + hatch env cache (parametrised by `inputs.python-env`)
- `.github/workflows/build.yaml` — pip cache only (Build doesn't use hatch envs)
- `.github/workflows/test_perfomance.yaml` — pip cache + hatch env cache (`performance` env)