### PR TITLE
Snowflake Apps: require --upgrade flag for deploy upgrade path

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@
 
 ## New additions
 * Added a `--protocol` option (plus matching `SNOWFLAKE_PROTOCOL` env var and `protocol` config key) to `snow connection add` and the global connection overrides. This allows selecting `http` or `https` as the connection protocol without editing `config.toml`, which is primarily useful for local development against `http` deployments.
+* Added a `--upgrade` flag to `snow app deploy` for Snowflake App Runtime projects. Upgrading an existing application service now requires `--upgrade`; without it, deploy fails fast when a service with the same name already exists. `snow app setup` also warns when an app service already exists at the resolved name.
 
 ## Fixes and improvements
 * Fixed `TooManyFilesError` during `snow streamlit deploy` when `main_file` is a descendant of a directory listed in `artifacts`.

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -223,6 +223,23 @@ def snowflake_app_setup(
 
     resolved_values = {k: v[0] for k, v in resolved.items()}
 
+    # ── Warn on an existing app service with the same FQN ─────────────
+    # The generated project targets ``<database>.<schema>.<app_name>``. If an
+    # app service already lives at that FQN, ``snow app deploy`` would refuse
+    # to recreate it, so surface this now while the user can still pick a
+    # different name or location.
+    with metrics.span("snowflake_app.setup.check_existing_service"):
+        existing_service_fqn = app_fqn(
+            database=resolved_values["database"],
+            schema=resolved_values["schema"],
+            name=resolved_app_name,
+        )
+        if manager.app_service_exists(existing_service_fqn):
+            cli_console.warning(
+                f"An app service named {existing_service_fqn.identifier} already exists. "
+                "To update it, deploy with 'snow app deploy --upgrade'."
+            )
+
     if not dry_run:
         use_workspace = resolved["database"][1] == SOURCE_DEFAULT
         project_file.write_text(
@@ -441,6 +458,7 @@ def snowflake_app_deploy(
     upload_only: bool,
     build_only: bool,
     deploy_only: bool,
+    upgrade: bool,
 ) -> CommandResult:
     """Build and deploy a Snowflake App Runtime through upload, build, and deploy phases."""
     phase_flags = sum((upload_only, build_only, deploy_only))
@@ -560,6 +578,28 @@ def snowflake_app_deploy(
 
     stage_manager = StageManager()
     metrics = get_cli_context().metrics
+
+    # ── Upgrade gating ────────────────────────────────────────────────
+    # The upgrade path (ALTER APPLICATION SERVICE ... UPGRADE) is only taken
+    # when the user explicitly passes ``--upgrade``. Resolve this up front,
+    # before any upload or build work, so we can fail fast when the request
+    # and the current account state disagree. The check is only meaningful
+    # for runs that reach the deploy phase.
+    should_upgrade = False
+    if run_deploy:
+        with metrics.span("snowflake_app.deploy.check_existing_service"):
+            service_already_exists = manager.app_service_exists(service_fqn)
+        if service_already_exists and not upgrade:
+            raise CliError(
+                f"Application service {service_fqn.identifier} already exists. "
+                "Re-run with --upgrade to upgrade the existing app service."
+            )
+        if upgrade and not service_already_exists:
+            raise CliError(
+                f"No existing application service {service_fqn.identifier} to upgrade. "
+                "Remove --upgrade to create a new app service."
+            )
+        should_upgrade = upgrade
 
     # ── Upload phase ──────────────────────────────────────────────────
 
@@ -711,12 +751,29 @@ def snowflake_app_deploy(
 
     eai_list = [build_eai] if build_eai else None
 
-    did_upgrade = False
+    did_upgrade = should_upgrade
     with metrics.span("snowflake_app.deploy_service"):
-        cli_console.step("Creating application service...")
-        try:
-            with metrics.span("snowflake_app.deploy_service.create") as create_span:
-                try:
+        if should_upgrade:
+            cli_console.step(
+                f"Application service {app_name} already exists. Upgrading..."
+            )
+            try:
+                with metrics.span("snowflake_app.deploy_service.upgrade"):
+                    manager.upgrade_app_service(
+                        service_fqn=service_fqn,
+                        version="LATEST",
+                    )
+            except ProgrammingError as upgrade_error:
+                _log_service_logs(manager, service_fqn)
+                raise CliError(
+                    "Deployment failed while upgrading application service "
+                    f"'{service_fqn.identifier}': {upgrade_error}. "
+                    "Verify privileges for ALTER APPLICATION SERVICE and access to referenced objects."
+                ) from upgrade_error
+        else:
+            cli_console.step("Creating application service...")
+            try:
+                with metrics.span("snowflake_app.deploy_service.create"):
                     manager.create_app_service(
                         service_fqn=service_fqn,
                         artifact_repo_fqn=artifact_repo_fqn_str,
@@ -727,36 +784,7 @@ def snowflake_app_deploy(
                         external_access_integrations=eai_list,
                         comment=app_comment,
                     )
-                except ProgrammingError as e:
-                    # "Already exists" is the expected re-deploy path: the
-                    # outer handler dispatches to ALTER ... UPGRADE. Finish
-                    # the Create span successfully so telemetry doesn't
-                    # double-count every redeploy as a ProgrammingError on
-                    # this span; the recovery is recorded by
-                    # ``deploy_service.upgrade`` instead.
-                    if e.errno == 2002 and "already exists" in str(e).lower():
-                        create_span.finish()
-                    raise
-        except ProgrammingError as e:
-            if e.errno == 2002 and "already exists" in str(e).lower():
-                cli_console.step(
-                    f"Application service {app_name} already exists. Upgrading..."
-                )
-                try:
-                    with metrics.span("snowflake_app.deploy_service.upgrade"):
-                        manager.upgrade_app_service(
-                            service_fqn=service_fqn,
-                            version="LATEST",
-                        )
-                except ProgrammingError as upgrade_error:
-                    _log_service_logs(manager, service_fqn)
-                    raise CliError(
-                        "Deployment failed while upgrading application service "
-                        f"'{service_fqn.identifier}': {upgrade_error}. "
-                        "Verify privileges for ALTER APPLICATION SERVICE and access to referenced objects."
-                    ) from upgrade_error
-                did_upgrade = True
-            else:
+            except ProgrammingError as e:
                 _log_service_logs(manager, service_fqn)
                 raise CliError(
                     "Deployment failed while creating application service "

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -964,6 +964,27 @@ class SnowflakeAppManager(SqlExecutionMixin):
             query += f"\nTO VERSION {version}"
         self.execute_query(query)
 
+    def app_service_exists(self, service_fqn: FQN) -> bool:
+        """Return True when an app service with this FQN already exists.
+
+        Unlike :meth:`is_application_service` (which distinguishes between an
+        application service and a legacy service and defaults to ``True`` when
+        type detection fails), this method answers the narrower question of
+        whether *any* service object with the given FQN is present. It returns
+        ``False`` when nothing exists so callers can gate the deploy upgrade
+        path on an explicit, positive existence check.
+        """
+        try:
+            if self.describe_app_service(service_fqn):
+                return True
+        except ProgrammingError:
+            log.debug(
+                "DESCRIBE APPLICATION SERVICE failed for %s",
+                service_fqn,
+                exc_info=True,
+            )
+        return _object_exists("service", service_fqn.identifier)
+
     def is_application_service(self, service_fqn: FQN) -> bool:
         """Return True when settings should use the ``app-service`` URL segment.
 

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -503,6 +503,12 @@ def app_deploy(
         help="(Snowflake App Runtime only) Run only the deploy phase (assumes a previous build phase has already completed). "
         "Skips the upload and build phases.",
     ),
+    upgrade: bool = typer.Option(
+        False,
+        "--upgrade",
+        help="(Snowflake App Runtime only) Upgrade the existing application service instead of creating a new one. "
+        "Required when an app service with the same name already exists.",
+    ),
     **options,
 ) -> CommandResult:
     """
@@ -532,7 +538,11 @@ def app_deploy(
             },
         )
         return snowflake_app_deploy(
-            options.get("entity_id") or None, upload_only, build_only, deploy_only
+            options.get("entity_id") or None,
+            upload_only,
+            build_only,
+            deploy_only,
+            upgrade,
         )
 
     _reject_snowflake_app_options(
@@ -541,6 +551,7 @@ def app_deploy(
             "--upload-only": True if upload_only else None,
             "--build-only": True if build_only else None,
             "--deploy-only": True if deploy_only else None,
+            "--upgrade": True if upgrade else None,
         },
     )
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -199,6 +199,14 @@
   |                                                    build phase has already   |
   |                                                    completed). Skips the     |
   |                                                    upload and build phases.  |
+  | --upgrade                                          (Snowflake App Runtime    |
+  |                                                    only) Upgrade the         |
+  |                                                    existing application      |
+  |                                                    service instead of        |
+  |                                                    creating a new one.       |
+  |                                                    Required when an app      |
+  |                                                    service with the same     |
+  |                                                    name already exists.      |
   | --package-entity-id                          TEXT  (Native App only) The ID  |
   |                                                    of the package entity on  |
   |                                                    which to operate when the |

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1410,6 +1410,43 @@ class TestSnowflakeAppManager:
         assert SnowflakeAppManager().is_application_service(fqn) is True
         mock_object_exists.assert_called_once_with("service", "DB.SCHEMA.my_app")
 
+    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(EXECUTE_QUERY)
+    def test_app_service_exists_true_when_describe_returns_row(
+        self, mock_execute, mock_object_exists
+    ):
+        cursor = Mock()
+        cursor.fetchone.return_value = {"URL": "my-app.snowflakecomputing.app"}
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="my_app")
+        assert SnowflakeAppManager().app_service_exists(fqn) is True
+        mock_object_exists.assert_not_called()
+
+    @patch(OBJECT_EXISTS, return_value=True)
+    @patch(EXECUTE_QUERY)
+    def test_app_service_exists_true_when_legacy_service_exists(
+        self, mock_execute, mock_object_exists
+    ):
+        mock_execute.side_effect = ProgrammingError("object does not exist")
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="my_app")
+        assert SnowflakeAppManager().app_service_exists(fqn) is True
+        mock_object_exists.assert_called_once_with("service", "DB.SCHEMA.my_app")
+
+    @patch(OBJECT_EXISTS, return_value=False)
+    @patch(EXECUTE_QUERY)
+    def test_app_service_exists_false_when_nothing_found(
+        self, mock_execute, mock_object_exists
+    ):
+        cursor = Mock()
+        cursor.fetchone.return_value = None
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="my_app")
+        assert SnowflakeAppManager().app_service_exists(fqn) is False
+        mock_object_exists.assert_called_once_with("service", "DB.SCHEMA.my_app")
+
     def test_resolve_application_service_url_from_describe(self):
         mgr = SnowflakeAppManager()
         assert mgr.resolve_application_service_url_from_describe({}) is None
@@ -2099,6 +2136,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2126,12 +2164,43 @@ class TestSetupCommand:
         return_value="definition_version: '2'\n",
     )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_setup_warns_when_app_service_already_exists(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """Setup warns (but still succeeds) when an app service already lives
+        at the resolved FQN."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = True
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+            assert result.exit_code == 0, result.output
+            assert "already exists" in result.output
+            assert "--upgrade" in result.output
+            assert (tmp_path / "snowflake.yml").exists()
+
+        service_fqn = mock_mgr.app_service_exists.call_args.args[0]
+        assert service_fqn.identifier == "PARAM_DB.PARAM_SCHEMA.my_app"
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_init_uses_current_directory_name_when_app_name_not_provided(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2158,6 +2227,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2179,6 +2249,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2218,6 +2289,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2246,6 +2318,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2272,6 +2345,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2316,6 +2390,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2355,6 +2430,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2383,6 +2459,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "build_compute_pool": "PARAM_POOL",
             "service_compute_pool": "PARAM_SVC_POOL",
@@ -2428,6 +2505,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "query_warehouse": "PARAM_WH",
             "build_compute_pool": "PARAM_POOL",
@@ -2456,6 +2534,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "query_warehouse": "PARAM_WH",
             "build_compute_pool": "PARAM_POOL",
@@ -2487,6 +2566,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
@@ -2517,6 +2597,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2564,6 +2645,7 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2738,6 +2820,7 @@ class TestValidateCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.database_exists.return_value = True
         mock_mgr.schema_exists.return_value = True
         return mock_mgr
@@ -2942,6 +3025,7 @@ class TestOpenCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = (
             "https://my-app.snowflakecomputing.app"
         )
@@ -2976,6 +3060,7 @@ class TestOpenCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = (
             "https://my-app.snowflakecomputing.app"
         )
@@ -3008,6 +3093,7 @@ class TestOpenCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = None
 
         with change_directory(tmp_path):
@@ -3084,6 +3170,7 @@ class TestOpenCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = (
             "https://my-app.snowflakecomputing.app"
         )
@@ -3402,6 +3489,7 @@ class TestEventsCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_logs.return_value = "INFO: app started\nINFO: listening"
 
         with change_directory(tmp_path):
@@ -3433,6 +3521,7 @@ class TestEventsCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_logs.return_value = ""
 
         with change_directory(tmp_path):
@@ -3462,6 +3551,7 @@ class TestEventsCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_logs.return_value = "line1"
 
         with change_directory(tmp_path):
@@ -3494,6 +3584,7 @@ class TestEventsCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_logs.side_effect = ProgrammingError("does not exist")
 
         with change_directory(tmp_path):
@@ -3542,6 +3633,191 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
+    def test_deploy_requires_upgrade_flag_when_service_exists(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """Deploy must refuse to recreate an existing app service and tell
+        the user to pass --upgrade. The check runs before any service is
+        created or upgraded."""
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = True
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            assert result.exit_code == 1, result.output
+            assert "already exists" in result.output
+            assert "--upgrade" in result.output
+
+        mock_mgr.create_app_service.assert_not_called()
+        mock_mgr.upgrade_app_service.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_upgrade_flag_without_existing_service_errors(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """Passing --upgrade when no app service exists is a hard error."""
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only", "--upgrade"])
+            assert result.exit_code == 1, result.output
+            assert "No existing application service" in result.output
+
+        mock_mgr.create_app_service.assert_not_called()
+        mock_mgr.upgrade_app_service.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_upgrade_flag_upgrades_existing_service(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """With --upgrade and an existing service, deploy upgrades instead of
+        creating."""
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = True
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--deploy-only", "--upgrade"])
+            assert result.exit_code == 0, result.output
+            assert "Upgrading" in result.output
+
+        mock_mgr.upgrade_app_service.assert_called_once()
+        mock_mgr.create_app_service.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
     def test_deploy_only_skips_upload_and_build_phase(
         self,
         mock_resolve,
@@ -3568,6 +3844,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -3631,6 +3908,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.create_app_service.side_effect = create_error
         mock_mgr.get_service_logs.return_value = (
             "create failed line1\ncreate failed line2"
@@ -3705,15 +3983,15 @@ class TestDeployCommand:
         entity.artifact_repository = None
         mock_get_entity.return_value = entity
 
-        create_error = ProgrammingError("already exists")
-        create_error.errno = 2002
         upgrade_error = ProgrammingError("permission denied")
         upgrade_error.errno = 2043
 
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.create_app_service.side_effect = create_error
+        # The app service already exists, so ``--upgrade`` routes the deploy
+        # straight to the upgrade path.
+        mock_mgr.app_service_exists.return_value = True
         mock_mgr.upgrade_app_service.side_effect = upgrade_error
         mock_mgr.get_service_logs.return_value = (
             "upgrade failed line1\nupgrade failed line2"
@@ -3729,18 +4007,15 @@ class TestDeployCommand:
         ):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--deploy-only", "--upgrade"])
             assert result.exit_code == 1
             assert (
                 "Deployment failed while upgrading application service" in result.output
             )
-            create_span = _get_completed_span("snowflake_app.deploy_service.create")
             upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
-            # The "already exists" ProgrammingError on CREATE is an
-            # expected redeploy signal, not a failure of the Create step;
-            # only the upgrade span should record the failure.
-            assert create_span[CLIMetricsSpan.ERROR_KEY] is None
             assert upgrade_span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
+            # CREATE is never attempted on the upgrade path.
+            mock_mgr.create_app_service.assert_not_called()
             mock_log.info.assert_any_call("upgrade failed line1")
             mock_log.info.assert_any_call("upgrade failed line2")
 
@@ -3795,6 +4070,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -3862,6 +4138,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.get_service_logs.return_value = "failed line1\nfailed line2"
         mock_mgr.resolve_application_service_url_from_describe.return_value = None
         mock_mgr.describe_app_service.return_value = {
@@ -3941,13 +4218,11 @@ class TestDeployCommand:
         entity.artifact_repository = None
         mock_get_entity.return_value = entity
 
-        already_exists = ProgrammingError("already exists")
-        already_exists.errno = 2002
-
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.create_app_service.side_effect = already_exists
+        # Existing app service + ``--upgrade`` exercises the upgrade wait path.
+        mock_mgr.app_service_exists.return_value = True
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -3956,12 +4231,11 @@ class TestDeployCommand:
         with change_directory(tmp_path):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--deploy-only", "--upgrade"])
             assert result.exit_code == 0, result.output
-            create_span = _get_completed_span("snowflake_app.deploy_service.create")
             upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
-            assert create_span[CLIMetricsSpan.ERROR_KEY] is None
             assert upgrade_span[CLIMetricsSpan.ERROR_KEY] is None
+            mock_mgr.create_app_service.assert_not_called()
 
         _, kwargs = mock_poll.call_args
         assert (
@@ -4043,6 +4317,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -4183,6 +4458,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -4284,6 +4560,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -4383,6 +4660,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
@@ -4481,6 +4759,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -4585,6 +4864,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -4669,6 +4949,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.stage_exists.return_value = False
 
         from tests_common import change_directory
@@ -4734,6 +5015,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -4804,6 +5086,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -4995,6 +5278,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -5098,6 +5382,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -5204,6 +5489,7 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = True
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = True
+        mock_mgr.app_service_exists.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

1. `snow app deploy` — require `--upgrade` for the upgrade path
- Added a `--upgrade` flag. The deploy now resolves the upgrade decision up front, before any upload/build/deploy work: it checks whether an app service with the same FQN already exists.
  - If the service exists and `--upgrade` was **not** passed, deploy fails fast with guidance to re-run with `--upgrade`.
  - If `--upgrade` is passed but no matching service exists, deploy fails with a clear "nothing to upgrade" error.
- The deploy phase now branches explicitly on the resolved decision (`ALTER ... UPGRADE` vs `CREATE`) instead of relying on catching the server's "already exists" error, making the behavior predictable and opt-in.

2. `snow app setup` — warn on an existing app service
- Setup now checks the resolved `<database>.<schema>.<app_name>` FQN and emits a warning when an app service already exists there, pointing the user at `snow app deploy --upgrade`. Setup still succeeds.
