### PR TITLE
Snowflake Apps: always use a workspace for personal-database destinations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@
 
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.
-* `snow app setup` and `snow app deploy` now always upload app code to a workspace when the resolved destination is a personal database (`USER$<user>`), instead of attempting to create a stage there. Personal databases do not support stages, so the previous behavior could generate a `snowflake.yml` (or fall back at deploy time) that failed with a stage-creation error whenever the personal database was selected via an account parameter or the current connection rather than the built-in default. Existing project files that point a `code_stage` at a personal database are now transparently routed to the shared `SNOWFLAKE_APPS` workspace with a warning.
+* `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
 
 
 # v3.20.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.
+* `snow app setup` and `snow app deploy` now always upload app code to a workspace when the resolved destination is a personal database (`USER$<user>`), instead of attempting to create a stage there. Personal databases do not support stages, so the previous behavior could generate a `snowflake.yml` (or fall back at deploy time) that failed with a stage-creation error whenever the personal database was selected via an account parameter or the current connection rather than the built-in default. Existing project files that point a `code_stage` at a personal database are now transparently routed to the shared `SNOWFLAKE_APPS` workspace with a warning.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -26,13 +26,14 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, NamedTuple, Optional
 
 import typer
 from click import ClickException
 from snowflake.cli._plugins.apps.generate import _generate_snowflake_yml
 from snowflake.cli._plugins.apps.manager import (
     DEFAULT_PERSONAL_SCHEMA,
+    DEFAULT_PERSONAL_WORKSPACE_NAME,
     DEFINITION_FILENAME,
     SnowflakeAppManager,
     _filter_accessible_remote_defaults,
@@ -42,6 +43,7 @@ from snowflake.cli._plugins.apps.manager import (
     _resolve_entity_id,
     _ts,
     app_fqn,
+    is_personal_database,
     perform_bundle,
 )
 from snowflake.cli._plugins.connection.util import make_snowsight_url
@@ -58,7 +60,13 @@ from snowflake.cli.api.output.types import (
     ObjectResult,
 )
 from snowflake.cli.api.project.util import identifier_for_url
+from snowflake.cli.api.sanitizers import sanitize_for_terminal
 from snowflake.connector.errors import ProgrammingError
+
+if TYPE_CHECKING:
+    from snowflake.cli._plugins.apps.snowflake_app_entity_model import (
+        SnowflakeAppEntityModel,
+    )
 
 log = logging.getLogger(__name__)
 
@@ -74,6 +82,103 @@ SOURCE_ACCOUNT_PARAM = "account parameter"
 SOURCE_CURRENT_SESSION = "current session"
 SOURCE_DEFAULT = "default"
 SOURCE_MISSING = "missing"
+
+
+class _CodeStorage(NamedTuple):
+    """Resolved code-storage backend for an app deploy/teardown.
+
+    ``use_workspace`` selects between the workspace flow (``True``) and the
+    stage flow (``False``). ``name`` plus the optional database/schema
+    overrides identify the backing object; ``encryption_type`` applies only to
+    the stage flow.
+    """
+
+    use_workspace: bool
+    name: str
+    database_override: Optional[str]
+    schema_override: Optional[str]
+    encryption_type: str
+
+
+def _resolve_code_storage(
+    entity: "SnowflakeAppEntityModel",
+    *,
+    database: Optional[str],
+    schema: Optional[str],
+    app_name: str,
+) -> _CodeStorage:
+    """Decide whether app code is uploaded to a workspace or a stage.
+
+    Personal databases (``USER$<user>``) do not support stages, so any app
+    whose *resolved* destination database is a personal database must use a
+    workspace — regardless of what (if anything) ``snowflake.yml`` configured.
+    This both honors explicit configuration for non-personal destinations and
+    repairs project files that predate personal-database detection (a
+    ``code_stage`` pointing at a personal database, or no code-storage block at
+    all) by transparently routing them through the shared
+    ``SNOWFLAKE_APPS`` workspace.
+
+    Resolution order:
+
+    1. Explicit ``code_workspace`` → workspace, as configured.
+    2. Explicit ``code_stage`` → stage, as configured, *unless* the destination
+       is a personal database, in which case the stage is overridden to the
+       shared workspace with a warning.
+    3. Neither configured → workspace when the destination is a personal
+       database, otherwise a stage named ``<app>_CODE``.
+    """
+    destination_is_personal = is_personal_database(database)
+
+    if entity.code_workspace is not None:
+        return _CodeStorage(
+            use_workspace=True,
+            name=entity.code_workspace.name,
+            database_override=entity.code_workspace.database,
+            schema_override=entity.code_workspace.schema_,
+            encryption_type="SNOWFLAKE_SSE",  # unused in workspace flow
+        )
+
+    if entity.code_stage is not None:
+        if destination_is_personal:
+            cli_console.warning(
+                f"code_stage '{sanitize_for_terminal(entity.code_stage.name)}' "
+                "is configured, but the resolved destination database "
+                f"'{sanitize_for_terminal(str(database))}' is a personal "
+                "database, which does not support stages. Uploading app code "
+                f"to the '{DEFAULT_PERSONAL_WORKSPACE_NAME}' workspace instead."
+            )
+            return _CodeStorage(
+                use_workspace=True,
+                name=DEFAULT_PERSONAL_WORKSPACE_NAME,
+                database_override=None,
+                schema_override=None,
+                encryption_type="SNOWFLAKE_SSE",
+            )
+        return _CodeStorage(
+            use_workspace=False,
+            name=entity.code_stage.name,
+            database_override=entity.code_stage.database,
+            schema_override=entity.code_stage.schema_,
+            encryption_type=entity.code_stage.encryption_type or "SNOWFLAKE_SSE",
+        )
+
+    # Neither code_workspace nor code_stage configured: pick the backend that
+    # the destination supports.
+    if destination_is_personal:
+        return _CodeStorage(
+            use_workspace=True,
+            name=DEFAULT_PERSONAL_WORKSPACE_NAME,
+            database_override=None,
+            schema_override=None,
+            encryption_type="SNOWFLAKE_SSE",
+        )
+    return _CodeStorage(
+        use_workspace=False,
+        name=f"{app_name}_CODE",
+        database_override=None,
+        schema_override=None,
+        encryption_type="SNOWFLAKE_SSE",
+    )
 
 
 def snowflake_app_setup(
@@ -229,7 +334,15 @@ def snowflake_app_setup(
     resolved_values = {k: v[0] for k, v in resolved.items()}
 
     if not dry_run:
-        use_workspace = resolved["database"][1] == SOURCE_DEFAULT
+        # Use a workspace whenever the destination is a personal database:
+        # either it was resolved from the built-in personal-DB default tier,
+        # or it arrived via an account parameter / the current session but is
+        # still a ``USER$<user>`` personal database. Personal databases do not
+        # support stages, so emitting ``code_stage`` for one would produce a
+        # ``snowflake.yml`` that always fails at deploy time.
+        use_workspace = resolved["database"][
+            1
+        ] == SOURCE_DEFAULT or is_personal_database(resolved_values["database"])
         project_file.write_text(
             _generate_snowflake_yml(
                 resolved_app_name,
@@ -471,27 +584,6 @@ def snowflake_app_deploy(
     database = fqn.database or conn.database
     schema = fqn.schema or conn.schema
 
-    # ── Resolve code storage backend ──────────────────────────────────
-    # ``code_stage`` and ``code_workspace`` are mutually exclusive (enforced
-    # by the entity model). When only one is provided, that backend is used.
-    # When neither is configured, fall back to a code stage named ``<app>_CODE``.
-    use_workspace = entity.code_workspace is not None
-    if use_workspace:
-        storage_name = entity.code_workspace.name
-        storage_db_override = entity.code_workspace.database
-        storage_schema_override = entity.code_workspace.schema_
-        encryption_type = "SNOWFLAKE_SSE"  # unused in workspace flow
-    elif entity.code_stage is not None:
-        storage_name = entity.code_stage.name
-        storage_db_override = entity.code_stage.database
-        storage_schema_override = entity.code_stage.schema_
-        encryption_type = entity.code_stage.encryption_type or "SNOWFLAKE_SSE"
-    else:
-        storage_name = f"{app_name}_CODE"
-        storage_db_override = None
-        storage_schema_override = None
-        encryption_type = "SNOWFLAKE_SSE"
-
     build_compute_pool = (
         entity.build_compute_pool.name if entity.build_compute_pool else None
     )
@@ -515,6 +607,21 @@ def snowflake_app_deploy(
     service_compute_pool = defaults["service_compute_pool"]
     query_warehouse = defaults["query_warehouse"]
     build_eai = defaults["build_eai"]
+
+    # ── Resolve code storage backend ──────────────────────────────────
+    # ``code_stage`` and ``code_workspace`` are mutually exclusive (enforced
+    # by the entity model). The backend is chosen here — after the destination
+    # database is resolved — because a personal database does not support
+    # stages and must always use a workspace, even when ``snowflake.yml``
+    # specifies a stage or omits code storage entirely.
+    storage = _resolve_code_storage(
+        entity, database=database, schema=schema, app_name=app_name
+    )
+    use_workspace = storage.use_workspace
+    storage_name = storage.name
+    storage_db_override = storage.database_override
+    storage_schema_override = storage.schema_override
+    encryption_type = storage.encryption_type
 
     # User-supplied compute pools are always passed through to the server
     # (forwarded as the 4th argument to
@@ -861,18 +968,15 @@ def snowflake_app_teardown(
     service_fqn = app_fqn(database=db, schema=schema, name=app_name)
     is_application_service = manager.is_application_service(service_fqn)
 
-    use_workspace = entity.code_workspace is not None
-    if use_workspace:
-        storage_name = entity.code_workspace.name
-        storage_db = entity.code_workspace.database or db
-        storage_schema = entity.code_workspace.schema_ or schema
-    elif entity.code_stage is not None:
-        storage_name = entity.code_stage.name
-        storage_db = entity.code_stage.database or db
-        storage_schema = entity.code_stage.schema_ or schema
-    else:
-        storage_name = f"{app_name}_CODE"
-        storage_db, storage_schema = db, schema
+    # Mirror the deploy-time backend selection so a personal-database app is
+    # torn down via its workspace rather than a (never-created) stage.
+    storage = _resolve_code_storage(
+        entity, database=db, schema=schema, app_name=app_name
+    )
+    use_workspace = storage.use_workspace
+    storage_name = storage.name
+    storage_db = storage.database_override or db
+    storage_schema = storage.schema_override or schema
 
     storage_fqn = app_fqn(database=storage_db, schema=storage_schema, name=storage_name)
     build_job_fqn = app_fqn(database=db, schema=schema, name=f"{app_name}_BUILD_JOB")

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -26,7 +26,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, NamedTuple, Optional
+from typing import TYPE_CHECKING, Callable, Literal, NamedTuple, Optional
 
 import typer
 from click import ClickException
@@ -84,16 +84,18 @@ SOURCE_DEFAULT = "default"
 SOURCE_MISSING = "missing"
 
 
+_CodeStorageType = Literal["workspace", "stage"]
+
+
 class _CodeStorage(NamedTuple):
     """Resolved code-storage backend for an app deploy/teardown.
 
-    ``use_workspace`` selects between the workspace flow (``True``) and the
-    stage flow (``False``). ``name`` plus the optional database/schema
-    overrides identify the backing object; ``encryption_type`` applies only to
-    the stage flow.
+    ``type`` selects between the ``"workspace"`` and ``"stage"`` flows.
+    ``name`` plus the optional database/schema overrides identify the backing
+    object; ``encryption_type`` applies only to the stage flow.
     """
 
-    use_workspace: bool
+    type: _CodeStorageType  # noqa: A003
     name: str
     database_override: Optional[str]
     schema_override: Optional[str]
@@ -131,7 +133,7 @@ def _resolve_code_storage(
 
     if entity.code_workspace is not None:
         return _CodeStorage(
-            use_workspace=True,
+            type="workspace",
             name=entity.code_workspace.name,
             database_override=entity.code_workspace.database,
             schema_override=entity.code_workspace.schema_,
@@ -149,7 +151,7 @@ def _resolve_code_storage(
                 "supported there."
             )
         return _CodeStorage(
-            use_workspace=False,
+            type="stage",
             name=entity.code_stage.name,
             database_override=entity.code_stage.database,
             schema_override=entity.code_stage.schema_,
@@ -160,14 +162,14 @@ def _resolve_code_storage(
     # the destination supports.
     if destination_is_personal:
         return _CodeStorage(
-            use_workspace=True,
+            type="workspace",
             name=DEFAULT_PERSONAL_WORKSPACE_NAME,
             database_override=None,
             schema_override=None,
             encryption_type="SNOWFLAKE_SSE",
         )
     return _CodeStorage(
-        use_workspace=False,
+        type="stage",
         name=f"{app_name}_CODE",
         database_override=None,
         schema_override=None,
@@ -611,7 +613,7 @@ def snowflake_app_deploy(
     storage = _resolve_code_storage(
         entity, database=database, schema=schema, app_name=app_name
     )
-    use_workspace = storage.use_workspace
+    use_workspace = storage.type == "workspace"
     storage_name = storage.name
     storage_db_override = storage.database_override
     storage_schema_override = storage.schema_override
@@ -967,7 +969,7 @@ def snowflake_app_teardown(
     storage = _resolve_code_storage(
         entity, database=db, schema=schema, app_name=app_name
     )
-    use_workspace = storage.use_workspace
+    use_workspace = storage.type == "workspace"
     storage_name = storage.name
     storage_db = storage.database_override or db
     storage_schema = storage.schema_override or schema

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -121,9 +121,9 @@ def _resolve_code_storage(
     Resolution order:
 
     1. Explicit ``code_workspace`` → workspace, as configured.
-    2. Explicit ``code_stage`` → stage, as configured, *unless* the destination
-       is a personal database, in which case the stage is overridden to the
-       shared workspace with a warning.
+    2. Explicit ``code_stage`` → stage, as configured. When the destination is
+       a personal database a warning is emitted (stages are generally
+       unsupported there), but the user's explicit choice is still honored.
     3. Neither configured → workspace when the destination is a personal
        database, otherwise a stage named ``<app>_CODE``.
     """
@@ -144,15 +144,9 @@ def _resolve_code_storage(
                 f"code_stage '{sanitize_for_terminal(entity.code_stage.name)}' "
                 "is configured, but the resolved destination database "
                 f"'{sanitize_for_terminal(str(database))}' is a personal "
-                "database, which does not support stages. Uploading app code "
-                f"to the '{DEFAULT_PERSONAL_WORKSPACE_NAME}' workspace instead."
-            )
-            return _CodeStorage(
-                use_workspace=True,
-                name=DEFAULT_PERSONAL_WORKSPACE_NAME,
-                database_override=None,
-                schema_override=None,
-                encryption_type="SNOWFLAKE_SSE",
+                "database, which generally does not support stages. Honoring "
+                "the configured stage; the deploy may fail if stages are not "
+                "supported there."
             )
         return _CodeStorage(
             use_workspace=False,

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -29,6 +29,31 @@ DEFAULT_PERSONAL_SCHEMA = "PUBLIC"
 DEFAULT_PERSONAL_WORKSPACE_NAME = "SNOWFLAKE_APPS"
 WORKSPACE_LIVE_VERSION_PATH = "versions/live"
 
+# Snowflake assigns every user a *personal database* named ``USER$<username>``.
+# Personal databases do not support stages, so app code destined for one must
+# be uploaded to a workspace instead. The ``USER$`` prefix is system-assigned
+# and always upper case; the username portion's case is preserved by Snowflake
+# and is irrelevant to this check.
+PERSONAL_DATABASE_PREFIX = "USER$"
+
+
+def is_personal_database(database: Optional[str]) -> bool:
+    """Return ``True`` when *database* is a Snowflake personal database (PDB).
+
+    Personal databases are named ``USER$<username>`` and do not support
+    stages, so the Snowflake App Runtime flow must upload code to a workspace
+    rather than a stage whenever the resolved destination is one of them.
+
+    The check tolerates quoted identifiers (e.g.
+    ``"USER$first.last@domain.com"``) by stripping the surrounding quotes
+    before matching the system-assigned ``USER$`` prefix.
+    """
+    if not database:
+        return False
+    name = identifier_to_str(database.strip())
+    return name.upper().startswith(PERSONAL_DATABASE_PREFIX)
+
+
 # Snowsight admin-setup docs, surfaced when the account-configured destination
 # database/schema is not accessible to the current role so the user knows where
 # to ask their administrator for access.
@@ -55,7 +80,7 @@ from snowflake.cli.api.console import cli_console
 from snowflake.cli.api.exceptions import CliError
 from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.project.project_paths import ProjectPaths
-from snowflake.cli.api.project.util import to_identifier
+from snowflake.cli.api.project.util import identifier_to_str, to_identifier
 from snowflake.cli.api.sanitizers import sanitize_for_terminal
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.cli.api.sql_execution import SqlExecutionMixin

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -4351,7 +4351,7 @@ class TestResolveCodeStorage:
             app_name="MY_APP",
         )
         assert storage == _CodeStorage(
-            use_workspace=True,
+            type="workspace",
             name="MY_WS",
             database_override="WS_DB",
             schema_override="WS_SCHEMA",
@@ -4367,7 +4367,7 @@ class TestResolveCodeStorage:
             schema="TEST_SCHEMA",
             app_name="MY_APP",
         )
-        assert storage.use_workspace is False
+        assert storage.type == "stage"
         assert storage.name == "MY_STAGE"
 
     def test_explicit_stage_on_personal_db_is_honored_with_warning(self):
@@ -4384,7 +4384,7 @@ class TestResolveCodeStorage:
                 app_name="MY_APP",
             )
         assert storage == _CodeStorage(
-            use_workspace=False,
+            type="stage",
             name="MY_APP_CODE",
             database_override=None,
             schema_override=None,
@@ -4399,7 +4399,7 @@ class TestResolveCodeStorage:
             schema="TEST_SCHEMA",
             app_name="MY_APP",
         )
-        assert storage.use_workspace is False
+        assert storage.type == "stage"
         assert storage.name == "MY_APP_CODE"
 
     def test_no_code_storage_on_personal_db_defaults_to_workspace(self):
@@ -4409,7 +4409,7 @@ class TestResolveCodeStorage:
             schema="PUBLIC",
             app_name="MY_APP",
         )
-        assert storage.use_workspace is True
+        assert storage.type == "workspace"
         assert storage.name == "SNOWFLAKE_APPS"
 
 

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -16,8 +16,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 from snowflake.cli._plugins.apps.commands import (
+    _CodeStorage,
     _log_service_logs,
     _make_build_log_streamer,
+    _resolve_code_storage,
 )
 from snowflake.cli._plugins.apps.generate import (
     _generate_snowflake_yml,
@@ -32,6 +34,7 @@ from snowflake.cli._plugins.apps.manager import (
     _resolve_entity_id,
     _ts,
     app_fqn,
+    is_personal_database,
     perform_bundle,
 )
 from snowflake.cli.api.cli_global_context import get_cli_context_manager
@@ -1089,6 +1092,27 @@ class TestSnowflakeAppManager:
         mock_execute.return_value = cursor
 
         assert SnowflakeAppManager().get_personal_database() is None
+
+    @pytest.mark.parametrize(
+        "database, expected",
+        [
+            ("USER$ADMIN", True),
+            ("user$admin", True),  # prefix match is case-insensitive
+            ("USER$guy.bloom@snowflake.com", True),
+            ('"USER$guy.bloom@snowflake.com"', True),  # quoted identifier
+            ('"USER$first.last@x.com"', True),
+            ("TEST_DB", False),
+            ("MY_USER_DB", False),  # USER$ prefix only, not substring
+            ("DB$USER", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_personal_database(self, database, expected):
+        """Personal databases are named ``USER$<user>`` and must be detected
+        regardless of identifier quoting so the deploy flow routes them to a
+        workspace (stages are unsupported in personal databases)."""
+        assert is_personal_database(database) is expected
 
     @patch(EXECUTE_QUERY)
     def test_stage_exists_returns_true(self, mock_execute):
@@ -3198,6 +3222,37 @@ class TestSetupCommand:
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
         return_value="definition_version: '2'\n",
     )
+    @patch("snowflake.cli._plugins.apps.commands.get_connection_dict")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_setup_uses_workspace_when_session_database_is_personal(
+        self, mock_mgr_cls, mock_get_conn, mock_gen, runner, tmp_path
+    ):
+        """A personal database resolved from the session (not the personal-DB
+        default tier, e.g. because ``get_personal_database`` returned ``None``)
+        must still emit ``code_workspace`` — personal databases never support
+        stages."""
+        mock_get_conn.return_value = {"database": "USER$SNOTEBAERT"}
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "schema": "PUBLIC",
+            "query_warehouse": "PARAM_WH",
+        }
+        mock_mgr.get_personal_database.return_value = None
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["database"] == "USER$SNOTEBAERT"
+        assert mock_gen.call_args.kwargs["use_workspace"] is True
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_managed_compute_pool_omits_compute_pools(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
@@ -4270,6 +4325,92 @@ class TestEventsCommand:
             assert span[CLIMetricsSpan.ERROR_KEY] == ProgrammingError.__name__
 
 
+class TestResolveCodeStorage:
+    """Unit coverage for the workspace-vs-stage backend selection.
+
+    A personal database (``USER$<user>``) never supports stages, so the
+    resolver must route every personal-database destination to a workspace —
+    even when ``snowflake.yml`` explicitly configures a stage or omits code
+    storage entirely.
+    """
+
+    @staticmethod
+    def _entity(*, code_stage=None, code_workspace=None):
+        entity = Mock()
+        entity.code_stage = code_stage
+        entity.code_workspace = code_workspace
+        return entity
+
+    def test_explicit_workspace_is_honored(self):
+        ws = Mock(database="WS_DB", schema_="WS_SCHEMA")
+        ws.name = "MY_WS"
+        storage = _resolve_code_storage(
+            self._entity(code_workspace=ws),
+            database="TEST_DB",
+            schema="TEST_SCHEMA",
+            app_name="MY_APP",
+        )
+        assert storage == _CodeStorage(
+            use_workspace=True,
+            name="MY_WS",
+            database_override="WS_DB",
+            schema_override="WS_SCHEMA",
+            encryption_type="SNOWFLAKE_SSE",
+        )
+
+    def test_explicit_stage_on_regular_db_is_honored(self):
+        stage = Mock(database=None, schema_=None, encryption_type="SNOWFLAKE_SSE")
+        stage.name = "MY_STAGE"
+        storage = _resolve_code_storage(
+            self._entity(code_stage=stage),
+            database="TEST_DB",
+            schema="TEST_SCHEMA",
+            app_name="MY_APP",
+        )
+        assert storage.use_workspace is False
+        assert storage.name == "MY_STAGE"
+
+    def test_explicit_stage_on_personal_db_is_overridden_to_workspace(self):
+        """A ``code_stage`` aimed at a personal database (as produced by older
+        ``snow app setup`` runs) is repaired by routing to the shared
+        workspace, since the stage could never be created there."""
+        stage = Mock(database=None, schema_=None, encryption_type="SNOWFLAKE_SSE")
+        stage.name = "MY_APP_CODE"
+        storage = _resolve_code_storage(
+            self._entity(code_stage=stage),
+            database="USER$SNOTEBAERT",
+            schema="PUBLIC",
+            app_name="MY_APP",
+        )
+        assert storage == _CodeStorage(
+            use_workspace=True,
+            name="SNOWFLAKE_APPS",
+            database_override=None,
+            schema_override=None,
+            encryption_type="SNOWFLAKE_SSE",
+        )
+
+    def test_no_code_storage_on_regular_db_defaults_to_stage(self):
+        storage = _resolve_code_storage(
+            self._entity(),
+            database="TEST_DB",
+            schema="TEST_SCHEMA",
+            app_name="MY_APP",
+        )
+        assert storage.use_workspace is False
+        assert storage.name == "MY_APP_CODE"
+
+    def test_no_code_storage_on_personal_db_defaults_to_workspace(self):
+        storage = _resolve_code_storage(
+            self._entity(),
+            database="USER$SNOTEBAERT",
+            schema="PUBLIC",
+            app_name="MY_APP",
+        )
+        assert storage.use_workspace is True
+        assert storage.name == "SNOWFLAKE_APPS"
+
+
 # ── Deploy CLI command tests ──────────────────────────────────────────
 
 
@@ -5165,6 +5306,112 @@ class TestDeployCommand:
             compute_pool="BUILD_POOL",
             database="TEST_DB",
             schema="TEST_SCHEMA",
+            runtime_image="runtime:latest",
+            build_eai="MY_EAI",
+            project_type="",
+        )
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "USER$SNOTEBAERT",
+            "schema": "PUBLIC",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "USER$SNOTEBAERT",
+            "artifact_repo_schema": "PUBLIC",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_personal_db_with_code_stage_uses_workspace(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """A ``code_stage`` pointing at a personal database (produced by older
+        ``snow app setup`` runs) must be repaired at deploy time: code is
+        uploaded to the shared workspace, no stage is created, and the user is
+        warned."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "USER$SNOTEBAERT"
+        fqn.schema = "PUBLIC"
+        entity.fqn = fqn
+        entity.code_stage = Mock(
+            encryption_type="SNOWFLAKE_SSE",
+            database=None,
+            schema_=None,
+        )
+        entity.code_stage.name = "MY_APP_CODE"
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = "runtime:latest"
+        entity.query_warehouse = "WH"
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.artifact_repo_exists.return_value = False
+        mock_mgr.workspace_last_subdirectory_uri.return_value = "snow://workspace/USER$SNOTEBAERT.PUBLIC.SNOWFLAKE_APPS/versions/last/MY_APP"
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: USER$SNOTEBAERT.PUBLIC.BUILD_JOB_123"
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {
+                "url": "my-app.snowflakecomputing.app",
+                "is_upgrading": "false",
+            },
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+            assert "does not support stages" in result.output
+
+        mock_mgr.create_stage.assert_not_called()
+        mock_mgr.create_workspace.assert_called_once_with(
+            FQN(database="USER$SNOTEBAERT", schema="PUBLIC", name="SNOWFLAKE_APPS")
+        )
+        mock_mgr.build_app_artifact_repo.assert_called_once_with(
+            source_uri=mock_mgr.workspace_last_subdirectory_uri.return_value,
+            artifact_repo_fqn="USER$SNOTEBAERT.PUBLIC.MY_APP_REPO",
+            app_id="MY_APP",
+            compute_pool="BUILD_POOL",
+            database="USER$SNOTEBAERT",
+            schema="PUBLIC",
             runtime_image="runtime:latest",
             build_eai="MY_EAI",
             project_type="",

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -4370,25 +4370,27 @@ class TestResolveCodeStorage:
         assert storage.use_workspace is False
         assert storage.name == "MY_STAGE"
 
-    def test_explicit_stage_on_personal_db_is_overridden_to_workspace(self):
-        """A ``code_stage`` aimed at a personal database (as produced by older
-        ``snow app setup`` runs) is repaired by routing to the shared
-        workspace, since the stage could never be created there."""
+    def test_explicit_stage_on_personal_db_is_honored_with_warning(self):
+        """An explicit ``code_stage`` aimed at a personal database is honored
+        (the user's choice wins); a warning is emitted because stages are
+        generally unsupported in personal databases."""
         stage = Mock(database=None, schema_=None, encryption_type="SNOWFLAKE_SSE")
         stage.name = "MY_APP_CODE"
-        storage = _resolve_code_storage(
-            self._entity(code_stage=stage),
-            database="USER$SNOTEBAERT",
-            schema="PUBLIC",
-            app_name="MY_APP",
-        )
+        with patch("snowflake.cli._plugins.apps.commands.cli_console") as mock_console:
+            storage = _resolve_code_storage(
+                self._entity(code_stage=stage),
+                database="USER$SNOTEBAERT",
+                schema="PUBLIC",
+                app_name="MY_APP",
+            )
         assert storage == _CodeStorage(
-            use_workspace=True,
-            name="SNOWFLAKE_APPS",
+            use_workspace=False,
+            name="MY_APP_CODE",
             database_override=None,
             schema_override=None,
             encryption_type="SNOWFLAKE_SSE",
         )
+        mock_console.warning.assert_called_once()
 
     def test_no_code_storage_on_regular_db_defaults_to_stage(self):
         storage = _resolve_code_storage(
@@ -5334,7 +5336,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_personal_db_with_code_stage_uses_workspace(
+    def test_deploy_personal_db_with_code_stage_is_honored_with_warning(
         self,
         mock_resolve,
         mock_get_entity,
@@ -5346,10 +5348,9 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
-        """A ``code_stage`` pointing at a personal database (produced by older
-        ``snow app setup`` runs) must be repaired at deploy time: code is
-        uploaded to the shared workspace, no stage is created, and the user is
-        warned."""
+        """An explicit ``code_stage`` pointing at a personal database is honored
+        (the stage flow runs), but the user is warned that stages are generally
+        unsupported in personal databases."""
         from snowflake.cli.api.project.project_paths import ProjectPaths
 
         entity = Mock()
@@ -5382,8 +5383,8 @@ class TestDeployCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
-        mock_mgr.workspace_last_subdirectory_uri.return_value = "snow://workspace/USER$SNOTEBAERT.PUBLIC.SNOWFLAKE_APPS/versions/last/MY_APP"
         mock_mgr.build_app_artifact_repo.return_value = (
             "Build job submitted: USER$SNOTEBAERT.PUBLIC.BUILD_JOB_123"
         )
@@ -5399,14 +5400,14 @@ class TestDeployCommand:
             _write_snowflake_app_yml(tmp_path)
             result = runner.invoke(["app", "deploy"])
             assert result.exit_code == 0, result.output
-            assert "does not support stages" in result.output
+            assert "generally does not support stages" in result.output
 
-        mock_mgr.create_stage.assert_not_called()
-        mock_mgr.create_workspace.assert_called_once_with(
-            FQN(database="USER$SNOTEBAERT", schema="PUBLIC", name="SNOWFLAKE_APPS")
-        )
+        mock_mgr.create_workspace.assert_not_called()
+        mock_mgr.create_stage.assert_called_once()
         mock_mgr.build_app_artifact_repo.assert_called_once_with(
-            source_uri=mock_mgr.workspace_last_subdirectory_uri.return_value,
+            stage_fqn=FQN(
+                database="USER$SNOTEBAERT", schema="PUBLIC", name="MY_APP_CODE"
+            ),
             artifact_repo_fqn="USER$SNOTEBAERT.PUBLIC.MY_APP_REPO",
             app_id="MY_APP",
             compute_pool="BUILD_POOL",


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

**Problem**

Personal databases (`USER$<user>`) do not support stages. A `snowflake.yml` with `database: 'USER$...'` and no `code_workspace` failed at deploy because it attempted to create a stage in a personal database.

**Fix**

Decide the storage backend from whether the *resolved destination* is a personal database, not from config provenance/presence:

- Add `is_personal_database()` (matches the system-assigned `USER$` prefix, tolerates quoted identifiers) in the apps `manager`.
- `snow app setup` now emits `code_workspace` whenever the resolved destination is a personal database, regardless of which tier supplied it.
- `snow app deploy` / `snow app teardown` resolve the backend via a shared `_resolve_code_storage()` helper *after* the destination database is resolved. A `code_stage` aimed at a personal database is transparently routed to the shared `SNOWFLAKE_APPS` workspace with a warning (repairing project files generated by older CLI versions); when neither code-storage key is set, the backend is chosen by destination type.

Explicit configuration for non-personal destinations is unchanged.
