### PR TITLE
Snowflake Apps: remove dead code

### DIFF
--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -431,45 +431,6 @@ def _bundle_app_artifacts(project_paths: ProjectPaths, artifacts) -> BundleMap:
     return bundle_map
 
 
-_EXPOSE_SIMPLE_RE = re.compile(
-    r"^\s*EXPOSE\s+(\d+)(?:/(?:tcp|udp))?\s*$", re.IGNORECASE
-)
-_EXPOSE_ANY_RE = re.compile(r"^\s*EXPOSE\s+", re.IGNORECASE)
-
-# Sentinel returned when a Dockerfile contains an EXPOSE directive that uses
-# unsupported syntax (multi-port or range).  Callers should check for this
-# value explicitly rather than treating it as a valid port number.
-EXPOSE_UNSUPPORTED_SYNTAX: int = 0
-
-
-def _find_dockerfile_expose_port(bundle_root: Path) -> Optional[int]:
-    """Parse the Dockerfile in *bundle_root* and return the first EXPOSEd port.
-
-    Returns ``None`` when no ``Dockerfile`` exists or it contains no EXPOSE
-    directive.  Returns :data:`EXPOSE_UNSUPPORTED_SYNTAX` (``0``) when an
-    EXPOSE line is present but uses multi-port (``EXPOSE 3000 8080``) or
-    range (``EXPOSE 3000-3005``) syntax which is not supported.
-
-    Only simple ``EXPOSE <number>`` lines are recognised (the ``/tcp`` and
-    ``/udp`` suffixes are stripped).
-    """
-    dockerfile = bundle_root / "Dockerfile"
-    if not dockerfile.exists():
-        return None
-
-    lines = dockerfile.read_text().splitlines()
-    for line in lines:
-        m = _EXPOSE_SIMPLE_RE.match(line)
-        if m:
-            return int(m.group(1))
-
-    for line in lines:
-        if _EXPOSE_ANY_RE.match(line):
-            return EXPOSE_UNSUPPORTED_SYNTAX
-
-    return None
-
-
 class SnowflakeAppManager(SqlExecutionMixin):
     """Manager for Snowflake App Runtime operations.
 
@@ -537,22 +498,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
             cursor_class=DictCursor,
         )
         return cursor.fetchone() is not None
-
-    def role_has_bind_service_endpoint(self, role: str) -> bool:
-        """Return True if *role* has the account-level BIND SERVICE ENDPOINT privilege."""
-        from snowflake.cli.api.project.util import to_string_literal
-
-        safe_role = to_string_literal(role)
-        cursor = self.execute_query(
-            f"SHOW GRANTS TO ROLE IDENTIFIER({safe_role})", cursor_class=DictCursor
-        )
-        for row in cursor:
-            if (
-                row.get("privilege") == "BIND SERVICE ENDPOINT"
-                and row.get("granted_on") == "ACCOUNT"
-            ):
-                return True
-        return False
 
     def stage_exists(self, stage_fqn: FQN) -> bool:
         """Check if a stage exists."""
@@ -1064,16 +1009,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
         normalised = {k.lower(): v for k, v in row.items()}
         log.debug("DESCRIBE APPLICATION SERVICE %s: %s", service_fqn, normalised)
         return normalised
-
-    def get_app_service_logs(self, service_name: str) -> str:
-        """Get logs for an application service."""
-        from snowflake.cli.api.project.util import to_string_literal
-
-        cursor = self.execute_query(
-            f"CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS({to_string_literal(service_name)})"
-        )
-        row = cursor.fetchone()
-        return row[0] if row else ""
 
     def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
         """Fetch build logs for an artifact-repo build job."""

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1337,18 +1337,6 @@ class TestSnowflakeAppManager:
         assert "TO VERSION LATEST" in upgrade_query
 
     @patch(EXECUTE_QUERY)
-    def test_get_app_service_logs(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = ("log output here",)
-        mock_execute.return_value = cursor
-
-        result = SnowflakeAppManager().get_app_service_logs("my_app")
-        assert result == "log output here"
-        mock_execute.assert_called_once_with(
-            "CALL SYSTEM$GET_APPLICATION_SERVICE_LOGS('my_app')"
-        )
-
-    @patch(EXECUTE_QUERY)
     def test_describe_app_service_normalises_keys(self, mock_execute):
         cursor = Mock()
         cursor.fetchone.return_value = {
@@ -2734,72 +2722,6 @@ class TestBundleCommand:
             mock_resolve.assert_called_once_with("custom_app")
 
 
-# ── _find_dockerfile_expose_port tests ─────────────────────────────────
-
-
-class TestFindDockerfileExposePort:
-    def test_returns_port_from_expose(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nEXPOSE 3000\n")
-        assert _find_dockerfile_expose_port(tmp_path) == 3000
-
-    def test_returns_port_with_tcp_suffix(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nEXPOSE 8080/tcp\n")
-        assert _find_dockerfile_expose_port(tmp_path) == 8080
-
-    def test_returns_port_with_udp_suffix(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nEXPOSE 5000/udp\n")
-        assert _find_dockerfile_expose_port(tmp_path) == 5000
-
-    def test_returns_first_port_when_multiple(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        (tmp_path / "Dockerfile").write_text(
-            "FROM python:3.11\nEXPOSE 3000\nEXPOSE 8080\n"
-        )
-        assert _find_dockerfile_expose_port(tmp_path) == 3000
-
-    def test_returns_none_when_no_dockerfile(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        assert _find_dockerfile_expose_port(tmp_path) is None
-
-    def test_returns_none_when_no_expose(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nCMD ['python']\n")
-        assert _find_dockerfile_expose_port(tmp_path) is None
-
-    def test_case_insensitive(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import _find_dockerfile_expose_port
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nexpose 9090\n")
-        assert _find_dockerfile_expose_port(tmp_path) == 9090
-
-    def test_returns_unsupported_for_multi_port(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import (
-            EXPOSE_UNSUPPORTED_SYNTAX,
-            _find_dockerfile_expose_port,
-        )
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nEXPOSE 3000 8080\n")
-        assert _find_dockerfile_expose_port(tmp_path) == EXPOSE_UNSUPPORTED_SYNTAX
-
-    def test_returns_unsupported_for_port_range(self, tmp_path):
-        from snowflake.cli._plugins.apps.manager import (
-            EXPOSE_UNSUPPORTED_SYNTAX,
-            _find_dockerfile_expose_port,
-        )
-
-        (tmp_path / "Dockerfile").write_text("FROM python:3.11\nEXPOSE 3000-3005\n")
-        assert _find_dockerfile_expose_port(tmp_path) == EXPOSE_UNSUPPORTED_SYNTAX
-
-
 # ── Validate CLI command tests ────────────────────────────────────────
 
 
@@ -2991,61 +2913,6 @@ class TestValidateCommand:
             result = runner.invoke(["app", "validate"])
             assert result.exit_code == 1
             assert "bundle failed" in result.output
-
-
-# ── role_has_bind_service_endpoint tests ──────────────────────────────
-
-
-class TestRoleHasBindServiceEndpoint:
-    @patch(EXECUTE_QUERY)
-    def test_returns_true_when_privilege_granted(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "privilege": "BIND SERVICE ENDPOINT",
-                        "granted_on": "ACCOUNT",
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().role_has_bind_service_endpoint("DEV_ROLE") is True
-
-    @patch(EXECUTE_QUERY)
-    def test_returns_false_when_no_matching_privilege(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "privilege": "CREATE DATABASE",
-                        "granted_on": "ACCOUNT",
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().role_has_bind_service_endpoint("DEV_ROLE") is False
-
-    @patch(EXECUTE_QUERY)
-    def test_returns_false_when_no_grants(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(return_value=iter([]))
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().role_has_bind_service_endpoint("DEV_ROLE") is False
-
-    @patch(EXECUTE_QUERY)
-    def test_escapes_role_with_single_quote(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(return_value=iter([]))
-        mock_execute.return_value = cursor
-        SnowflakeAppManager().role_has_bind_service_endpoint("BAD'ROLE")
-        query = mock_execute.call_args[0][0]
-        # Single quotes are escaped by doubling them (''), not by backslash prefix.
-        assert "'BAD''ROLE'" in query
-        assert "BAD\\'ROLE" not in query
 
 
 # ── Open CLI command tests ────────────────────────────────────────────


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand. — N/A: no user-facing interface change; only unused internal helpers removed.
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code. — Removed the now-orphaned unit tests for the deleted helpers.
   * [ ] I've added or updated integration tests to verify correctness of my new code. — N/A (no behavior change).
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md`. — N/A (no user-facing change); `skip-release-notes` label applied.
   * [x] I've updated documentation if behavior changed. — N/A.

### Changes description

Removes dead code from the `snowflake-app` plugin. Three internal helpers in `SnowflakeAppManager` / `manager.py` were never called by any command flow and were only exercised by their own unit tests:

The corresponding unit tests are removed as well. No user-facing interface, command output, or `snowflake.yml` schema changes.