### PR TITLE
Snowflake Apps: skip query spinner in non-interactive mode

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -442,6 +442,7 @@ def snowflake_app_deploy(
     upload_only: bool,
     build_only: bool,
     deploy_only: bool,
+    interactive: Optional[bool] = None,
 ) -> CommandResult:
     """Build and deploy a Snowflake App Runtime through upload, build, and deploy phases."""
     phase_flags = sum((upload_only, build_only, deploy_only))
@@ -501,7 +502,7 @@ def snowflake_app_deploy(
     app_icon = entity.meta.icon if entity.meta else None
 
     # ── Resolve defaults (snowflake.yml > account parameters > built-in) ──
-    manager = SnowflakeAppManager()
+    manager = SnowflakeAppManager(interactive=interactive)
     defaults = _resolve_deploy_defaults(entity, manager, app_name=app_name)
 
     database = defaults["database"]

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -45,6 +45,7 @@ from snowflake.cli.api.project.util import to_identifier
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.utils.path_utils import resolve_without_follow
+from snowflake.cli.api.utils.tty import is_tty_interactive
 from snowflake.connector.cursor import DictCursor
 from snowflake.connector.errors import ProgrammingError
 
@@ -450,8 +451,31 @@ class SnowflakeAppManager(SqlExecutionMixin):
     ``FQN``-based parameters that already use ``.sql_identifier``.
     """
 
+    def __init__(self, *args, interactive: Optional[bool] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Whether to show the query spinner. ``None`` defers to TTY detection;
+        # callers (e.g. ``snow app deploy``) pass the resolved
+        # ``--interactive`` / ``--no-interactive`` flag.
+        self._interactive = interactive
+
+    @property
+    def _is_interactive(self) -> bool:
+        if self._interactive is not None:
+            return self._interactive
+        return is_tty_interactive()
+
     def execute_query(self, query: str, **kwargs):
-        """Execute a Snowflake query with CLI spinner feedback."""
+        """Execute a Snowflake query with CLI spinner feedback.
+
+        The spinner is only shown when running interactively. This honors the
+        ``--interactive`` / ``--no-interactive`` flag passed by the command and
+        falls back to TTY detection when the flag is not set, so the spinner is
+        skipped for non-interactive runs (``--no-interactive``, piped/redirected
+        output, CI, etc.) where its control characters would pollute captured
+        output.
+        """
+        if not self._is_interactive:
+            return super().execute_query(query, **kwargs)
         with cli_console.spinner() as spinner:
             spinner.add_task(description="", total=None)
             return super().execute_query(query, **kwargs)

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -532,7 +532,11 @@ def app_deploy(
             },
         )
         return snowflake_app_deploy(
-            options.get("entity_id") or None, upload_only, build_only, deploy_only
+            options.get("entity_id") or None,
+            upload_only,
+            build_only,
+            deploy_only,
+            interactive=interactive,
         )
 
     _reject_snowflake_app_options(

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -758,8 +758,8 @@ class TestGenerateSnowflakeYml:
 
 
 class TestSnowflakeAppManagerQuerySpinner:
-    def test_execute_query_wraps_query_with_spinner(self):
-        manager = SnowflakeAppManager()
+    def test_execute_query_wraps_query_with_spinner_when_interactive(self):
+        manager = SnowflakeAppManager(interactive=True)
         with patch(
             "snowflake.cli._plugins.apps.manager.cli_console.spinner"
         ) as mock_spinner, patch(
@@ -778,6 +778,45 @@ class TestSnowflakeAppManagerQuerySpinner:
                 description="",
                 total=None,
             )
+            mock_super_execute.assert_called_once_with(
+                "SELECT 1", cursor_class=DictCursor
+            )
+
+    def test_execute_query_skips_spinner_when_non_interactive(self):
+        manager = SnowflakeAppManager(interactive=False)
+        with patch(
+            "snowflake.cli._plugins.apps.manager.cli_console.spinner"
+        ) as mock_spinner, patch(
+            "snowflake.cli.api.sql_execution.BaseSqlExecutor.execute_query"
+        ) as mock_super_execute:
+            cursor = Mock()
+            mock_super_execute.return_value = cursor
+
+            result = manager.execute_query("SELECT 1", cursor_class=DictCursor)
+
+            assert result is cursor
+            mock_spinner.assert_not_called()
+            mock_super_execute.assert_called_once_with(
+                "SELECT 1", cursor_class=DictCursor
+            )
+
+    def test_execute_query_falls_back_to_tty_detection_when_unset(self):
+        manager = SnowflakeAppManager()
+        with patch(
+            "snowflake.cli._plugins.apps.manager.is_tty_interactive",
+            return_value=False,
+        ), patch(
+            "snowflake.cli._plugins.apps.manager.cli_console.spinner"
+        ) as mock_spinner, patch(
+            "snowflake.cli.api.sql_execution.BaseSqlExecutor.execute_query"
+        ) as mock_super_execute:
+            cursor = Mock()
+            mock_super_execute.return_value = cursor
+
+            result = manager.execute_query("SELECT 1", cursor_class=DictCursor)
+
+            assert result is cursor
+            mock_spinner.assert_not_called()
             mock_super_execute.assert_called_once_with(
                 "SELECT 1", cursor_class=DictCursor
             )


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description

For `snow app` commands, don't show the loading spinner when the CLI is invoked non-interactively (CI, agents, etc.).
