### PR TITLE
Snowflake Apps: prefix polling messages with timestamp

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -39,6 +39,7 @@ from snowflake.cli._plugins.apps.manager import (
     _poll_until,
     _resolve_deploy_defaults,
     _resolve_entity_id,
+    _ts,
     app_fqn,
     perform_bundle,
 )
@@ -677,7 +678,7 @@ def snowflake_app_deploy(
                     )
                 artifact_build_job_fqn = FQN.from_string(match.group(1))
                 cli_console.step(
-                    f"Waiting for artifact repo build to complete: "
+                    f"[{_ts()}] Waiting for artifact repo build to complete: "
                     f"{artifact_build_job_fqn}..."
                 )
 
@@ -776,7 +777,7 @@ def snowflake_app_deploy(
     try:
         with metrics.span("snowflake_app.endpoint_provision"):
             if did_upgrade:
-                cli_console.step("Waiting for upgrade to complete...")
+                cli_console.step(f"[{_ts()}] Waiting for upgrade to complete...")
                 with metrics.span("snowflake_app.endpoint_provision.wait_for_upgrade"):
                     desc = _poll_until(
                         poll_fn=lambda: manager.describe_app_service(service_fqn),
@@ -792,7 +793,9 @@ def snowflake_app_deploy(
                         ),
                     )
             else:
-                cli_console.step("Waiting for application service endpoint...")
+                cli_console.step(
+                    f"[{_ts()}] Waiting for application service endpoint..."
+                )
                 with metrics.span("snowflake_app.endpoint_provision.wait_for_endpoint"):
                     desc = _poll_until(
                         poll_fn=lambda: manager.describe_app_service(service_fqn),

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -119,6 +119,11 @@ MANAGED_COMPUTE_POOL_FALLBACK_PARAM = (
 T = TypeVar("T")
 
 
+def _ts() -> str:
+    """Return the current local time as ``HH:MM:SS`` for polling message prefixes."""
+    return time.strftime("%H:%M:%S")
+
+
 def _poll_until(
     poll_fn: Callable[[], T],
     *,
@@ -170,7 +175,7 @@ def _poll_until(
             time.sleep(interval_seconds)
 
         result = poll_fn()
-        cli_console.step(f"Status: {format_status(result)}")
+        cli_console.step(f"[{_ts()}] Status: {format_status(result)}")
 
         if is_done is not None:
             # ── Predicate mode ────────────────────────────────────

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -30,6 +30,7 @@ from snowflake.cli._plugins.apps.manager import (
     _object_exists,
     _poll_until,
     _resolve_entity_id,
+    _ts,
     app_fqn,
     perform_bundle,
 )
@@ -193,6 +194,22 @@ class TestGetEntity:
     def test_raises_when_not_found(self, _):
         with pytest.raises(CliError, match="Entity 'my_app' not found"):
             _get_entity("my_app")
+
+
+# ── _ts tests ─────────────────────────────────────────────────────────
+
+
+class TestTs:
+    """Tests for the _ts() timestamp helper used in polling messages."""
+
+    @patch("snowflake.cli._plugins.apps.manager.time.strftime", return_value="12:34:56")
+    def test_returns_formatted_time(self, mock_strftime):
+        assert _ts() == "12:34:56"
+        mock_strftime.assert_called_once_with("%H:%M:%S")
+
+    @patch("snowflake.cli._plugins.apps.manager.time.strftime", return_value="00:00:00")
+    def test_midnight_format(self, mock_strftime):
+        assert _ts() == "00:00:00"
 
 
 # ── _poll_until tests ─────────────────────────────────────────────────
@@ -392,6 +409,38 @@ class TestPollUntilOnPoll:
         )
         assert mock_sleep.call_count == 2
         mock_sleep.assert_called_with(3)
+
+
+class TestPollUntilStatusMessage:
+    """Verify the per-iteration status step includes a ``[HH:MM:SS]`` prefix."""
+
+    @patch("snowflake.cli._plugins.apps.manager.cli_console")
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    @patch("snowflake.cli._plugins.apps.manager.time.strftime", return_value="10:00:00")
+    def test_status_step_includes_timestamp(self, _mock_strftime, _mock_sleep, mock_cc):
+        _poll_until(
+            poll_fn=lambda: "DONE",
+            done_states={"DONE"},
+            error_states={"FAILED"},
+            known_pending_states={"PENDING"},
+            timeout_message="timed out",
+        )
+        mock_cc.step.assert_called_once_with("[10:00:00] Status: DONE")
+
+    @patch("snowflake.cli._plugins.apps.manager.cli_console")
+    @patch("snowflake.cli._plugins.apps.manager.time.sleep")
+    @patch("snowflake.cli._plugins.apps.manager.time.strftime", return_value="23:59:59")
+    def test_status_step_timestamp_format(self, _mock_strftime, _mock_sleep, mock_cc):
+        """Status line uses [HH:MM:SS] bracket format."""
+        _poll_until(
+            poll_fn=lambda: "DONE",
+            done_states={"DONE"},
+            error_states={"FAILED"},
+            known_pending_states={"PENDING"},
+            timeout_message="timed out",
+        )
+        step_arg = mock_cc.step.call_args[0][0]
+        assert step_arg.startswith("[23:59:59] Status: ")
 
 
 # ── Build log streamer tests ──────────────────────────────────────────


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
All polling-related `cli_console.step` messages in `snow app` now include a `[HH:MM:SS]` local-time prefix. This makes it easy to see exactly when each status check fired during long-running `snow app deploy` operations (artifact-repo build wait, service upgrade wait, and endpoint-provision wait).
