### PR TITLE
Snowflake Apps: fetch build logs via SYSTEM$GET_SERVICE_LOGS

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -32,8 +32,6 @@ import typer
 from click import ClickException
 from snowflake.cli._plugins.apps.generate import _generate_snowflake_yml
 from snowflake.cli._plugins.apps.manager import (
-    BUILD_JOB_CONTAINER_NAME,
-    BUILD_JOB_INSTANCE_ID,
     DEFAULT_PERSONAL_SCHEMA,
     DEFINITION_FILENAME,
     SnowflakeAppManager,
@@ -692,9 +690,8 @@ def snowflake_app_deploy(
                     known_pending_states={"PENDING", "RUNNING"},
                     timeout_message=(
                         f"Artifact repo build timed out. Check build logs:\n"
-                        f"  CALL SYSTEM$GET_SERVICE_LOGS("
-                        f"'{artifact_build_job_fqn.identifier}', "
-                        f"'{BUILD_JOB_INSTANCE_ID}', '{BUILD_JOB_CONTAINER_NAME}')"
+                        f"  SELECT * FROM TABLE("
+                        f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
                     ),
                     on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
                 )

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -32,6 +32,8 @@ import typer
 from click import ClickException
 from snowflake.cli._plugins.apps.generate import _generate_snowflake_yml
 from snowflake.cli._plugins.apps.manager import (
+    BUILD_JOB_CONTAINER_NAME,
+    BUILD_JOB_INSTANCE_ID,
     DEFAULT_PERSONAL_SCHEMA,
     DEFINITION_FILENAME,
     SnowflakeAppManager,
@@ -690,8 +692,9 @@ def snowflake_app_deploy(
                     known_pending_states={"PENDING", "RUNNING"},
                     timeout_message=(
                         f"Artifact repo build timed out. Check build logs:\n"
-                        f"  SELECT * FROM TABLE("
-                        f"{artifact_build_job_fqn.identifier}!SPCS_GET_LOGS())"
+                        f"  CALL SYSTEM$GET_SERVICE_LOGS("
+                        f"'{artifact_build_job_fqn.identifier}', "
+                        f"'{BUILD_JOB_INSTANCE_ID}', '{BUILD_JOB_CONTAINER_NAME}')"
                     ),
                     on_poll=_make_build_log_streamer(manager, artifact_build_job_fqn),
                 )

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -42,6 +42,7 @@ from snowflake.cli.api.exceptions import CliError
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.project_paths import ProjectPaths
 from snowflake.cli.api.project.util import to_identifier
+from snowflake.cli.api.sanitizers import sanitize_for_terminal
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.api.utils.path_utils import resolve_without_follow
@@ -116,9 +117,11 @@ MANAGED_COMPUTE_POOL_FALLBACK_PARAM = (
     "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK"
 )
 
-# Artifact-repo build jobs run as single-instance SPCS job services whose
-# container is named ``builder`` (instance ``0``). These coordinates are needed
-# to fetch build logs through ``SYSTEM$GET_SERVICE_LOGS``.
+# Artifact-repo build jobs run as single-instance SPCS job services. The
+# container/instance to read logs from is resolved at runtime via
+# ``SHOW SERVICE CONTAINERS IN SERVICE``; these values are the expected defaults
+# (container ``builder``, instance ``0``) and are surfaced in the build-timeout
+# hint so users can fetch logs manually.
 BUILD_JOB_INSTANCE_ID = "0"
 BUILD_JOB_CONTAINER_NAME = "builder"
 
@@ -1021,21 +1024,86 @@ class SnowflakeAppManager(SqlExecutionMixin):
         log.debug("DESCRIBE APPLICATION SERVICE %s: %s", service_fqn, normalised)
         return normalised
 
+    def _resolve_build_job_container(
+        self, build_job_fqn: FQN
+    ) -> Optional[tuple[str, str]]:
+        """Resolve the ``(instance_id, container_name)`` for a build job.
+
+        Runs ``SHOW SERVICE CONTAINERS IN SERVICE`` (the build job is an SPCS
+        job service) and returns the coordinates of the container to read logs
+        from. When the service exposes more than one container, a warning lists
+        them and the container named :data:`BUILD_JOB_CONTAINER_NAME` is
+        preferred, falling back to the first one.
+
+        Returns ``None`` when no running container is reported yet (e.g. the
+        service is still ``PENDING``); such results are not cached so a later
+        poll can retry. Successful resolutions are cached per build job so the
+        ``SHOW`` query and any warning happen only once.
+        """
+        cache: Dict[str, tuple[str, str]] = self.__dict__.setdefault(
+            "_build_job_container_cache", {}
+        )
+        cache_key = build_job_fqn.identifier
+        if cache_key in cache:
+            return cache[cache_key]
+
+        cursor = self.execute_query(
+            f"SHOW SERVICE CONTAINERS IN SERVICE {build_job_fqn.identifier}",
+            cursor_class=DictCursor,
+        )
+        containers: list[tuple[str, str]] = []
+        for row in cursor:
+            normalised = {k.lower(): v for k, v in row.items()}
+            container_name = normalised.get("container_name")
+            instance_id = normalised.get("instance_id")
+            # A SUSPENDED/PENDING service reports NULL container fields.
+            if container_name is None or instance_id is None:
+                continue
+            containers.append((str(instance_id), str(container_name)))
+
+        if not containers:
+            return None
+
+        if len(containers) > 1:
+            listed = ", ".join(sanitize_for_terminal(name) for _, name in containers)
+            cli_console.warning(
+                f"Build job {sanitize_for_terminal(build_job_fqn.identifier)} "
+                f"has multiple containers: {listed}. Using "
+                f"'{BUILD_JOB_CONTAINER_NAME}' if present, otherwise the first."
+            )
+
+        resolved = next(
+            (
+                (instance_id, name)
+                for instance_id, name in containers
+                if name == BUILD_JOB_CONTAINER_NAME
+            ),
+            containers[0],
+        )
+        cache[cache_key] = resolved
+        return resolved
+
     def get_build_job_logs(self, build_job_fqn: FQN, last: int = 500) -> list[str]:
         """Fetch build logs for an artifact-repo build job.
 
         Uses ``SYSTEM$GET_SERVICE_LOGS`` — the same mechanism that backs the
         application logs surfaced by ``snow app events`` — rather than the build
-        job's ``SPCS_GET_LOGS`` table function. The build job is a single-instance
-        SPCS job service whose container is named :data:`BUILD_JOB_CONTAINER_NAME`.
+        job's ``SPCS_GET_LOGS`` table function. The build job's container and
+        instance are resolved at runtime via ``SHOW SERVICE CONTAINERS IN
+        SERVICE`` (see :meth:`_resolve_build_job_container`).
         """
         from snowflake.cli.api.project.util import to_string_literal
+
+        resolved = self._resolve_build_job_container(build_job_fqn)
+        if resolved is None:
+            return []
+        instance_id, container_name = resolved
 
         cursor = self.execute_query(
             f"CALL SYSTEM$GET_SERVICE_LOGS("
             f"{to_string_literal(build_job_fqn.identifier)}, "
-            f"{to_string_literal(BUILD_JOB_INSTANCE_ID)}, "
-            f"{to_string_literal(BUILD_JOB_CONTAINER_NAME)}, "
+            f"{to_string_literal(instance_id)}, "
+            f"{to_string_literal(container_name)}, "
             f"{last})"
         )
         row = cursor.fetchone()

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -117,12 +117,10 @@ MANAGED_COMPUTE_POOL_FALLBACK_PARAM = (
     "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK"
 )
 
-# Artifact-repo build jobs run as single-instance SPCS job services. The
-# container/instance to read logs from is resolved at runtime via
-# ``SHOW SERVICE CONTAINERS IN SERVICE``; these values are the expected defaults
-# (container ``builder``, instance ``0``) and are surfaced in the build-timeout
-# hint so users can fetch logs manually.
-BUILD_JOB_INSTANCE_ID = "0"
+# Artifact-repo build jobs run as SPCS job services. The container/instance to
+# read logs from is resolved at runtime via ``SHOW SERVICE CONTAINERS IN
+# SERVICE``; when a service exposes multiple containers the one named ``builder``
+# is preferred.
 BUILD_JOB_CONTAINER_NAME = "builder"
 
 T = TypeVar("T")
@@ -884,7 +882,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
         The build source is specified by either *stage_fqn* (legacy stage
         flow) or *source_uri* (e.g. a ``snow://workspace/...`` URI for the
-        workspace flow).          Exactly one of the two must be provided.
+        workspace flow).  Exactly one of the two must be provided.
         """
         from snowflake.cli.api.project.util import to_string_literal
 
@@ -1051,11 +1049,21 @@ class SnowflakeAppManager(SqlExecutionMixin):
             f"SHOW SERVICE CONTAINERS IN SERVICE {build_job_fqn.identifier}",
             cursor_class=DictCursor,
         )
+        rows = [{k.lower(): v for k, v in row.items()} for row in cursor]
+
+        # Surface the raw result in verbose mode (INFO) to aid debugging.
+        log.info(
+            "SHOW SERVICE CONTAINERS IN SERVICE %s returned %d row(s):",
+            sanitize_for_terminal(build_job_fqn.identifier),
+            len(rows),
+        )
+        for row in rows:
+            log.info("  %s", sanitize_for_terminal(str(row)))
+
         containers: list[tuple[str, str]] = []
-        for row in cursor:
-            normalised = {k.lower(): v for k, v in row.items()}
-            container_name = normalised.get("container_name")
-            instance_id = normalised.get("instance_id")
+        for row in rows:
+            container_name = row.get("container_name")
+            instance_id = row.get("instance_id")
             # A SUSPENDED/PENDING service reports NULL container fields.
             if container_name is None or instance_id is None:
                 continue

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -117,10 +117,10 @@ MANAGED_COMPUTE_POOL_FALLBACK_PARAM = (
 )
 
 # Artifact-repo build jobs run as single-instance SPCS job services whose
-# container is named ``main`` (instance ``0``). These coordinates are needed to
-# fetch build logs through ``SYSTEM$GET_SERVICE_LOGS``.
+# container is named ``builder`` (instance ``0``). These coordinates are needed
+# to fetch build logs through ``SYSTEM$GET_SERVICE_LOGS``.
 BUILD_JOB_INSTANCE_ID = "0"
-BUILD_JOB_CONTAINER_NAME = "main"
+BUILD_JOB_CONTAINER_NAME = "builder"
 
 T = TypeVar("T")
 

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -116,6 +116,12 @@ MANAGED_COMPUTE_POOL_FALLBACK_PARAM = (
     "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK"
 )
 
+# Artifact-repo build jobs run as single-instance SPCS job services whose
+# container is named ``main`` (instance ``0``). These coordinates are needed to
+# fetch build logs through ``SYSTEM$GET_SERVICE_LOGS``.
+BUILD_JOB_INSTANCE_ID = "0"
+BUILD_JOB_CONTAINER_NAME = "main"
+
 T = TypeVar("T")
 
 
@@ -875,7 +881,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
         The build source is specified by either *stage_fqn* (legacy stage
         flow) or *source_uri* (e.g. a ``snow://workspace/...`` URI for the
-        workspace flow).  Exactly one of the two must be provided.
+        workspace flow).          Exactly one of the two must be provided.
         """
         from snowflake.cli.api.project.util import to_string_literal
 
@@ -1015,9 +1021,24 @@ class SnowflakeAppManager(SqlExecutionMixin):
         log.debug("DESCRIBE APPLICATION SERVICE %s: %s", service_fqn, normalised)
         return normalised
 
-    def get_build_job_logs(self, build_job_fqn: FQN) -> list[str]:
-        """Fetch build logs for an artifact-repo build job."""
+    def get_build_job_logs(self, build_job_fqn: FQN, last: int = 500) -> list[str]:
+        """Fetch build logs for an artifact-repo build job.
+
+        Uses ``SYSTEM$GET_SERVICE_LOGS`` — the same mechanism that backs the
+        application logs surfaced by ``snow app events`` — rather than the build
+        job's ``SPCS_GET_LOGS`` table function. The build job is a single-instance
+        SPCS job service whose container is named :data:`BUILD_JOB_CONTAINER_NAME`.
+        """
+        from snowflake.cli.api.project.util import to_string_literal
+
         cursor = self.execute_query(
-            f"SELECT LOG FROM TABLE({build_job_fqn.identifier}!SPCS_GET_LOGS())",
+            f"CALL SYSTEM$GET_SERVICE_LOGS("
+            f"{to_string_literal(build_job_fqn.identifier)}, "
+            f"{to_string_literal(BUILD_JOB_INSTANCE_ID)}, "
+            f"{to_string_literal(BUILD_JOB_CONTAINER_NAME)}, "
+            f"{last})"
         )
-        return [str(row[0]) for row in cursor if row[0]]
+        row = cursor.fetchone()
+        if not row or not row[0]:
+            return []
+        return [line for line in str(row[0]).splitlines() if line]

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1785,6 +1785,28 @@ class TestSnowflakeAppManager:
             "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'foo', 500)"
         )
 
+    @patch("snowflake.cli._plugins.apps.manager.log")
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_logs_show_result(self, mock_execute, mock_log):
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": 0, "container_name": "builder", "status": "READY"}]
+        )
+        logs_cursor = self._build_logs_cursor(("ok",))
+        mock_execute.side_effect = [show_cursor, logs_cursor]
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        SnowflakeAppManager().get_build_job_logs(fqn)
+
+        info_messages = [call.args[0] for call in mock_log.info.call_args_list]
+        assert any(
+            "SHOW SERVICE CONTAINERS IN SERVICE" in message for message in info_messages
+        )
+        # The container row itself is emitted at INFO for verbose visibility.
+        logged = " ".join(
+            str(arg) for call in mock_log.info.call_args_list for arg in call.args
+        )
+        assert "builder" in logged
+
     @patch(EXECUTE_QUERY)
     def test_get_build_job_logs_caches_container_resolution(self, mock_execute):
         show_cursor = self._build_show_containers_cursor(

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1653,7 +1653,7 @@ class TestSnowflakeAppManager:
         logs = SnowflakeAppManager().get_build_job_logs(fqn)
         assert logs == ["step 1", "step 2", "step 3"]
         mock_execute.assert_called_once_with(
-            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'main', 500)"
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'builder', 500)"
         )
 
     @patch(EXECUTE_QUERY)
@@ -1666,7 +1666,7 @@ class TestSnowflakeAppManager:
         logs = SnowflakeAppManager().get_build_job_logs(fqn, last=100)
         assert logs == ["step 1"]
         mock_execute.assert_called_once_with(
-            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'main', 100)"
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'builder', 100)"
         )
 
     @patch(EXECUTE_QUERY)

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1644,6 +1644,52 @@ class TestSnowflakeAppManager:
         assert logs == ""
 
     @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("step 1\nstep 2\nstep 3",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == ["step 1", "step 2", "step 3"]
+        mock_execute.assert_called_once_with(
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'main', 500)"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_custom_last(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("step 1",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn, last=100)
+        assert logs == ["step 1"]
+        mock_execute.assert_called_once_with(
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'main', 100)"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_empty_result(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = None
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == []
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_blank_lines_skipped(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("step 1\n\nstep 2\n",)
+        mock_execute.return_value = cursor
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == ["step 1", "step 2"]
+
+    @patch(EXECUTE_QUERY)
     def test_get_service_endpoint_url(self, mock_execute):
         cursor = Mock()
         cursor.fetchone.return_value = {

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1643,37 +1643,63 @@ class TestSnowflakeAppManager:
         logs = SnowflakeAppManager().get_service_logs(fqn)
         assert logs == ""
 
+    @staticmethod
+    def _build_show_containers_cursor(rows):
+        cursor = Mock()
+        cursor.__iter__ = Mock(return_value=iter(rows))
+        return cursor
+
+    @staticmethod
+    def _build_logs_cursor(value):
+        cursor = Mock()
+        cursor.fetchone.return_value = value
+        return cursor
+
     @patch(EXECUTE_QUERY)
     def test_get_build_job_logs(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = ("step 1\nstep 2\nstep 3",)
-        mock_execute.return_value = cursor
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": 0, "container_name": "builder"}]
+        )
+        logs_cursor = self._build_logs_cursor(("step 1\nstep 2\nstep 3",))
+        mock_execute.side_effect = [show_cursor, logs_cursor]
 
         fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
         logs = SnowflakeAppManager().get_build_job_logs(fqn)
         assert logs == ["step 1", "step 2", "step 3"]
-        mock_execute.assert_called_once_with(
+
+        assert mock_execute.call_count == 2
+        show_call = mock_execute.call_args_list[0]
+        assert (
+            show_call.args[0]
+            == "SHOW SERVICE CONTAINERS IN SERVICE DB.SCHEMA.BUILD_JOB"
+        )
+        assert show_call.kwargs["cursor_class"] is DictCursor
+        assert mock_execute.call_args_list[1].args[0] == (
             "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'builder', 500)"
         )
 
     @patch(EXECUTE_QUERY)
     def test_get_build_job_logs_custom_last(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = ("step 1",)
-        mock_execute.return_value = cursor
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": 0, "container_name": "builder"}]
+        )
+        logs_cursor = self._build_logs_cursor(("step 1",))
+        mock_execute.side_effect = [show_cursor, logs_cursor]
 
         fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
         logs = SnowflakeAppManager().get_build_job_logs(fqn, last=100)
         assert logs == ["step 1"]
-        mock_execute.assert_called_once_with(
+        assert mock_execute.call_args_list[1].args[0] == (
             "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'builder', 100)"
         )
 
     @patch(EXECUTE_QUERY)
     def test_get_build_job_logs_empty_result(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = None
-        mock_execute.return_value = cursor
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": 0, "container_name": "builder"}]
+        )
+        logs_cursor = self._build_logs_cursor(None)
+        mock_execute.side_effect = [show_cursor, logs_cursor]
 
         fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
         logs = SnowflakeAppManager().get_build_job_logs(fqn)
@@ -1681,13 +1707,108 @@ class TestSnowflakeAppManager:
 
     @patch(EXECUTE_QUERY)
     def test_get_build_job_logs_blank_lines_skipped(self, mock_execute):
-        cursor = Mock()
-        cursor.fetchone.return_value = ("step 1\n\nstep 2\n",)
-        mock_execute.return_value = cursor
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": 0, "container_name": "builder"}]
+        )
+        logs_cursor = self._build_logs_cursor(("step 1\n\nstep 2\n",))
+        mock_execute.side_effect = [show_cursor, logs_cursor]
 
         fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
         logs = SnowflakeAppManager().get_build_job_logs(fqn)
         assert logs == ["step 1", "step 2"]
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_no_running_containers(self, mock_execute):
+        # SUSPENDED/PENDING service reports no usable containers.
+        show_cursor = self._build_show_containers_cursor([])
+        mock_execute.side_effect = [show_cursor]
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == []
+        # No SYSTEM$GET_SERVICE_LOGS call when there is no container.
+        mock_execute.assert_called_once()
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_skips_null_container_rows(self, mock_execute):
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": None, "container_name": None}]
+        )
+        mock_execute.side_effect = [show_cursor]
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == []
+        mock_execute.assert_called_once()
+
+    @patch("snowflake.cli._plugins.apps.manager.cli_console")
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_multiple_containers_prefers_builder(
+        self, mock_execute, mock_console
+    ):
+        show_cursor = self._build_show_containers_cursor(
+            [
+                {"instance_id": 0, "container_name": "sidecar"},
+                {"instance_id": 0, "container_name": "builder"},
+            ]
+        )
+        logs_cursor = self._build_logs_cursor(("ok",))
+        mock_execute.side_effect = [show_cursor, logs_cursor]
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == ["ok"]
+        mock_console.warning.assert_called_once()
+        assert mock_execute.call_args_list[1].args[0] == (
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'builder', 500)"
+        )
+
+    @patch("snowflake.cli._plugins.apps.manager.cli_console")
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_multiple_containers_falls_back_to_first(
+        self, mock_execute, mock_console
+    ):
+        show_cursor = self._build_show_containers_cursor(
+            [
+                {"instance_id": 0, "container_name": "foo"},
+                {"instance_id": 1, "container_name": "bar"},
+            ]
+        )
+        logs_cursor = self._build_logs_cursor(("ok",))
+        mock_execute.side_effect = [show_cursor, logs_cursor]
+
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        logs = SnowflakeAppManager().get_build_job_logs(fqn)
+        assert logs == ["ok"]
+        mock_console.warning.assert_called_once()
+        assert mock_execute.call_args_list[1].args[0] == (
+            "CALL SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.BUILD_JOB', '0', 'foo', 500)"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_get_build_job_logs_caches_container_resolution(self, mock_execute):
+        show_cursor = self._build_show_containers_cursor(
+            [{"instance_id": 0, "container_name": "builder"}]
+        )
+        mock_execute.side_effect = [
+            show_cursor,
+            self._build_logs_cursor(("a",)),
+            self._build_logs_cursor(("a\nb",)),
+        ]
+
+        manager = SnowflakeAppManager()
+        fqn = FQN(database="DB", schema="SCHEMA", name="BUILD_JOB")
+        assert manager.get_build_job_logs(fqn) == ["a"]
+        assert manager.get_build_job_logs(fqn) == ["a", "b"]
+
+        # SHOW SERVICE CONTAINERS runs once; only the log fetch repeats.
+        show_calls = [
+            call
+            for call in mock_execute.call_args_list
+            if call.args[0].startswith("SHOW SERVICE CONTAINERS")
+        ]
+        assert len(show_calls) == 1
+        assert mock_execute.call_count == 3
 
     @patch(EXECUTE_QUERY)
     def test_get_service_endpoint_url(self, mock_execute):


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
When `snow app deploy --verbose` streams artifact-repo build logs, the CLI now retrieves them with a `CALL SYSTEM$GET_SERVICE_LOGS(...)` query instead of `SELECT LOG FROM TABLE(<build_job>!SPCS_GET_LOGS())`. This query is much faster and mirrors how the application logs in `snow app events` are fetched.

**`SnowflakeAppManager.get_build_job_logs`**
- Resolves the build job's container and instance dynamically rather than hardcoding them: it runs `SHOW SERVICE CONTAINERS IN SERVICE <build_job>` and reads the `instance_id` / `container_name` columns.
- Rows with `NULL` container fields (a `SUSPENDED`/`PENDING` service) are skipped; if no usable container is reported yet, it returns no logs without calling `SYSTEM$GET_SERVICE_LOGS`, so a later poll can retry.
- When the service exposes more than one container, it emits a warning listing them (sanitized for terminal safety) and prefers the container named `builder`, falling back to the first.
- The resolved container is cached per build job, so the `SHOW` query and any warning run once instead of on every one-second poll.
