### PR TITLE
Snowflake Apps: fall back to personal DB when account default destination is inaccessible

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
 * `snow dcm list-deployments` and `snow dcm drop-deployment` now wrap the project name in `IDENTIFIER(...)`, matching every other DCM subcommand. Fully-qualified and quoted project names are now handled consistently.
 * Fixed `snow sql` table output rendering as a series of `|` characters when selecting many columns into a non-terminal destination (e.g. piped or redirected output).
 * `get_account_identifier()` and `snow spcs service build-image` now raise a clear, user-visible error when `CURRENT_ORGANIZATION_NAME()` / `CURRENT_ACCOUNT_NAME()` return no row or a NULL value, instead of a cryptic `TypeError: 'NoneType' object is not subscriptable` / `AttributeError: 'NoneType' object has no attribute 'lower'`.
+* `snow app setup` and `snow app deploy` now verify the current role can deploy to the account-configured destination (the `DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE` / `DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA` account defaults) before using it. When the role is missing the required privileges, the commands fall back to your personal database — as if no account default were set — and print a warning listing the missing grants and pointing you to your account administrator.
 
 
 # v3.19.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -35,6 +35,7 @@ from snowflake.cli._plugins.apps.manager import (
     DEFAULT_PERSONAL_SCHEMA,
     DEFINITION_FILENAME,
     SnowflakeAppManager,
+    _filter_accessible_remote_defaults,
     _get_entity,
     _poll_until,
     _resolve_deploy_defaults,
@@ -124,6 +125,9 @@ def snowflake_app_setup(
     metrics = ctx.metrics
     with metrics.span("snowflake_app.setup.resolve_defaults"):
         params = manager.fetch_snow_apps_parameters()
+        # Drop the account-configured destination database/schema the current
+        # role cannot access so resolution falls back to the personal database.
+        params = _filter_accessible_remote_defaults(manager, params)
         managed_compute_pool_enabled = manager.is_managed_compute_pool_enabled()
 
     def _resolve(

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -414,11 +414,10 @@ def _filter_accessible_remote_defaults(
     role_label = f" '{sanitize_for_terminal(role)}'" if role else ""
     cli_console.warning(
         f"Your current role{role_label} is missing privileges required to "
-        "deploy to the account-configured Snowflake Apps destination "
-        f"'{sanitize_for_terminal(database)}.{sanitize_for_terminal(schema)}': "
-        f"{', '.join(missing_descriptions)}. Falling back to your personal "
-        "database. Ask your account administrator to grant access: "
-        f"{ACCOUNT_ADMIN_SETUP_URL}"
+        "deploy to the account-configured Snowflake App Runtime destination "
+        f"'{sanitize_for_terminal(database)}.{sanitize_for_terminal(schema)}'. "
+        "Falling back to your personal database. Ask your account administrator "
+        f"to grant access: {ACCOUNT_ADMIN_SETUP_URL}"
     )
     filtered = dict(params)
     filtered.pop("database", None)
@@ -434,7 +433,7 @@ def _resolve_deploy_defaults(
     """Resolve deploy defaults using a four-tier precedence:
 
     1. Values explicitly set in ``snowflake.yml`` (highest priority)
-    2. SnowApps parameters (``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``)
+    2. Snowflake App Runtime parameters (``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``)
     3. Built-in defaults (personal DB for database, ``<app-id>_REPO`` for artifact repository)
     4. Current session values (lowest priority)
 
@@ -471,13 +470,13 @@ def _resolve_deploy_defaults(
         "schema": fqn.schema,
     }
 
-    # ── 2. SnowApps parameters (user-level) ──────────────────────────
+    # ── 2. Snowflake App Runtime parameters (user-level) ─────────────
     param_vals: Dict[str, Optional[str]] = {}
-    cli_console.step("Fetching SnowApps account parameters...")
+    cli_console.step("Fetching Snowflake App Runtime account parameters...")
     raw_params = manager.fetch_snow_apps_parameters()
     if raw_params:
         cli_console.step(
-            "Loaded SnowApps parameters: "
+            "Loaded Snowflake App Runtime parameters: "
             + ", ".join(f"{k}={v}" for k, v in raw_params.items())
         )
         # Drop the account-configured destination database/schema when the
@@ -1051,7 +1050,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         return self._is_boolean_param_true(MANAGED_COMPUTE_POOL_FALLBACK_PARAM)
 
     def fetch_snow_apps_parameters(self) -> Dict[str, str]:
-        """Fetch SnowApps default parameters for the current user.
+        """Fetch Snowflake App Runtime default parameters for the current user.
 
         Runs ``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``
         and returns a dict whose keys match the internal resolution names
@@ -1075,7 +1074,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
             return result
         except ProgrammingError:
             log.warning(
-                "Could not fetch SnowApps user parameters – skipping.",
+                "Could not fetch Snowflake App Runtime user parameters – skipping.",
                 exc_info=True,
             )
             return {}

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -29,6 +29,14 @@ DEFAULT_PERSONAL_SCHEMA = "PUBLIC"
 DEFAULT_PERSONAL_WORKSPACE_NAME = "SNOWFLAKE_APPS"
 WORKSPACE_LIVE_VERSION_PATH = "versions/live"
 
+# Snowsight admin-setup docs, surfaced when the account-configured destination
+# database/schema is not accessible to the current role so the user knows where
+# to ask their administrator for access.
+ACCOUNT_ADMIN_SETUP_URL = (
+    "https://docs.snowflake.com/en/developer-guide/snowflake-app-runtime/"
+    "account-admin-setup#after-setup"
+)
+
 if TYPE_CHECKING:
     from snowflake.cli._plugins.apps.snowflake_app_entity_model import (
         SnowflakeAppEntityModel,
@@ -222,6 +230,70 @@ def _object_exists(object_type: str, name: str) -> bool:
         return False
 
 
+def _filter_accessible_remote_defaults(
+    manager: "SnowflakeAppManager",
+    params: Dict[str, str],
+) -> Dict[str, str]:
+    """Drop the account-configured destination database/schema when the current
+    role cannot access them.
+
+    The destination database and schema can be configured at the account level
+    by an administrator (``DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE`` /
+    ``DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA``), but the role running the CLI
+    may not have been granted access to them. Deploying against an inaccessible
+    destination fails late with an opaque error, so we verify access up front.
+
+    When the database (or its schema) is not visible to the current role, the
+    inaccessible values are removed from *params* and a warning is printed so
+    resolution falls back to the user's personal database — exactly as if no
+    account defaults were configured. Any error while checking is treated as
+    "not accessible" so the safe personal-database fallback is preferred over a
+    confusing downstream failure.
+
+    Returns a copy of *params* with the inaccessible keys removed (or the
+    original dict unchanged when the destination is accessible or unset).
+    """
+    database = params.get("database")
+    if not database:
+        return params
+    schema = params.get("schema")
+
+    def _accessible(check: Callable[[], bool], description: str) -> bool:
+        try:
+            return check()
+        except Exception:
+            log.debug("Could not verify access to %s", description, exc_info=True)
+            return False
+
+    inaccessible: list[str] = []
+    if not _accessible(
+        lambda: manager.database_exists(database), f"database {database!r}"
+    ):
+        inaccessible.append(f"database '{sanitize_for_terminal(database)}'")
+    elif schema and not _accessible(
+        lambda: manager.schema_exists(database, schema),
+        f"schema {database!r}.{schema!r}",
+    ):
+        inaccessible.append(
+            f"schema '{sanitize_for_terminal(database)}."
+            f"{sanitize_for_terminal(schema)}'"
+        )
+
+    if not inaccessible:
+        return params
+
+    cli_console.warning(
+        "Your current role does not have access to the account-configured "
+        f"Snowflake Apps destination ({', '.join(inaccessible)}). "
+        "Falling back to your personal database. Ask your account administrator "
+        f"to grant access to these objects: {ACCOUNT_ADMIN_SETUP_URL}"
+    )
+    filtered = dict(params)
+    filtered.pop("database", None)
+    filtered.pop("schema", None)
+    return filtered
+
+
 def _resolve_deploy_defaults(
     entity: "SnowflakeAppEntityModel",
     manager: "SnowflakeAppManager",
@@ -276,6 +348,10 @@ def _resolve_deploy_defaults(
             "Loaded SnowApps parameters: "
             + ", ".join(f"{k}={v}" for k, v in raw_params.items())
         )
+        # Drop the account-configured destination database/schema when the
+        # current role cannot access them so resolution falls back to the
+        # personal database below.
+        raw_params = _filter_accessible_remote_defaults(manager, raw_params)
         param_vals = dict(raw_params)
 
     # ── 3. Built-in defaults ────────────────────────────────────────────

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -37,6 +37,12 @@ ACCOUNT_ADMIN_SETUP_URL = (
     "account-admin-setup#after-setup"
 )
 
+# Placeholder object name used when probing destination privileges with
+# EXPLAIN_PRIVILEGES. The privileges required to create these objects depend on
+# the destination database/schema, not on the (not-yet-created) object name, so
+# a fixed placeholder is sufficient.
+PRIVILEGE_CHECK_OBJECT_NAME = "SNOWFLAKE_CLI_PRIVILEGE_CHECK"
+
 if TYPE_CHECKING:
     from snowflake.cli._plugins.apps.snowflake_app_entity_model import (
         SnowflakeAppEntityModel,
@@ -230,63 +236,139 @@ def _object_exists(object_type: str, name: str) -> bool:
         return False
 
 
+def _flatten_missing_privileges(node: Any) -> list[Dict[str, str]]:
+    """Flatten an ``EXPLAIN_PRIVILEGES`` JSON tree into a flat list of the
+    permission (leaf) nodes it reports.
+
+    The tree is composed of permission nodes (``{"privilege", "objectType",
+    "objectName"}``), ``allOf`` / ``oneOf`` group nodes, and the terminal
+    decision node ``{"authorized": true}``. With ``missing_only => true`` an
+    ``authorized`` node means nothing is missing, so it contributes nothing.
+    """
+    if not isinstance(node, dict):
+        return []
+    if node.get("authorized") is True:
+        return []
+    if any(key in node for key in ("privilege", "objectType", "objectName")):
+        return [node]
+    results: list[Dict[str, str]] = []
+    for group_key in ("allOf", "oneOf"):
+        for child in node.get(group_key, []) or []:
+            results.extend(_flatten_missing_privileges(child))
+    return results
+
+
+def _deploy_privilege_check_statements(database: str, schema: str) -> list[str]:
+    """Build the representative DDL ``snow app deploy`` issues against the
+    destination *database*/*schema*, for privilege probing via
+    ``EXPLAIN_PRIVILEGES``.
+
+    Object names are placeholders: the privileges required to create these
+    objects depend on the destination database and schema, not on the final
+    object name. Statements are emitted as plain (per-component quoted) dotted
+    identifiers rather than ``IDENTIFIER(...)`` so the privilege analyzer can
+    resolve the referenced objects.
+    """
+    placeholder = app_fqn(
+        database=database, schema=schema, name=PRIVILEGE_CHECK_OBJECT_NAME
+    ).identifier
+    return [
+        f"CREATE STAGE {placeholder} ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')",
+        f"CREATE ARTIFACT REPOSITORY {placeholder} TYPE=APPLICATION",
+        f"CREATE APPLICATION SERVICE {placeholder} "
+        f"FROM ARTIFACT REPOSITORY {placeholder} "
+        f"PACKAGE {PRIVILEGE_CHECK_OBJECT_NAME}",
+    ]
+
+
+def _format_missing_privileges(nodes: list[Dict[str, str]]) -> list[str]:
+    """Render missing-privilege nodes as de-duplicated, terminal-safe strings."""
+    formatted: list[str] = []
+    for node in nodes:
+        privilege = (node.get("privilege") or "").strip()
+        object_type = (node.get("objectType") or "").strip()
+        object_name = (node.get("objectName") or "").strip()
+        privilege_label = privilege if privilege else "any privilege"
+        target = " ".join(part for part in (object_type, object_name) if part)
+        description = (
+            f"{privilege_label} on {sanitize_for_terminal(target)}"
+            if target
+            else privilege_label
+        )
+        if description not in formatted:
+            formatted.append(description)
+    return formatted
+
+
 def _filter_accessible_remote_defaults(
     manager: "SnowflakeAppManager",
     params: Dict[str, str],
 ) -> Dict[str, str]:
     """Drop the account-configured destination database/schema when the current
-    role cannot access them.
+    role lacks the privileges to deploy there.
 
     The destination database and schema can be configured at the account level
     by an administrator (``DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE`` /
     ``DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA``), but the role running the CLI
-    may not have been granted access to them. Deploying against an inaccessible
-    destination fails late with an opaque error, so we verify access up front.
+    may not have been granted the privileges needed to build and deploy there.
+    Deploying against such a destination fails late with an opaque error, so we
+    probe up front: every representative statement ``snow app deploy`` runs is
+    analyzed with ``EXPLAIN_PRIVILEGES(… , missing_only => true, for_role =>
+    <current role>)``.
 
-    When the database (or its schema) is not visible to the current role, the
-    inaccessible values are removed from *params* and a warning is printed so
-    resolution falls back to the user's personal database — exactly as if no
-    account defaults were configured. Any error while checking is treated as
-    "not accessible" so the safe personal-database fallback is preferred over a
-    confusing downstream failure.
+    When the role is missing privileges (or no statement can be analyzed at all,
+    which means the destination cannot even be resolved), the destination is
+    removed from *params* and a warning lists the missing grants, so resolution
+    falls back to the user's personal database — exactly as if no account
+    defaults were configured. Statements that individually fail to analyze while
+    others succeed are ignored, so an unsupported statement never diverts a user
+    who otherwise has access.
 
-    Returns a copy of *params* with the inaccessible keys removed (or the
-    original dict unchanged when the destination is accessible or unset).
+    Returns a copy of *params* with the destination keys removed, or the
+    original dict unchanged when the destination is usable or unset.
     """
     database = params.get("database")
     if not database:
         return params
-    schema = params.get("schema")
+    schema = params.get("schema") or DEFAULT_PERSONAL_SCHEMA
 
-    def _accessible(check: Callable[[], bool], description: str) -> bool:
+    role = manager.current_role()
+    statements = _deploy_privilege_check_statements(database, schema)
+
+    missing: list[Dict[str, str]] = []
+    analyzed_any = False
+    failed_any = False
+    for statement in statements:
         try:
-            return check()
+            missing.extend(manager.get_missing_privileges(statement, role))
+            analyzed_any = True
         except Exception:
-            log.debug("Could not verify access to %s", description, exc_info=True)
-            return False
+            failed_any = True
+            log.debug(
+                "EXPLAIN_PRIVILEGES could not analyze statement: %s",
+                statement,
+                exc_info=True,
+            )
 
-    inaccessible: list[str] = []
-    if not _accessible(
-        lambda: manager.database_exists(database), f"database {database!r}"
-    ):
-        inaccessible.append(f"database '{sanitize_for_terminal(database)}'")
-    elif schema and not _accessible(
-        lambda: manager.schema_exists(database, schema),
-        f"schema {database!r}.{schema!r}",
-    ):
-        inaccessible.append(
-            f"schema '{sanitize_for_terminal(database)}."
-            f"{sanitize_for_terminal(schema)}'"
-        )
-
-    if not inaccessible:
+    if missing:
+        missing_descriptions = _format_missing_privileges(missing)
+    elif not analyzed_any and failed_any:
+        # Nothing could be analyzed — the current role most likely cannot
+        # resolve the destination at all, so treat it as inaccessible.
+        missing_descriptions = [
+            f"access to database '{sanitize_for_terminal(database)}'"
+        ]
+    else:
         return params
 
+    role_label = f" '{sanitize_for_terminal(role)}'" if role else ""
     cli_console.warning(
-        "Your current role does not have access to the account-configured "
-        f"Snowflake Apps destination ({', '.join(inaccessible)}). "
-        "Falling back to your personal database. Ask your account administrator "
-        f"to grant access to these objects: {ACCOUNT_ADMIN_SETUP_URL}"
+        f"Your current role{role_label} is missing privileges required to "
+        "deploy to the account-configured Snowflake Apps destination "
+        f"'{sanitize_for_terminal(database)}.{sanitize_for_terminal(schema)}': "
+        f"{', '.join(missing_descriptions)}. Falling back to your personal "
+        "database. Ask your account administrator to grant access: "
+        f"{ACCOUNT_ADMIN_SETUP_URL}"
     )
     filtered = dict(params)
     filtered.pop("database", None)
@@ -610,6 +692,50 @@ class SnowflakeAppManager(SqlExecutionMixin):
             cursor_class=DictCursor,
         )
         return cursor.fetchone() is not None
+
+    def current_role(self) -> Optional[str]:
+        """Return the active role name, or ``None`` when it cannot be resolved."""
+        try:
+            cursor = self.execute_query("SELECT CURRENT_ROLE()")
+            row = cursor.fetchone()
+            if row and row[0]:
+                return str(row[0])
+        except Exception:
+            log.warning("Could not resolve current role.", exc_info=True)
+        return None
+
+    def get_missing_privileges(
+        self, statement: str, role: Optional[str] = None
+    ) -> list[Dict[str, str]]:
+        """Return the privileges *role* is missing to run *statement*.
+
+        Calls ``EXPLAIN_PRIVILEGES(statement => …, missing_only => true
+        [, for_role => …])`` and flattens the returned JSON tree into a list
+        of permission dicts (``{"privilege", "objectType", "objectName"}``).
+
+        Returns an empty list when no privileges are missing (the server
+        responds with ``{"authorized": true}``). Propagates ``ProgrammingError``
+        when the statement cannot be analyzed — e.g. the current role cannot
+        resolve a referenced object, which itself signals missing access.
+        """
+        from snowflake.cli.api.project.util import to_string_literal
+
+        args = [
+            f"statement => {to_string_literal(statement)}",
+            "missing_only => true",
+        ]
+        if role:
+            args.append(f"for_role => {to_string_literal(role)}")
+        cursor = self.execute_query(f"CALL EXPLAIN_PRIVILEGES({', '.join(args)})")
+        row = cursor.fetchone()
+        if not row or not row[0]:
+            return []
+        try:
+            payload = json.loads(row[0])
+        except (TypeError, ValueError):
+            log.debug("Could not parse EXPLAIN_PRIVILEGES output: %r", row[0])
+            return []
+        return _flatten_missing_privileges(payload)
 
     def stage_exists(self, stage_fqn: FQN) -> bool:
         """Check if a stage exists."""

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -263,11 +263,23 @@ def _deploy_privilege_check_statements(database: str, schema: str) -> list[str]:
     destination *database*/*schema*, for privilege probing via
     ``EXPLAIN_PRIVILEGES``.
 
-    Object names are placeholders: the privileges required to create these
-    objects depend on the destination database and schema, not on the final
-    object name. Statements are emitted as plain (per-component quoted) dotted
-    identifiers rather than ``IDENTIFIER(...)`` so the privilege analyzer can
-    resolve the referenced objects.
+    We probe two statements: ``CREATE STAGE`` and ``CREATE ARTIFACT
+    REPOSITORY``. Object names are placeholders — the required privileges depend
+    on the destination database and schema, not the final object name — and are
+    emitted as plain (per-component quoted) dotted identifiers rather than
+    ``IDENTIFIER(...)`` so the analyzer can resolve them. Together these two
+    require ``USAGE`` on the database and ``CREATE`` on the schema, the
+    privileges that distinguish an accessible destination from an inaccessible
+    one.
+
+    Limitation: this is not the full set of statements ``snow app deploy`` runs.
+    The others cannot be probed because they reference objects that do not exist
+    at check time (artifact repository, package, build/app service, stage
+    contents) — ``EXPLAIN_PRIVILEGES`` rejects those with "requires access on all
+    objects" regardless of grants — or they need only ``USAGE`` already implied
+    by the two probes (``SHOW`` / ``USE``), or they belong to the workspace
+    upload flow used only for the personal-database default rather than the
+    account-configured destination checked here.
     """
     placeholder = app_fqn(
         database=database, schema=schema, name=PRIVILEGE_CHECK_OBJECT_NAME
@@ -275,9 +287,6 @@ def _deploy_privilege_check_statements(database: str, schema: str) -> list[str]:
     return [
         f"CREATE STAGE {placeholder} ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')",
         f"CREATE ARTIFACT REPOSITORY {placeholder} TYPE=APPLICATION",
-        f"CREATE APPLICATION SERVICE {placeholder} "
-        f"FROM ARTIFACT REPOSITORY {placeholder} "
-        f"PACKAGE {PRIVILEGE_CHECK_OBJECT_NAME}",
     ]
 
 
@@ -333,33 +342,74 @@ def _filter_accessible_remote_defaults(
     schema = params.get("schema") or DEFAULT_PERSONAL_SCHEMA
 
     role = manager.current_role()
+    cli_console.step(
+        "Checking deploy privileges on the account-configured destination "
+        f"{sanitize_for_terminal(database)}.{sanitize_for_terminal(schema)}..."
+    )
     statements = _deploy_privilege_check_statements(database, schema)
+    log.info(
+        "Probing deploy privileges as role %r on %r statement(s).",
+        role,
+        len(statements),
+    )
 
+    # The check fails if any probe statement reports missing privileges *or*
+    # raises. With the reduced statement set (which references only the
+    # destination database/schema) a ``ProgrammingError`` means the role cannot
+    # analyze/resolve the destination — e.g. ``EXPLAIN_PRIVILEGES`` rejects it
+    # with "requires access on all objects" — which is itself a failure, not a
+    # condition to skip.
     missing: list[Dict[str, str]] = []
-    analyzed_any = False
-    failed_any = False
+    check_failed = False
     for statement in statements:
         try:
-            missing.extend(manager.get_missing_privileges(statement, role))
-            analyzed_any = True
-        except Exception:
-            failed_any = True
-            log.debug(
-                "EXPLAIN_PRIVILEGES could not analyze statement: %s",
+            statement_missing = manager.get_missing_privileges(statement, role)
+        except Exception as exc:
+            check_failed = True
+            log.info(
+                "Privilege check: failed to analyze statement: %s (%s)",
                 statement,
-                exc_info=True,
+                exc,
             )
+            log.debug(
+                "EXPLAIN_PRIVILEGES error detail for: %s", statement, exc_info=True
+            )
+            continue
+        if statement_missing:
+            check_failed = True
+            log.info(
+                "Privilege check: missing %s for: %s",
+                _format_missing_privileges(statement_missing),
+                statement,
+            )
+            missing.extend(statement_missing)
+        else:
+            log.info("Privilege check: OK for: %s", statement)
 
-    if missing:
-        missing_descriptions = _format_missing_privileges(missing)
-    elif not analyzed_any and failed_any:
-        # Nothing could be analyzed — the current role most likely cannot
-        # resolve the destination at all, so treat it as inaccessible.
-        missing_descriptions = [
-            f"access to database '{sanitize_for_terminal(database)}'"
-        ]
-    else:
+    if not check_failed:
+        log.info(
+            "Privilege check passed: role %r has the privileges to deploy to " "%r.%r.",
+            role,
+            database,
+            schema,
+        )
         return params
+
+    # Prefer the specific missing privileges when EXPLAIN_PRIVILEGES returned
+    # them; otherwise the failure came from an analysis error, which means the
+    # role cannot resolve the destination at all.
+    missing_descriptions = _format_missing_privileges(missing) or [
+        f"access to database '{sanitize_for_terminal(database)}'"
+    ]
+
+    log.info(
+        "Privilege check failed: role %r is missing %s on %r.%r; "
+        "falling back to the personal database.",
+        role,
+        missing_descriptions,
+        database,
+        schema,
+    )
 
     role_label = f" '{sanitize_for_terminal(role)}'" if role else ""
     cli_console.warning(

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -52,6 +52,14 @@ FETCH_SNOW_APPS_PARAMS = (
     "snowflake.cli._plugins.apps.manager.SnowflakeAppManager"
     ".fetch_snow_apps_parameters"
 )
+DATABASE_EXISTS = (
+    "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.database_exists"
+)
+SCHEMA_EXISTS = "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.schema_exists"
+GET_PERSONAL_DATABASE = (
+    "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.get_personal_database"
+)
+MANAGER_CLI_CONSOLE = "snowflake.cli._plugins.apps.manager.cli_console"
 
 
 _SNOWFLAKE_APP_YML = """definition_version: '2'
@@ -2251,7 +2259,11 @@ class TestResolveDeployDefaults:
         },
     )
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    def test_parameters_fill_gaps(self, mock_ctx, mock_params):
+    @patch(SCHEMA_EXISTS, return_value=True)
+    @patch(DATABASE_EXISTS, return_value=True)
+    def test_parameters_fill_gaps(
+        self, mock_db_exists, mock_schema_exists, mock_ctx, mock_params
+    ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(database=None, schema=None)
@@ -2312,7 +2324,11 @@ class TestResolveDeployDefaults:
         GET_CLI_CONTEXT,
         return_value=_mock_connection_context(warehouse="CONN_WH"),
     )
-    def test_params_beat_session(self, mock_ctx, mock_params):
+    @patch(SCHEMA_EXISTS, return_value=True)
+    @patch(DATABASE_EXISTS, return_value=True)
+    def test_params_beat_session(
+        self, mock_db_exists, mock_schema_exists, mock_ctx, mock_params
+    ):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(database=None, schema=None)
@@ -2361,6 +2377,143 @@ class TestResolveDeployDefaults:
             entity, SnowflakeAppManager(), app_name="OVERRIDE_NAME"
         )
         assert result["artifact_repository"] == "OVERRIDE_NAME_REPO"
+
+    @patch(MANAGER_CLI_CONSOLE)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
+    )
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    @patch(GET_PERSONAL_DATABASE, return_value="USER$MYUSER")
+    @patch(DATABASE_EXISTS, return_value=False)
+    def test_inaccessible_param_database_falls_back_to_personal_db(
+        self, mock_db_exists, mock_personal, mock_ctx, mock_params, mock_console
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(database=None, schema=None)
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        assert result["database"] == "USER$MYUSER"
+        assert result["schema"] == "PUBLIC"
+        mock_console.warning.assert_called_once()
+        warning = mock_console.warning.call_args[0][0]
+        assert "PARAM_DB" in warning
+        assert "account-admin-setup" in warning
+
+    @patch(MANAGER_CLI_CONSOLE)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
+    )
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    @patch(GET_PERSONAL_DATABASE, return_value="USER$MYUSER")
+    @patch(SCHEMA_EXISTS, return_value=False)
+    @patch(DATABASE_EXISTS, return_value=True)
+    def test_inaccessible_param_schema_falls_back_to_personal_db(
+        self,
+        mock_db_exists,
+        mock_schema_exists,
+        mock_personal,
+        mock_ctx,
+        mock_params,
+        mock_console,
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(database=None, schema=None)
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        # Both the database and schema fall back together so the app does not
+        # land in an inaccessible schema of an otherwise-visible database.
+        assert result["database"] == "USER$MYUSER"
+        assert result["schema"] == "PUBLIC"
+        mock_console.warning.assert_called_once()
+        warning = mock_console.warning.call_args[0][0]
+        assert "PARAM_DB.PARAM_SCHEMA" in warning
+
+
+class TestFilterAccessibleRemoteDefaults:
+    """Direct tests for the account-default access check that protects deploy
+    and setup from targeting a destination the current role cannot use."""
+
+    def _manager(self, *, db_exists=True, schema_exists=True):
+        manager = Mock()
+        manager.database_exists.return_value = db_exists
+        manager.schema_exists.return_value = schema_exists
+        return manager
+
+    def test_no_database_returns_params_unchanged(self):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        params = {"query_warehouse": "WH"}
+        manager = self._manager()
+        assert _filter_accessible_remote_defaults(manager, params) == params
+        manager.database_exists.assert_not_called()
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_accessible_destination_returns_params_unchanged(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        params = {"database": "DB", "schema": "SCH", "query_warehouse": "WH"}
+        result = _filter_accessible_remote_defaults(
+            self._manager(db_exists=True, schema_exists=True), params
+        )
+        assert result == params
+        mock_console.warning.assert_not_called()
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_inaccessible_database_drops_database_and_schema(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        manager = self._manager(db_exists=False)
+        params = {"database": "DB", "schema": "SCH", "query_warehouse": "WH"}
+        result = _filter_accessible_remote_defaults(manager, params)
+        assert result == {"query_warehouse": "WH"}
+        # The schema check is skipped when the database itself is inaccessible.
+        manager.schema_exists.assert_not_called()
+        mock_console.warning.assert_called_once()
+        assert "database 'DB'" in mock_console.warning.call_args[0][0]
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_inaccessible_schema_drops_database_and_schema(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        manager = self._manager(db_exists=True, schema_exists=False)
+        params = {"database": "DB", "schema": "SCH"}
+        result = _filter_accessible_remote_defaults(manager, params)
+        assert result == {}
+        mock_console.warning.assert_called_once()
+        assert "schema 'DB.SCH'" in mock_console.warning.call_args[0][0]
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_check_error_is_treated_as_inaccessible(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        manager = Mock()
+        manager.database_exists.side_effect = ProgrammingError("boom")
+        params = {"database": "DB", "schema": "SCH"}
+        result = _filter_accessible_remote_defaults(manager, params)
+        assert result == {}
+        mock_console.warning.assert_called_once()
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_does_not_mutate_input_params(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        params = {"database": "DB", "schema": "SCH"}
+        _filter_accessible_remote_defaults(self._manager(db_exists=False), params)
+        assert params == {"database": "DB", "schema": "SCH"}
 
 
 # ── CLI command tests ─────────────────────────────────────────────────
@@ -2739,6 +2892,37 @@ class TestSetupCommand:
             "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
+        mock_mgr.get_personal_database.return_value = "USER$MYUSER"
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["database"] == "USER$MYUSER"
+        assert resolved["schema"] == "PUBLIC"
+        assert mock_gen.call_args.kwargs["use_workspace"] is True
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_inaccessible_account_default_falls_back_to_personal_db(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """When the account-configured destination database is not accessible
+        to the current role, setup falls back to the personal database (as if
+        no account default were set) and warns the user."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+        mock_mgr.database_exists.return_value = False
         mock_mgr.get_personal_database.return_value = "USER$MYUSER"
 
         with change_directory(tmp_path):

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2501,7 +2501,7 @@ class TestResolveDeployDefaults:
         mock_console.warning.assert_called_once()
         warning = mock_console.warning.call_args[0][0]
         assert "ENGINEER" in warning
-        assert "CREATE STAGE on SCHEMA PARAM_DB.PARAM_SCHEMA" in warning
+        assert "Snowflake App Runtime" in warning
         assert "PARAM_DB.PARAM_SCHEMA" in warning
         assert "account-admin-setup" in warning
 
@@ -2700,7 +2700,11 @@ class TestFilterAccessibleRemoteDefaults:
         assert result == {"query_warehouse": "WH"}
         mock_console.warning.assert_called_once()
         warning = mock_console.warning.call_args[0][0]
-        assert "CREATE ARTIFACT REPOSITORY on SCHEMA DB.SCH" in warning
+        # The warning names the destination and feature, not the specific grants
+        # (those are only in the verbose INFO logs).
+        assert "Snowflake App Runtime" in warning
+        assert "'DB.SCH'" in warning
+        assert "CREATE ARTIFACT REPOSITORY" not in warning
 
     @patch(MANAGER_CLI_CONSOLE)
     def test_all_probes_error_drops_destination(self, mock_console):
@@ -2713,7 +2717,7 @@ class TestFilterAccessibleRemoteDefaults:
         result = _filter_accessible_remote_defaults(manager, params)
         assert result == {}
         mock_console.warning.assert_called_once()
-        assert "access to database 'DB'" in mock_console.warning.call_args[0][0]
+        assert "'DB.SCH'" in mock_console.warning.call_args[0][0]
 
     @patch(MANAGER_CLI_CONSOLE)
     def test_any_probe_error_drops_destination(self, mock_console):
@@ -2733,7 +2737,7 @@ class TestFilterAccessibleRemoteDefaults:
         result = _filter_accessible_remote_defaults(manager, params)
         assert result == {}
         mock_console.warning.assert_called_once()
-        assert "access to database 'DB'" in mock_console.warning.call_args[0][0]
+        assert "'DB.SCH'" in mock_console.warning.call_args[0][0]
 
     @patch(MANAGER_CLI_CONSOLE)
     def test_missing_schema_defaults_to_public(self, mock_console):
@@ -3068,7 +3072,7 @@ class TestSetupCommand:
     )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_flags_beat_parameters(self, mock_mgr_cls, mock_gen, runner, tmp_path):
-        """CLI flags should override SnowApps parameters."""
+        """CLI flags should override Snowflake App Runtime parameters."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
@@ -3113,7 +3117,7 @@ class TestSetupCommand:
     def test_setup_shows_parameter_provenance(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
-        """Resolved values from SnowApps parameters should show 'account parameter' provenance."""
+        """Resolved values from Snowflake App Runtime parameters should show 'account parameter' provenance."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -52,10 +52,10 @@ FETCH_SNOW_APPS_PARAMS = (
     "snowflake.cli._plugins.apps.manager.SnowflakeAppManager"
     ".fetch_snow_apps_parameters"
 )
-DATABASE_EXISTS = (
-    "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.database_exists"
+CURRENT_ROLE = "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.current_role"
+GET_MISSING_PRIVILEGES = (
+    "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.get_missing_privileges"
 )
-SCHEMA_EXISTS = "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.schema_exists"
 GET_PERSONAL_DATABASE = (
     "snowflake.cli._plugins.apps.manager.SnowflakeAppManager.get_personal_database"
 )
@@ -883,6 +883,97 @@ class TestSchemaExists:
         mock_execute.return_value = cursor
 
         assert SnowflakeAppManager().schema_exists("MY_DB", "NO_SUCH") is False
+
+
+class TestCurrentRole:
+    @patch(EXECUTE_QUERY)
+    def test_returns_role(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ("ENGINEER",)
+        mock_execute.return_value = cursor
+
+        assert SnowflakeAppManager().current_role() == "ENGINEER"
+        assert mock_execute.call_args[0][0] == "SELECT CURRENT_ROLE()"
+
+    @patch(EXECUTE_QUERY)
+    def test_returns_none_when_unset(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = (None,)
+        mock_execute.return_value = cursor
+
+        assert SnowflakeAppManager().current_role() is None
+
+    @patch(EXECUTE_QUERY, side_effect=ProgrammingError("boom"))
+    def test_returns_none_on_error(self, mock_execute):
+        assert SnowflakeAppManager().current_role() is None
+
+
+class TestGetMissingPrivileges:
+    @patch(EXECUTE_QUERY)
+    def test_authorized_returns_empty(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ('{"authorized": true}',)
+        mock_execute.return_value = cursor
+
+        result = SnowflakeAppManager().get_missing_privileges(
+            "CREATE STAGE APPS.PUBLIC.x", "ENGINEER"
+        )
+        assert result == []
+        query = mock_execute.call_args[0][0]
+        assert "CALL EXPLAIN_PRIVILEGES(" in query
+        assert "statement => 'CREATE STAGE APPS.PUBLIC.x'" in query
+        assert "missing_only => true" in query
+        assert "for_role => 'ENGINEER'" in query
+
+    @patch(EXECUTE_QUERY)
+    def test_returns_flattened_missing_nodes(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = (
+            '{"allOf": [{"privilege": "USAGE", "objectType": "DATABASE", '
+            '"objectName": "APPS"}]}',
+        )
+        mock_execute.return_value = cursor
+
+        result = SnowflakeAppManager().get_missing_privileges(
+            "CREATE STAGE APPS.PUBLIC.x", "ENGINEER"
+        )
+        assert result == [
+            {"privilege": "USAGE", "objectType": "DATABASE", "objectName": "APPS"}
+        ]
+
+    @patch(EXECUTE_QUERY)
+    def test_omits_for_role_when_role_is_none(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ('{"authorized": true}',)
+        mock_execute.return_value = cursor
+
+        SnowflakeAppManager().get_missing_privileges("CREATE STAGE APPS.PUBLIC.x")
+        query = mock_execute.call_args[0][0]
+        assert "for_role" not in query
+
+    @patch(EXECUTE_QUERY)
+    def test_escapes_statement(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = ('{"authorized": true}',)
+        mock_execute.return_value = cursor
+
+        SnowflakeAppManager().get_missing_privileges(
+            'CREATE STAGE "USER$x".PUBLIC.y', "ENGINEER"
+        )
+        query = mock_execute.call_args[0][0]
+        # Quoted personal-database identifiers survive inside the SQL literal.
+        assert '"USER$x".PUBLIC.y' in query
+
+    @patch(EXECUTE_QUERY)
+    def test_empty_response_returns_empty(self, mock_execute):
+        cursor = Mock()
+        cursor.fetchone.return_value = None
+        mock_execute.return_value = cursor
+
+        assert (
+            SnowflakeAppManager().get_missing_privileges("CREATE STAGE A.B.C", "R")
+            == []
+        )
 
 
 class TestAppFqn:
@@ -2259,11 +2350,9 @@ class TestResolveDeployDefaults:
         },
     )
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    @patch(SCHEMA_EXISTS, return_value=True)
-    @patch(DATABASE_EXISTS, return_value=True)
-    def test_parameters_fill_gaps(
-        self, mock_db_exists, mock_schema_exists, mock_ctx, mock_params
-    ):
+    @patch(GET_MISSING_PRIVILEGES, return_value=[])
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    def test_parameters_fill_gaps(self, mock_role, mock_missing, mock_ctx, mock_params):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(database=None, schema=None)
@@ -2324,11 +2413,9 @@ class TestResolveDeployDefaults:
         GET_CLI_CONTEXT,
         return_value=_mock_connection_context(warehouse="CONN_WH"),
     )
-    @patch(SCHEMA_EXISTS, return_value=True)
-    @patch(DATABASE_EXISTS, return_value=True)
-    def test_params_beat_session(
-        self, mock_db_exists, mock_schema_exists, mock_ctx, mock_params
-    ):
+    @patch(GET_MISSING_PRIVILEGES, return_value=[])
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    def test_params_beat_session(self, mock_role, mock_missing, mock_ctx, mock_params):
         from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
 
         entity = self._make_entity(database=None, schema=None)
@@ -2385,34 +2472,21 @@ class TestResolveDeployDefaults:
     )
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
     @patch(GET_PERSONAL_DATABASE, return_value="USER$MYUSER")
-    @patch(DATABASE_EXISTS, return_value=False)
-    def test_inaccessible_param_database_falls_back_to_personal_db(
-        self, mock_db_exists, mock_personal, mock_ctx, mock_params, mock_console
-    ):
-        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
-
-        entity = self._make_entity(database=None, schema=None)
-        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
-        assert result["database"] == "USER$MYUSER"
-        assert result["schema"] == "PUBLIC"
-        mock_console.warning.assert_called_once()
-        warning = mock_console.warning.call_args[0][0]
-        assert "PARAM_DB" in warning
-        assert "account-admin-setup" in warning
-
-    @patch(MANAGER_CLI_CONSOLE)
     @patch(
-        FETCH_SNOW_APPS_PARAMS,
-        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
+        GET_MISSING_PRIVILEGES,
+        return_value=[
+            {
+                "privilege": "CREATE STAGE",
+                "objectType": "SCHEMA",
+                "objectName": "PARAM_DB.PARAM_SCHEMA",
+            }
+        ],
     )
-    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
-    @patch(GET_PERSONAL_DATABASE, return_value="USER$MYUSER")
-    @patch(SCHEMA_EXISTS, return_value=False)
-    @patch(DATABASE_EXISTS, return_value=True)
-    def test_inaccessible_param_schema_falls_back_to_personal_db(
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    def test_missing_privileges_fall_back_to_personal_db(
         self,
-        mock_db_exists,
-        mock_schema_exists,
+        mock_role,
+        mock_missing,
         mock_personal,
         mock_ctx,
         mock_params,
@@ -2422,23 +2496,121 @@ class TestResolveDeployDefaults:
 
         entity = self._make_entity(database=None, schema=None)
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
-        # Both the database and schema fall back together so the app does not
-        # land in an inaccessible schema of an otherwise-visible database.
         assert result["database"] == "USER$MYUSER"
         assert result["schema"] == "PUBLIC"
         mock_console.warning.assert_called_once()
         warning = mock_console.warning.call_args[0][0]
+        assert "ENGINEER" in warning
+        assert "CREATE STAGE on SCHEMA PARAM_DB.PARAM_SCHEMA" in warning
         assert "PARAM_DB.PARAM_SCHEMA" in warning
+        assert "account-admin-setup" in warning
+
+    @patch(MANAGER_CLI_CONSOLE)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
+    )
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    @patch(GET_PERSONAL_DATABASE, return_value="USER$MYUSER")
+    @patch(GET_MISSING_PRIVILEGES, side_effect=ProgrammingError("cannot resolve"))
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    def test_unresolvable_destination_falls_back_to_personal_db(
+        self,
+        mock_role,
+        mock_missing,
+        mock_personal,
+        mock_ctx,
+        mock_params,
+        mock_console,
+    ):
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(database=None, schema=None)
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        # Every probe statement errored, so the destination cannot be resolved
+        # by the current role and we fall back to the personal database.
+        assert result["database"] == "USER$MYUSER"
+        assert result["schema"] == "PUBLIC"
+        mock_console.warning.assert_called_once()
+        assert "PARAM_DB" in mock_console.warning.call_args[0][0]
+
+
+class TestFlattenMissingPrivileges:
+    def test_authorized_returns_empty(self):
+        from snowflake.cli._plugins.apps.manager import _flatten_missing_privileges
+
+        assert _flatten_missing_privileges({"authorized": True}) == []
+
+    def test_single_permission_node(self):
+        from snowflake.cli._plugins.apps.manager import _flatten_missing_privileges
+
+        node = {"privilege": "USAGE", "objectType": "DATABASE", "objectName": "DB"}
+        assert _flatten_missing_privileges(node) == [node]
+
+    def test_nested_all_of_and_one_of(self):
+        from snowflake.cli._plugins.apps.manager import _flatten_missing_privileges
+
+        tree = {
+            "allOf": [
+                {"privilege": "USAGE", "objectType": "DATABASE", "objectName": "DB"},
+                {
+                    "oneOf": [
+                        {
+                            "privilege": "CREATE STAGE",
+                            "objectType": "SCHEMA",
+                            "objectName": "DB.SCH",
+                        }
+                    ]
+                },
+            ]
+        }
+        result = _flatten_missing_privileges(tree)
+        assert {n["privilege"] for n in result} == {"USAGE", "CREATE STAGE"}
+
+    def test_non_dict_returns_empty(self):
+        from snowflake.cli._plugins.apps.manager import _flatten_missing_privileges
+
+        assert _flatten_missing_privileges(None) == []
+        assert _flatten_missing_privileges("nope") == []
+
+
+class TestDeployPrivilegeCheckStatements:
+    def test_statements_reference_destination(self):
+        from snowflake.cli._plugins.apps.manager import (
+            PRIVILEGE_CHECK_OBJECT_NAME,
+            _deploy_privilege_check_statements,
+        )
+
+        statements = _deploy_privilege_check_statements("APPS", "PUBLIC")
+        assert any(s.startswith("CREATE STAGE APPS.PUBLIC.") for s in statements)
+        assert any("CREATE ARTIFACT REPOSITORY APPS.PUBLIC." in s for s in statements)
+        assert any("CREATE APPLICATION SERVICE APPS.PUBLIC." in s for s in statements)
+        assert all(PRIVILEGE_CHECK_OBJECT_NAME in s for s in statements)
+
+    def test_personal_database_is_quoted(self):
+        from snowflake.cli._plugins.apps.manager import (
+            _deploy_privilege_check_statements,
+        )
+
+        statements = _deploy_privilege_check_statements(
+            "USER$first.last@snowflake.com", "PUBLIC"
+        )
+        # Personal database names contain characters illegal in unquoted
+        # identifiers and must be quoted so EXPLAIN_PRIVILEGES can parse them.
+        assert all('"USER$first.last@snowflake.com".PUBLIC.' in s for s in statements)
 
 
 class TestFilterAccessibleRemoteDefaults:
-    """Direct tests for the account-default access check that protects deploy
+    """Direct tests for the account-default privilege check that protects deploy
     and setup from targeting a destination the current role cannot use."""
 
-    def _manager(self, *, db_exists=True, schema_exists=True):
+    def _manager(self, *, role="ENGINEER", missing=None, side_effect=None):
         manager = Mock()
-        manager.database_exists.return_value = db_exists
-        manager.schema_exists.return_value = schema_exists
+        manager.current_role.return_value = role
+        if side_effect is not None:
+            manager.get_missing_privileges.side_effect = side_effect
+        else:
+            manager.get_missing_privileges.return_value = missing or []
         return manager
 
     def test_no_database_returns_params_unchanged(self):
@@ -2449,61 +2621,93 @@ class TestFilterAccessibleRemoteDefaults:
         params = {"query_warehouse": "WH"}
         manager = self._manager()
         assert _filter_accessible_remote_defaults(manager, params) == params
-        manager.database_exists.assert_not_called()
+        manager.get_missing_privileges.assert_not_called()
 
     @patch(MANAGER_CLI_CONSOLE)
-    def test_accessible_destination_returns_params_unchanged(self, mock_console):
+    def test_no_missing_privileges_returns_params_unchanged(self, mock_console):
         from snowflake.cli._plugins.apps.manager import (
             _filter_accessible_remote_defaults,
         )
 
         params = {"database": "DB", "schema": "SCH", "query_warehouse": "WH"}
-        result = _filter_accessible_remote_defaults(
-            self._manager(db_exists=True, schema_exists=True), params
+        manager = self._manager(missing=[])
+        result = _filter_accessible_remote_defaults(manager, params)
+        assert result == params
+        mock_console.warning.assert_not_called()
+        # Every representative deploy statement is probed for the active role.
+        assert manager.get_missing_privileges.call_count == 3
+        for call in manager.get_missing_privileges.call_args_list:
+            assert call.args[1] == "ENGINEER"
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_missing_privileges_drops_destination(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
         )
+
+        manager = self._manager(
+            missing=[
+                {
+                    "privilege": "CREATE ARTIFACT REPOSITORY",
+                    "objectType": "SCHEMA",
+                    "objectName": "DB.SCH",
+                }
+            ]
+        )
+        params = {"database": "DB", "schema": "SCH", "query_warehouse": "WH"}
+        result = _filter_accessible_remote_defaults(manager, params)
+        assert result == {"query_warehouse": "WH"}
+        mock_console.warning.assert_called_once()
+        warning = mock_console.warning.call_args[0][0]
+        assert "CREATE ARTIFACT REPOSITORY on SCHEMA DB.SCH" in warning
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_all_probes_error_drops_destination(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        manager = self._manager(side_effect=ProgrammingError("cannot resolve"))
+        params = {"database": "DB", "schema": "SCH"}
+        result = _filter_accessible_remote_defaults(manager, params)
+        assert result == {}
+        mock_console.warning.assert_called_once()
+        assert "access to database 'DB'" in mock_console.warning.call_args[0][0]
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_partial_probe_errors_do_not_drop_destination(self, mock_console):
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        # First statement errors (e.g. unsupported), the rest report no missing
+        # privileges; an analysis error alone must not divert a user with access.
+        manager = Mock()
+        manager.current_role.return_value = "ENGINEER"
+        manager.get_missing_privileges.side_effect = [
+            ProgrammingError("unsupported"),
+            [],
+            [],
+        ]
+        params = {"database": "DB", "schema": "SCH"}
+        result = _filter_accessible_remote_defaults(manager, params)
         assert result == params
         mock_console.warning.assert_not_called()
 
     @patch(MANAGER_CLI_CONSOLE)
-    def test_inaccessible_database_drops_database_and_schema(self, mock_console):
+    def test_missing_schema_defaults_to_public(self, mock_console):
         from snowflake.cli._plugins.apps.manager import (
+            _deploy_privilege_check_statements,
             _filter_accessible_remote_defaults,
         )
 
-        manager = self._manager(db_exists=False)
-        params = {"database": "DB", "schema": "SCH", "query_warehouse": "WH"}
-        result = _filter_accessible_remote_defaults(manager, params)
-        assert result == {"query_warehouse": "WH"}
-        # The schema check is skipped when the database itself is inaccessible.
-        manager.schema_exists.assert_not_called()
-        mock_console.warning.assert_called_once()
-        assert "database 'DB'" in mock_console.warning.call_args[0][0]
-
-    @patch(MANAGER_CLI_CONSOLE)
-    def test_inaccessible_schema_drops_database_and_schema(self, mock_console):
-        from snowflake.cli._plugins.apps.manager import (
-            _filter_accessible_remote_defaults,
-        )
-
-        manager = self._manager(db_exists=True, schema_exists=False)
-        params = {"database": "DB", "schema": "SCH"}
-        result = _filter_accessible_remote_defaults(manager, params)
-        assert result == {}
-        mock_console.warning.assert_called_once()
-        assert "schema 'DB.SCH'" in mock_console.warning.call_args[0][0]
-
-    @patch(MANAGER_CLI_CONSOLE)
-    def test_check_error_is_treated_as_inaccessible(self, mock_console):
-        from snowflake.cli._plugins.apps.manager import (
-            _filter_accessible_remote_defaults,
-        )
-
-        manager = Mock()
-        manager.database_exists.side_effect = ProgrammingError("boom")
-        params = {"database": "DB", "schema": "SCH"}
-        result = _filter_accessible_remote_defaults(manager, params)
-        assert result == {}
-        mock_console.warning.assert_called_once()
+        manager = self._manager(missing=[])
+        params = {"database": "DB"}
+        _filter_accessible_remote_defaults(manager, params)
+        probed = manager.get_missing_privileges.call_args_list[0].args[0]
+        assert "DB.PUBLIC." in probed
+        # Sanity check the statement set is the deploy set.
+        assert probed in _deploy_privilege_check_statements("DB", "PUBLIC")
 
     @patch(MANAGER_CLI_CONSOLE)
     def test_does_not_mutate_input_params(self, mock_console):
@@ -2512,7 +2716,8 @@ class TestFilterAccessibleRemoteDefaults:
         )
 
         params = {"database": "DB", "schema": "SCH"}
-        _filter_accessible_remote_defaults(self._manager(db_exists=False), params)
+        manager = self._manager(side_effect=ProgrammingError("cannot resolve"))
+        _filter_accessible_remote_defaults(manager, params)
         assert params == {"database": "DB", "schema": "SCH"}
 
 
@@ -2911,9 +3116,9 @@ class TestSetupCommand:
     def test_inaccessible_account_default_falls_back_to_personal_db(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
-        """When the account-configured destination database is not accessible
-        to the current role, setup falls back to the personal database (as if
-        no account default were set) and warns the user."""
+        """When the current role is missing privileges on the account-configured
+        destination, setup falls back to the personal database (as if no account
+        default were set) and warns the user."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
@@ -2922,7 +3127,14 @@ class TestSetupCommand:
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
         }
-        mock_mgr.database_exists.return_value = False
+        mock_mgr.current_role.return_value = "ENGINEER"
+        mock_mgr.get_missing_privileges.return_value = [
+            {
+                "privilege": "CREATE STAGE",
+                "objectType": "SCHEMA",
+                "objectName": "PARAM_DB.PARAM_SCHEMA",
+            }
+        ]
         mock_mgr.get_personal_database.return_value = "USER$MYUSER"
 
         with change_directory(tmp_path):

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2582,10 +2582,18 @@ class TestDeployPrivilegeCheckStatements:
         )
 
         statements = _deploy_privilege_check_statements("APPS", "PUBLIC")
+        # Exactly two statements are probed: CREATE STAGE and CREATE ARTIFACT
+        # REPOSITORY, both referencing only the destination database/schema.
+        assert len(statements) == 2
         assert any(s.startswith("CREATE STAGE APPS.PUBLIC.") for s in statements)
         assert any("CREATE ARTIFACT REPOSITORY APPS.PUBLIC." in s for s in statements)
-        assert any("CREATE APPLICATION SERVICE APPS.PUBLIC." in s for s in statements)
         assert all(PRIVILEGE_CHECK_OBJECT_NAME in s for s in statements)
+        # Statements that reference not-yet-existing objects, only need USAGE, or
+        # belong to the workspace flow are intentionally excluded.
+        joined = " ".join(statements)
+        assert "CREATE APPLICATION SERVICE" not in joined
+        assert "CREATE WORKSPACE" not in joined
+        assert "SHOW" not in joined
 
     def test_personal_database_is_quoted(self):
         from snowflake.cli._plugins.apps.manager import (
@@ -2634,10 +2642,43 @@ class TestFilterAccessibleRemoteDefaults:
         result = _filter_accessible_remote_defaults(manager, params)
         assert result == params
         mock_console.warning.assert_not_called()
+        # A step message announces the privilege-check phase to the user.
+        mock_console.step.assert_called_once()
+        assert "Checking deploy privileges" in mock_console.step.call_args[0][0]
+        assert "DB.SCH" in mock_console.step.call_args[0][0]
         # Every representative deploy statement is probed for the active role.
-        assert manager.get_missing_privileges.call_count == 3
+        assert manager.get_missing_privileges.call_count == 2
         for call in manager.get_missing_privileges.call_args_list:
             assert call.args[1] == "ENGINEER"
+
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_verbose_logs_per_statement_and_summary(self, mock_console, caplog):
+        import logging
+
+        from snowflake.cli._plugins.apps.manager import (
+            _filter_accessible_remote_defaults,
+        )
+
+        manager = self._manager(
+            missing=[
+                {
+                    "privilege": "CREATE STAGE",
+                    "objectType": "SCHEMA",
+                    "objectName": "DB.SCH",
+                }
+            ]
+        )
+        params = {"database": "DB", "schema": "SCH"}
+        with caplog.at_level(
+            logging.INFO, logger="snowflake.cli._plugins.apps.manager"
+        ):
+            _filter_accessible_remote_defaults(manager, params)
+        messages = "\n".join(r.getMessage() for r in caplog.records)
+        # Per-statement results and a final summary are emitted at INFO so they
+        # surface under --verbose.
+        assert "Privilege check: missing" in messages
+        assert "Privilege check failed" in messages
+        assert "CREATE STAGE on SCHEMA DB.SCH" in messages
 
     @patch(MANAGER_CLI_CONSOLE)
     def test_missing_privileges_drops_destination(self, mock_console):
@@ -2675,24 +2716,24 @@ class TestFilterAccessibleRemoteDefaults:
         assert "access to database 'DB'" in mock_console.warning.call_args[0][0]
 
     @patch(MANAGER_CLI_CONSOLE)
-    def test_partial_probe_errors_do_not_drop_destination(self, mock_console):
+    def test_any_probe_error_drops_destination(self, mock_console):
         from snowflake.cli._plugins.apps.manager import (
             _filter_accessible_remote_defaults,
         )
 
-        # First statement errors (e.g. unsupported), the rest report no missing
-        # privileges; an analysis error alone must not divert a user with access.
+        # A probe error means the role cannot analyze/resolve the destination,
+        # so the check fails even if another statement reports no missing grants.
         manager = Mock()
         manager.current_role.return_value = "ENGINEER"
         manager.get_missing_privileges.side_effect = [
-            ProgrammingError("unsupported"),
-            [],
+            ProgrammingError("requires access on all objects"),
             [],
         ]
         params = {"database": "DB", "schema": "SCH"}
         result = _filter_accessible_remote_defaults(manager, params)
-        assert result == params
-        mock_console.warning.assert_not_called()
+        assert result == {}
+        mock_console.warning.assert_called_once()
+        assert "access to database 'DB'" in mock_console.warning.call_args[0][0]
 
     @patch(MANAGER_CLI_CONSOLE)
     def test_missing_schema_defaults_to_public(self, mock_console):
@@ -2725,6 +2766,19 @@ class TestFilterAccessibleRemoteDefaults:
 
 
 class TestSetupCommand:
+    @pytest.fixture(autouse=True)
+    def _assume_destination_accessible(self):
+        """Resolution/precedence tests assume the active role can access the
+        account-configured destination. The privilege probe itself is covered by
+        ``TestFilterAccessibleRemoteDefaults`` and ``TestSetupPrivilegeFallback``,
+        so patch it to a pass-through here to keep these tests focused.
+        """
+        with patch(
+            "snowflake.cli._plugins.apps.commands._filter_accessible_remote_defaults",
+            side_effect=lambda manager, params: params,
+        ):
+            yield
+
     @patch(
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
         return_value="definition_version: '2'\n",
@@ -3112,44 +3166,6 @@ class TestSetupCommand:
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
         return_value="definition_version: '2'\n",
     )
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_inaccessible_account_default_falls_back_to_personal_db(
-        self, mock_mgr_cls, mock_gen, runner, tmp_path
-    ):
-        """When the current role is missing privileges on the account-configured
-        destination, setup falls back to the personal database (as if no account
-        default were set) and warns the user."""
-        mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
-        mock_mgr.fetch_snow_apps_parameters.return_value = {
-            "database": "PARAM_DB",
-            "schema": "PARAM_SCHEMA",
-            "query_warehouse": "PARAM_WH",
-        }
-        mock_mgr.current_role.return_value = "ENGINEER"
-        mock_mgr.get_missing_privileges.return_value = [
-            {
-                "privilege": "CREATE STAGE",
-                "objectType": "SCHEMA",
-                "objectName": "PARAM_DB.PARAM_SCHEMA",
-            }
-        ]
-        mock_mgr.get_personal_database.return_value = "USER$MYUSER"
-
-        with change_directory(tmp_path):
-            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
-            assert result.exit_code == 0, result.output
-
-        resolved = mock_gen.call_args[0][1]
-        assert resolved["database"] == "USER$MYUSER"
-        assert resolved["schema"] == "PUBLIC"
-        assert mock_gen.call_args.kwargs["use_workspace"] is True
-
-    @patch(
-        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
-        return_value="definition_version: '2'\n",
-    )
     @patch("snowflake.cli._plugins.apps.commands.get_connection_dict")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_setup_uses_stage_when_database_resolved_from_session(
@@ -3265,6 +3281,78 @@ class TestSetupCommand:
 
 
 # ── perform_bundle tests ──────────────────────────────────────────────
+
+
+class TestSetupPrivilegeFallback:
+    """End-to-end ``snow app setup`` coverage that exercises the real privilege
+    probe (no pass-through patch) and asserts the personal-database fallback."""
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_missing_privileges_fall_back_to_personal_db(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """When the current role is missing privileges on the account-configured
+        destination, setup falls back to the personal database (as if no account
+        default were set) and warns the user."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+        mock_mgr.current_role.return_value = "ENGINEER"
+        mock_mgr.get_missing_privileges.return_value = [
+            {
+                "privilege": "CREATE STAGE",
+                "objectType": "SCHEMA",
+                "objectName": "PARAM_DB.PARAM_SCHEMA",
+            }
+        ]
+        mock_mgr.get_personal_database.return_value = "USER$MYUSER"
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["database"] == "USER$MYUSER"
+        assert resolved["schema"] == "PUBLIC"
+        assert mock_gen.call_args.kwargs["use_workspace"] is True
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_accessible_destination_is_used(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """When the role has the privileges (no missing), the account-configured
+        destination is used as-is."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+        mock_mgr.current_role.return_value = "ENGINEER"
+        mock_mgr.get_missing_privileges.return_value = []
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["database"] == "PARAM_DB"
+        assert resolved["schema"] == "PARAM_SCHEMA"
 
 
 class TestPerformBundle:


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description

`snow app setup` and `snow app deploy` resolve the deploy destination from the
account-configured Snowflake App Runtime defaults
(`DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE` /
`DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA`).

The current role may not have the
privileges to deploy there, which previously surfaced as an opaque failure late
in the deploy.

This PR verifies the destination is usable up front and falls
back to the user's personal database when it isn't.
