### PR TITLE
Snowflake Apps: remove unused snowflake-app entity model fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /src/snowflake/cli/_plugins/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 /tests/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 /tests_integration/apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
+/tests_integration/test_data/projects/snowflake_apps/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 /tests/__snapshots__/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 /tests_integration/__snapshots__/ @snowflakedb/snowcli @snowflakedb/client-side-interfaces @snowflakedb/native-apps
 

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from textwrap import dedent
 from typing import Dict, Optional
 
 from snowflake.cli._plugins.apps.manager import DEFAULT_PERSONAL_WORKSPACE_NAME
-
-log = logging.getLogger(__name__)
 
 
 def _generate_snowflake_yml(
@@ -52,13 +49,6 @@ def _generate_snowflake_yml(
     Otherwise the generator emits ``code_stage`` as a bare stage name
     resolved against the app's database and schema at deploy time.
     """
-
-    if resolved.get("image_repository"):
-        log.warning(
-            "image_repository is configured but is no longer included in "
-            "generated snowflake.yml. The CLI defaults to <app-id>_REPO at "
-            "deploy time. You can remove the image_repository setting."
-        )
 
     database = resolved["database"]
     schema = resolved["schema"]

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Literal, Optional, Union
-
-# Default port exposed by Snowflake App Runtime services
-DEFAULT_APP_PORT = 3000
+from typing import Literal, Optional, Union
 
 from pydantic import Field, field_validator, model_validator
 from snowflake.cli.api.project.schemas.entities.common import (
@@ -68,18 +65,6 @@ class ArtifactRepositoryReference(UpdatableModel):
     )
     database: Optional[str] = IdentifierField(
         title="Database of the artifact repository", default=None
-    )
-
-
-class ImageRepositoryReference(UpdatableModel):
-    """Reference to an image repository used for container image storage."""
-
-    name: str = IdentifierField(title="Name of the image repository")
-    schema_: Optional[str] = IdentifierField(
-        title="Schema of the image repository", alias="schema", default=None
-    )
-    database: Optional[str] = IdentifierField(
-        title="Database of the image repository", default=None
     )
 
 
@@ -160,24 +145,16 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
         title="External access integration for build", default=None
     )
 
-    service_eai: Union[ExternalAccessReference, None] = Field(
-        title="External access integration for service", default=None
-    )
-
-    @field_validator("build_eai", "service_eai", mode="before")
+    @field_validator("build_eai", mode="before")
     @classmethod
     def _validate_eai(cls, value):
-        """Allow null/None values for EAI fields."""
+        """Allow null/None values for the EAI field."""
         if value is None or value == "null":
             return None
         return value
 
     artifact_repository: Optional[ArtifactRepositoryReference] = Field(
         title="Artifact repository for the app", default=None
-    )
-
-    image_repository: Optional[ImageRepositoryReference] = Field(
-        title="Image repository for container images", default=None
     )
 
     code_stage: Optional[CodeStageReference] = Field(
@@ -218,8 +195,6 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
             raise ValueError("Specify either code_stage or code_workspace, not both.")
         return self
 
-    app_port: int = Field(title="Port the app listens on", default=DEFAULT_APP_PORT)
-
     runtime_image: str = Field(
         title="Runtime image used by SPCS artifact repo build/run",
         default="",
@@ -238,37 +213,3 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
         if not isinstance(value, str):
             raise ValueError("spcs_test_project_type must be a string or null")
         return value.strip()
-
-    build_image: Optional[str] = Field(
-        title="Custom container image for building the app",
-        default=None,
-    )
-
-    @field_validator("build_image", mode="before")
-    @classmethod
-    def _validate_build_image(cls, value):
-        if value is None:
-            return None
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError("build_image must be a non-empty string")
-        value = value.strip()
-        import re
-
-        if re.search(r"\s", value):
-            raise ValueError(f"build_image must not contain whitespace, got: {value!r}")
-        _unsafe_chars = {"$", '"'}
-        found = _unsafe_chars.intersection(value)
-        if found:
-            raise ValueError(
-                f"build_image contains unsafe character(s) {found}, got: {value!r}"
-            )
-        return value
-
-    execute_as_caller: bool = Field(
-        title="Whether the service runs with caller privileges",
-        default=True,
-    )
-
-    dev_roles: Optional[List[str]] = Field(
-        title="Development roles for the app", default=None
-    )

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -612,7 +612,6 @@ class TestGenerateSnowflakeYml:
         # code_workspace is a shared workspace, fully-qualified.
         assert "code_workspace: TEST_DB.SNOW_APPS.SNOWFLAKE_APPS" in result
         assert "code_stage:" not in result
-        assert "image_repository" not in result
         assert "artifact_repository" not in result
 
     def test_generates_yml_with_code_stage_when_not_using_workspace(self):
@@ -3492,9 +3491,8 @@ class TestBundleCommand:
 
 class TestValidateCommand:
     @staticmethod
-    def _make_validate_entity(app_port=3000):
+    def _make_validate_entity():
         entity = Mock()
-        entity.app_port = app_port
         entity.fqn = Mock(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP")
         return entity
 
@@ -4792,8 +4790,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
@@ -4932,8 +4928,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
@@ -5033,8 +5027,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
@@ -5133,8 +5125,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
@@ -5230,8 +5220,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
@@ -5743,8 +5731,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = Mock()
         entity.build_compute_pool.name = "YML_BUILD_POOL"
@@ -5848,8 +5834,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = None
         entity.service_compute_pool = None
@@ -5952,8 +5936,6 @@ class TestDeployCommand:
         entity.meta = None
         entity.runtime_image = "runtime:latest"
         entity.query_warehouse = "WH"
-        entity.build_image = None
-        entity.execute_as_caller = False
         entity.artifact_repository = None
         entity.build_compute_pool = Mock()
         entity.build_compute_pool.name = "YML_BUILD_POOL"

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -37,14 +37,10 @@ class TestSnowflakeAppEntityModel:
         assert model.build_compute_pool is None
         assert model.service_compute_pool is None
         assert model.build_eai is None
-        assert model.service_eai is None
         assert model.artifact_repository is None
         assert model.code_stage is None
         assert model.meta is None
-        assert model.build_image is None
         assert model.spcs_test_project_type is None
-        assert model.execute_as_caller is True
-        assert model.dev_roles is None
 
     def test_full_model(self):
         """Model can be created with all fields."""
@@ -68,11 +64,6 @@ class TestSnowflakeAppEntityModel:
                 "schema": "MY_SCHEMA",
                 "database": "MY_DB",
             },
-            service_eai={
-                "name": "SERVICE_EAI",
-                "schema": "MY_SCHEMA",
-                "database": "MY_DB",
-            },
             artifact_repository={
                 "name": "ARTIFACT_REPO",
                 "schema": "MY_SCHEMA",
@@ -80,9 +71,6 @@ class TestSnowflakeAppEntityModel:
             },
             code_stage={"name": "MY_STAGE", "encryption_type": "SNOWFLAKE_SSE"},
             meta={"title": "My App", "description": "A test app", "icon": "icon.png"},
-            build_image="/custom/builder:1.0",
-            execute_as_caller=True,
-            dev_roles=["DEV_ROLE_1", "DEV_ROLE_2"],
         )
         assert model.query_warehouse == "TEST_WH"
         assert model.build_compute_pool.name == "BUILD_POOL"
@@ -94,9 +82,6 @@ class TestSnowflakeAppEntityModel:
         assert model.build_eai.name == "BUILD_EAI"
         assert model.build_eai.schema_ == "MY_SCHEMA"
         assert model.build_eai.database == "MY_DB"
-        assert model.service_eai.name == "SERVICE_EAI"
-        assert model.service_eai.schema_ == "MY_SCHEMA"
-        assert model.service_eai.database == "MY_DB"
         assert model.artifact_repository.name == "ARTIFACT_REPO"
         assert model.artifact_repository.schema_ == "MY_SCHEMA"
         assert model.artifact_repository.database == "MY_DB"
@@ -105,9 +90,6 @@ class TestSnowflakeAppEntityModel:
         assert model.meta.title == "My App"
         assert model.meta.description == "A test app"
         assert model.meta.icon == "icon.png"
-        assert model.build_image == "/custom/builder:1.0"
-        assert model.execute_as_caller is True
-        assert model.dev_roles == ["DEV_ROLE_1", "DEV_ROLE_2"]
 
     @pytest.mark.parametrize("value", [None, "null"])
     def test_compute_pool_validator_none_values(self, value):
@@ -140,10 +122,8 @@ class TestSnowflakeAppEntityModel:
             identifier="my_app",
             artifacts=["app/*"],
             build_eai=value,
-            service_eai=value,
         )
         assert model.build_eai is None
-        assert model.service_eai is None
 
     def test_eai_validator_dict_value(self):
         """EAI validator passes through dict values."""
@@ -231,95 +211,6 @@ class TestSnowflakeAppEntityModel:
         assert model.meta.description is None
         assert model.meta.icon is None
 
-    def test_build_image_defaults_to_none(self):
-        model = SnowflakeAppEntityModel(
-            type="snowflake-app",
-            identifier="my_app",
-            artifacts=["app/*"],
-        )
-        assert model.build_image is None
-
-    def test_build_image_accepts_valid_image(self):
-        model = SnowflakeAppEntityModel(
-            type="snowflake-app",
-            identifier="my_app",
-            artifacts=["app/*"],
-            build_image="/my/custom/builder:2.0",
-        )
-        assert model.build_image == "/my/custom/builder:2.0"
-
-    def test_build_image_strips_whitespace(self):
-        model = SnowflakeAppEntityModel(
-            type="snowflake-app",
-            identifier="my_app",
-            artifacts=["app/*"],
-            build_image="  /my/custom/builder:2.0  ",
-        )
-        assert model.build_image == "/my/custom/builder:2.0"
-
-    def test_build_image_rejects_empty_string(self):
-        with pytest.raises(ValueError, match="non-empty string"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image="",
-            )
-
-    def test_build_image_rejects_whitespace_only(self):
-        with pytest.raises(ValueError, match="non-empty string"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image="   ",
-            )
-
-    def test_build_image_rejects_internal_whitespace(self):
-        with pytest.raises(ValueError, match="must not contain whitespace"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image="/my image:latest",
-            )
-
-    def test_build_image_rejects_newline(self):
-        with pytest.raises(ValueError, match="must not contain whitespace"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image="/my/image:latest\n/other",
-            )
-
-    def test_build_image_rejects_carriage_return(self):
-        with pytest.raises(ValueError, match="must not contain whitespace"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image="/my/image\r:latest",
-            )
-
-    def test_build_image_rejects_dollar_sign(self):
-        with pytest.raises(ValueError, match="unsafe character"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image="/my/$image:latest",
-            )
-
-    def test_build_image_rejects_double_quote(self):
-        with pytest.raises(ValueError, match="unsafe character"):
-            SnowflakeAppEntityModel(
-                type="snowflake-app",
-                identifier="my_app",
-                artifacts=["app/*"],
-                build_image='/my/"image":latest',
-            )
-
     def test_spcs_test_project_type_strips_whitespace(self):
         model = SnowflakeAppEntityModel(
             type="snowflake-app",
@@ -338,23 +229,6 @@ class TestSnowflakeAppEntityModel:
             spcs_test_project_type=value,
         )
         assert model.spcs_test_project_type is None
-
-    def test_execute_as_caller_defaults_to_true(self):
-        model = SnowflakeAppEntityModel(
-            type="snowflake-app",
-            identifier="my_app",
-            artifacts=["app/*"],
-        )
-        assert model.execute_as_caller is True
-
-    def test_execute_as_caller_can_be_set_false(self):
-        model = SnowflakeAppEntityModel(
-            type="snowflake-app",
-            identifier="my_app",
-            artifacts=["app/*"],
-            execute_as_caller=False,
-        )
-        assert model.execute_as_caller is False
 
     def test_code_storage_mutually_exclusive(self):
         """``code_stage`` and ``code_workspace`` cannot both be set."""
@@ -456,11 +330,6 @@ class TestSnowflakeAppInProjectDefinition:
                         "schema": "EAI_SCHEMA",
                         "database": "EAI_DB",
                     },
-                    "service_eai": {
-                        "name": "SERVICE_EAI",
-                        "schema": "EAI_SCHEMA",
-                        "database": "EAI_DB",
-                    },
                     "artifact_repository": {
                         "name": "ARTIFACT_REPO",
                         "schema": "REPO_SCHEMA",
@@ -481,9 +350,6 @@ class TestSnowflakeAppInProjectDefinition:
         assert entity.build_eai.name == "BUILD_EAI"
         assert entity.build_eai.schema_ == "EAI_SCHEMA"
         assert entity.build_eai.database == "EAI_DB"
-        assert entity.service_eai.name == "SERVICE_EAI"
-        assert entity.service_eai.schema_ == "EAI_SCHEMA"
-        assert entity.service_eai.database == "EAI_DB"
         assert entity.artifact_repository.name == "ARTIFACT_REPO"
         assert entity.artifact_repository.schema_ == "REPO_SCHEMA"
         assert entity.artifact_repository.database == "REPO_DB"

--- a/tests_integration/test_data/projects/snowflake_apps/snowflake.yml
+++ b/tests_integration/test_data/projects/snowflake_apps/snowflake.yml
@@ -16,7 +16,6 @@ entities:
     service_compute_pool:
       name: snowcli_compute_pool
     build_eai: null
-    service_eai: null
     artifact_repository:
       name: SNOW_APPS_DEFAULT_ARTIFACT_REPOSITORY
     code_stage:


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [x] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description

Removes fields from the `snowflake-app` entity model (`snowflake.yml`) that were defined but never read by `snow app setup` or `snow app deploy`:

- `service_eai` — only `build_eai` is wired into the build config and `CREATE APPLICATION SERVICE`; `service_eai` was never consumed.
- `app_port` — defined with a default of `3000` but never referenced.
- `build_image` — defined and validated but never referenced.
- `execute_as_caller` — defined but never referenced.
- `dev_roles` — defined but never referenced.
- `image_repository` — defined but never read (the CLI defaults to `<app-id>_REPO`); the dead warning branch in `generate.py` that checked for it is removed too.
