### PR TITLE
docs: add CLI design principles to adding-commands.md

### DIFF
--- a/docs/contributing/adding-commands.md
+++ b/docs/contributing/adding-commands.md
@@ -39,6 +39,20 @@ maintainer for review.
 
 ---
 
+## Design principles
+
+**Verbs for commands, nouns for groups.** The group is the entity (`snow git`,
+`snow stage`), the command is the action (`fetch`, `create`, `list`). Avoid dashes in
+command names unless the concept truly cannot be expressed otherwise.
+
+**Find the closest existing command first.** Match its flag names, output
+type, and default behavior. Consistency across groups beats local cleverness.
+
+**Commands are what, flags are how.** Flags are configuration and conditions for a
+command (`--force`, `--delta`, `--if-exists`), not an alternate operation.
+
+---
+
 ## Which case are you in?
 
 **Adding a command to an existing group** — skip to


### PR DESCRIPTION
## Summary

Adds a short **Design principles** section to `docs/contributing/adding-commands.md`, slotted between *Design sign-off* and *Which case are you in?*.

The sign-off section already lists *what* maintainers review (names, flags, lifecycle, output, location), but doesn't capture the rules of thumb behind those reviews. This adds three:

- Verbs for commands, nouns for groups (no dashes in command names unless unavoidable)
- Find the closest existing command first (consistency over local cleverness)
- Commands are *what*, flags are *how*

Three principles only — kept tight to avoid duplicating destructive-command, return-type, and standard-flag guidance that already lives elsewhere in the file.

## Heads-up

`jw/SNOW-3511654-revamp-contributor-guidelines` (PR #3031) is also revamping contributor docs. Will rebase on top if that lands first.

## Test plan

- [ ] Render preview on GitHub looks right
- [ ] Cross-references (`lifecycle.md`, `flags.py`) still resolve