### PR TITLE
Add native-apps team as CODEOWNERS for nativeapp plugin and release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,11 @@
 /tests_integration/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 /tests/__snapshots__/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 /tests_integration/__snapshots__/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+
+# Nativeapp plugin
+/src/snowflake/cli/_plugins/nativeapp/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests/nativeapp/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests_integration/nativeapp/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+
+# Release notes
+/RELEASE-NOTES.md @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
Extends `.github/CODEOWNERS` so the `@snowflakedb/native-apps` team co-owns the nativeapp plugin in addition to the existing apps plugin.
