### PR TITLE
fix: [SNOW-3595038] make /ok-to-test actually test and report fork PRs

### DIFF
--- a/.github/workflows/ok_to_test.yml
+++ b/.github/workflows/ok_to_test.yml
@@ -1,4 +1,16 @@
-# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+# /ok-to-test: when a maintainer with write access comments "/ok-to-test sha=<sha>"
+# on a pull request, emit a repository_dispatch (ok-to-test-command) event that
+# runs the fork's integration/e2e suites WITH repository secrets (the Snowflake
+# integration account). slash-command-dispatch enforces the write-access check;
+# the downstream caller gate additionally requires contains(head.sha, sha).
+#
+# TRUST EXPECTATION: commenting "/ok-to-test sha=<sha>" means "I have read this
+# exact commit -- including tests, conftest.py, hatch/build hooks and anything
+# else that executes during the run -- and I accept it running against our
+# integration account." The pinned <sha> is the security boundary: only that
+# commit is checked out and given secrets (see test_fork.yaml), so a contributor
+# who pushes new commits after the review invalidates the grant and must be
+# re-vouched.
 name: Ok To Test
 
 on:

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -62,6 +62,7 @@ jobs:
         os: ${{ fromJSON(needs.define-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     permissions:
+      contents: read
       pull-requests: write
       checks: write
     if: |

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -63,7 +63,7 @@ jobs:
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       checks: write
     if: |
       github.event_name == 'repository_dispatch' &&

--- a/.github/workflows/test_fork.yaml
+++ b/.github/workflows/test_fork.yaml
@@ -19,16 +19,31 @@ on:
         required: true
         type: string
 
+# This reusable workflow runs fork PR code in a trusted context (with secrets)
+# after a maintainer vouches for a specific commit via `/ok-to-test sha=<sha>`.
+# It needs `checks: write` to report the result back onto the required
+# `integration-fork` / `e2e-fork` status checks, and `pull-requests: read` to
+# resolve the dispatched PR. A reusable workflow's token takes its scopes from
+# THIS block (capped by the caller), so the caller granting `checks: write` is
+# not enough on its own -- that omission is what produced the
+# "Resource not accessible by integration" 403 on checks.update.
 permissions:
-  contents: none
-  issues: none
+  contents: read
+  checks: write
+  pull-requests: read
 
 jobs:
   test-fork:
     runs-on: ${{ inputs.runs-on }}
     steps:
+      # Check out the commit the maintainer reviewed (the fork's head), NOT the
+      # base repo's default branch. With no repository/ref, checkout defaulted
+      # to snowflakedb/snowflake-cli@main, so the tests never exercised the
+      # contributor's changes.
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -49,40 +64,57 @@ jobs:
           SNOWFLAKE_CONNECTIONS_INTEGRATION_PRIVATE_KEY_RAW: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_RAW }}
         run: python -m hatch run ${{ inputs.hatch-run }}
 
-      # Update check run called "integration-fork"
+      # Report this run's result onto the required check (`integration-fork` /
+      # `e2e-fork`). On a fork PR that check already exists as a skipped run on
+      # the head commit; update every run with that name, and create one if none
+      # exist, so the required check always receives a real conclusion.
       - uses: actions/github-script@v7
         id: update-check-run
         if: ${{ always() }}
         env:
           number: ${{ github.event.client_payload.pull_request.number }}
-          job: ${{ github.job }}
-          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          job_name: ${{ inputs.job-name }}
+          # job.status maps to a valid check-run conclusion
+          # (success / failure / cancelled).
           conclusion: ${{ job.status }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const { number, job_name, conclusion } = process.env;
+
             const { data: pull } = await github.rest.pulls.get({
               ...context.repo,
-              pull_number: process.env.number
+              pull_number: Number(number),
             });
             const ref = pull.head.sha;
 
             const { data: checks } = await github.rest.checks.listForRef({
               ...context.repo,
-              ref
-            });
-            console.log("Check runs for ref:", checks.check_runs);
-            console.log("Job name:", '${{ inputs.job-name }}');
-            console.log("Check run names for ref:", checks.check_runs.map(c => c.name));
-
-            const check = checks.check_runs.filter(c => c.name === '${{ inputs.job-name }}');
-            console.log("Filtered check:", check.check_runs);
-
-            const { data: result } = await github.rest.checks.update({
-              ...context.repo,
-              check_run_id: check[0].id,
-              status: 'completed',
-              conclusion: process.env.conclusion
+              ref,
             });
 
-            return result;
+            const matching = checks.check_runs.filter((c) => c.name === job_name);
+            console.log(
+              `Reporting '${conclusion}' to check '${job_name}' on ${ref}: ` +
+                `${matching.length} existing run(s)`
+            );
+
+            if (matching.length === 0) {
+              await github.rest.checks.create({
+                ...context.repo,
+                name: job_name,
+                head_sha: ref,
+                status: "completed",
+                conclusion,
+              });
+              return;
+            }
+
+            for (const check of matching) {
+              await github.rest.checks.update({
+                ...context.repo,
+                check_run_id: check.id,
+                status: "completed",
+                conclusion,
+              });
+            }

--- a/.github/workflows/test_fork.yaml
+++ b/.github/workflows/test_fork.yaml
@@ -21,20 +21,29 @@ on:
 
 # This reusable workflow runs fork PR code in a trusted context (with secrets)
 # after a maintainer vouches for a specific commit via `/ok-to-test sha=<sha>`.
-# It needs `checks: write` to report the result back onto the required
-# `integration-fork` / `e2e-fork` status checks, and `pull-requests: read` to
-# resolve the dispatched PR. A reusable workflow's token takes its scopes from
-# THIS block (capped by the caller), so the caller granting `checks: write` is
-# not enough on its own -- that omission is what produced the
-# "Resource not accessible by integration" 403 on checks.update.
-permissions:
-  contents: read
-  checks: write
-  pull-requests: read
+# The caller (`integration-fork` / `e2e-fork`) gates the dispatch on a
+# write-access maintainer AND `contains(head.sha, args.named.sha)`, so only the
+# exact commit the maintainer reviewed is ever checked out and given secrets.
+#
+# The work is split across two jobs so the privileged `checks: write` token is
+# never co-resident with the untrusted fork code:
+#   * test-fork -- checks out and runs the fork commit WITH secrets, but its
+#                  token is `contents: read` only and is not persisted to the
+#                  git config, so untrusted code has no write-scoped token to
+#                  steal (the irreducible exposure here is the secrets, which
+#                  the maintainer vouch accepts).
+#   * report    -- holds `checks: write` to report the result onto the required
+#                  check, but checks out no fork code and handles no secrets.
+# A reusable workflow's token takes its scopes from the job's `permissions:`
+# block (capped by the caller); the caller granting `checks: write` is not
+# enough on its own -- that omission is what produced the "Resource not
+# accessible by integration" 403 on checks.update.
 
 jobs:
   test-fork:
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
     steps:
       # Check out the commit the maintainer reviewed (the fork's head), NOT the
       # base repo's default branch. With no repository/ref, checkout defaulted
@@ -64,19 +73,29 @@ jobs:
           SNOWFLAKE_CONNECTIONS_INTEGRATION_PRIVATE_KEY_RAW: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_RAW }}
         run: python -m hatch run ${{ inputs.hatch-run }}
 
-      # Report this run's result onto the required check (`integration-fork` /
-      # `e2e-fork`). On a fork PR that check already exists as a skipped run on
-      # the head commit; update every run with that name, and create one if none
-      # exist, so the required check always receives a real conclusion.
+  # Report the test-fork result onto the required check (`integration-fork` /
+  # `e2e-fork`). Runs in its own job -- with `checks: write` but no fork
+  # checkout and no secrets -- so the write-scoped token is isolated from the
+  # untrusted code executed in `test-fork`. On a fork PR that check already
+  # exists as a skipped run on the head commit; update every run with that name,
+  # and create one if none exist, so the required check always receives a real
+  # conclusion.
+  report:
+    needs: test-fork
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: read
+    steps:
       - uses: actions/github-script@v7
         id: update-check-run
-        if: ${{ always() }}
         env:
           number: ${{ github.event.client_payload.pull_request.number }}
           job_name: ${{ inputs.job-name }}
-          # job.status maps to a valid check-run conclusion
-          # (success / failure / cancelled).
-          conclusion: ${{ job.status }}
+          # needs.test-fork.result is a valid check-run conclusion
+          # (success / failure / cancelled / skipped).
+          conclusion: ${{ needs.test-fork.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -63,6 +63,7 @@ jobs:
         os: ${{ fromJSON(needs.define-matrix.outputs.os) }}
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     permissions:
+      contents: read
       pull-requests: write
       checks: write
     if: |

--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -64,7 +64,7 @@ jobs:
         python-version: ${{ fromJSON(needs.define-matrix.outputs.python) }}
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       checks: write
     if: |
       github.event_name == 'repository_dispatch' &&


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)). — N/A, CI-only
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code. — N/A, GitHub Actions workflow change (not unit-testable)
   * [x] I've added or updated integration tests to verify correctness of my new code. — N/A, see verification note below
   * [x] Manually tested on macOS — N/A, runs on GitHub Actions runners only
   * [x] Manually tested on Windows — N/A, runs on GitHub Actions runners only
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)). — N/A, no user-facing change ([NOSNOW])
   * [x] I've updated documentation if behavior changed. — N/A

### Changes description

`/ok-to-test` has been **failing on every fork PR**. The flow is:

> maintainer comments `/ok-to-test sha=<sha>` → `ok_to_test.yml` (slash-command-dispatch) → `repository_dispatch (ok-to-test-command)` → `integration-fork` / `e2e-fork` jobs → `test_fork.yaml`

The dispatch itself works, but the dispatched `test_fork.yaml` job is broken in three ways. All three are confirmed from **production run logs** (e.g. [run 24777708864](https://github.com/snowflakedb/snowflake-cli/actions/runs/24777708864)), where the integration job both tested the wrong code and then errored on the check-run update.

#### Bug 1 — it tested `main`, not the contributor's code
`test_fork.yaml` ran `actions/checkout` with no `repository`/`ref`. On a `repository_dispatch` event that defaults to `snowflakedb/snowflake-cli@main`, so the integration/e2e suites **never exercised the PR's changes**. The run log confirms it: `repository: snowflakedb/snowflake-cli`, `git remote add origin https://github.com/snowflakedb/snowflake-cli`.

Fixed by checking out the maintainer-reviewed fork commit:
```yaml
- uses: actions/checkout@v4
  with:
    repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
    ref: ${{ github.event.client_payload.pull_request.head.sha }}
    persist-credentials: false
```
This is exactly the `sha` the maintainer pins with `sha=<sha>`, which the caller `if:` already validates via `contains(head.sha, args.named.sha)`.

#### Bug 2 — `403 Resource not accessible by integration` on the check update
The "Update check run" step died with HTTP 403 on `checks.update`. A **reusable workflow's `GITHUB_TOKEN` scopes come from the reusable workflow's own `permissions:` block** (capped by the caller) — so the caller jobs declaring `checks: write` had no effect while `test_fork.yaml` declared only `contents: none / issues: none`. Because the matrix uses `fail-fast: true`, this 403 sank the whole `integration-fork` / `e2e-fork` job **even when the tests passed**, leaving the required check unsatisfied → PR stays BLOCKED.

Fix: grant the scopes the run needs, but **split them across two jobs** so the privileged token never shares a job with untrusted fork code:
- `test-fork` runs the fork commit (with secrets) under a `contents: read`-only token;
- a dependent `report` job carries `checks: write` / `pull-requests: read`, checks out no fork code, and reports `needs.test-fork.result` onto the required check.

The `integration-fork` / `e2e-fork` caller jobs grant the union as the cap (`contents: read`, `pull-requests: read`, `checks: write`).

#### Bug 3 — fragile check reporting
The script logged `check.check_runs` (always `undefined` on an array) and indexed `check[0].id` with no guard, so it threw whenever the name didn't match. Rewritten to update **every** check run named `integration-fork` / `e2e-fork` on the head commit, and to **create** one if none exist — so the required check always receives a real conclusion. The job name is now passed via `env` instead of inline `${{ }}` interpolation (avoids expression-injection foot-guns in `github-script`).

#### Security
The trust gate is intentionally **preserved**: fork code still only runs against the specific commit the maintainer reviewed and pinned with `sha=` (the caller `if:` enforces `contains(head.sha, args.named.sha)`). No gate is weakened.

Beyond preserving the gate, the secret-handling path is **hardened**:
- **Token isolation** — the `checks: write` token lives in the separate `report` job, never co-resident with untrusted fork code; `persist-credentials: false` keeps even the `contents: read` token out of the fork checkout.
- **Least privilege** — the caller jobs drop the unused `pull-requests: write` down to `read`.
- **Documented expectation** — `ok_to_test.yml` now spells out that `/ok-to-test sha=<sha>` means the maintainer has read that exact commit (tests, `conftest.py`, build hooks included) and accepts it running against the integration account.

The irreducible exposure — the pinned commit runs with the Snowflake integration secrets — is inherent to `/ok-to-test` and is exactly what the maintainer vouch accepts.

### Verification

The breakage is proven from the production run logs cited above (wrong checkout + 403). However — **`repository_dispatch` / `issue_comment` workflows always execute the workflow files on the default branch**, so this fix cannot be exercised end-to-end from a PR branch; it can only be validated by a `/ok-to-test` on a fork PR *after* this merges to `main`. YAML and the embedded `github-script` were validated locally (`yaml.safe_load`; `node --check` on the script body wrapped in the async function `github-script` runs it in).

### Files changed
- `.github/workflows/test_fork.yaml` — check out the fork head; **split into `test-fork` (runs fork code; `contents: read` + secrets) and `report` (`checks: write` / `pull-requests: read`; no fork checkout)**; robust check-run reporting via `needs.test-fork.result`
- `.github/workflows/test_integration.yaml` — `integration-fork` caller: `contents: read`, and `pull-requests: write` → `read`
- `.github/workflows/test_e2e.yaml` — `e2e-fork` caller: `contents: read`, and `pull-requests: write` → `read`
- `.github/workflows/ok_to_test.yml` — document the `/ok-to-test sha=<sha>` trust expectation
