### PR TITLE
Snowflake Apps: support bare string for snowflake-app build_eai

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
+* The `build_eai` field of a `snowflake-app` entity can now be specified as a bare string (e.g. `build_eai: MY_EAI`) in addition to the existing `build_eai:\n  name: MY_EAI` object form.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -41,18 +41,14 @@ class ComputePoolReference(UpdatableModel):
 
 
 class ExternalAccessReference(UpdatableModel):
-    """Reference to an external access integration."""
+    """Reference to an external access integration.
+
+    External access integrations are account-level objects, so only a name is
+    accepted (no database/schema qualification).
+    """
 
     name: Optional[str] = IdentifierField(
         title="Name of the external access integration", default=None
-    )
-    schema_: Optional[str] = IdentifierField(
-        title="Schema of the external access integration",
-        alias="schema",
-        default=None,
-    )
-    database: Optional[str] = IdentifierField(
-        title="Database of the external access integration", default=None
     )
 
 
@@ -148,9 +144,15 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
     @field_validator("build_eai", mode="before")
     @classmethod
     def _validate_eai(cls, value):
-        """Allow null/None values for the EAI field."""
+        """Accept a bare name string, a mapping with ``name``, or null/None.
+
+        External access integrations are account-level objects, so a plain
+        string is treated as the integration name (e.g. ``build_eai: MY_EAI``).
+        """
         if value is None or value == "null":
             return None
+        if isinstance(value, str):
+            return {"name": value}
         return value
 
     artifact_repository: Optional[ArtifactRepositoryReference] = Field(

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -59,11 +59,7 @@ class TestSnowflakeAppEntityModel:
                 "schema": "MY_SCHEMA",
                 "database": "MY_DB",
             },
-            build_eai={
-                "name": "BUILD_EAI",
-                "schema": "MY_SCHEMA",
-                "database": "MY_DB",
-            },
+            build_eai={"name": "BUILD_EAI"},
             artifact_repository={
                 "name": "ARTIFACT_REPO",
                 "schema": "MY_SCHEMA",
@@ -80,8 +76,6 @@ class TestSnowflakeAppEntityModel:
         assert model.service_compute_pool.schema_ == "MY_SCHEMA"
         assert model.service_compute_pool.database == "MY_DB"
         assert model.build_eai.name == "BUILD_EAI"
-        assert model.build_eai.schema_ == "MY_SCHEMA"
-        assert model.build_eai.database == "MY_DB"
         assert model.artifact_repository.name == "ARTIFACT_REPO"
         assert model.artifact_repository.schema_ == "MY_SCHEMA"
         assert model.artifact_repository.database == "MY_DB"
@@ -132,6 +126,18 @@ class TestSnowflakeAppEntityModel:
             identifier="my_app",
             artifacts=["app/*"],
             build_eai={"name": "MY_EAI"},
+        )
+        assert model.build_eai.name == "MY_EAI"
+
+    def test_eai_validator_bare_string(self):
+        """``build_eai: MY_EAI`` (bare string) is treated as the integration
+        name. External access integrations are account-level objects, so no
+        database/schema qualification is applied."""
+        model = SnowflakeAppEntityModel(
+            type="snowflake-app",
+            identifier="my_app",
+            artifacts=["app/*"],
+            build_eai="MY_EAI",
         )
         assert model.build_eai.name == "MY_EAI"
 
@@ -325,11 +331,7 @@ class TestSnowflakeAppInProjectDefinition:
                         "schema": "SVC_SCHEMA",
                         "database": "SVC_DB",
                     },
-                    "build_eai": {
-                        "name": "BUILD_EAI",
-                        "schema": "EAI_SCHEMA",
-                        "database": "EAI_DB",
-                    },
+                    "build_eai": {"name": "BUILD_EAI"},
                     "artifact_repository": {
                         "name": "ARTIFACT_REPO",
                         "schema": "REPO_SCHEMA",
@@ -348,8 +350,6 @@ class TestSnowflakeAppInProjectDefinition:
         assert entity.service_compute_pool.schema_ == "SVC_SCHEMA"
         assert entity.service_compute_pool.database == "SVC_DB"
         assert entity.build_eai.name == "BUILD_EAI"
-        assert entity.build_eai.schema_ == "EAI_SCHEMA"
-        assert entity.build_eai.database == "EAI_DB"
         assert entity.artifact_repository.name == "ARTIFACT_REPO"
         assert entity.artifact_repository.schema_ == "REPO_SCHEMA"
         assert entity.artifact_repository.database == "REPO_DB"
@@ -418,16 +418,11 @@ class TestSubModels:
     def test_external_access_reference(self):
         ref = ExternalAccessReference(name="MY_EAI")
         assert ref.name == "MY_EAI"
-        assert ref.schema_ is None
-        assert ref.database is None
 
-    def test_external_access_reference_with_database_schema(self):
-        ref = ExternalAccessReference(
-            name="MY_EAI", schema="MY_SCHEMA", database="MY_DB"
-        )
-        assert ref.name == "MY_EAI"
-        assert ref.schema_ == "MY_SCHEMA"
-        assert ref.database == "MY_DB"
+    def test_external_access_reference_rejects_database_schema(self):
+        """EAIs are account-level objects, so database/schema are not accepted."""
+        with pytest.raises(ValueError):
+            ExternalAccessReference(name="MY_EAI", schema="MY_SCHEMA", database="MY_DB")
 
     def test_artifact_repository_reference(self):
         ref = ArtifactRepositoryReference(name="MY_REPO")


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
The `build_eai` field of a `snowflake-app` entity can now be specified as a bare string (e.g. `build_eai: MY_EAI`), in addition to the existing object form with a single `name` field.

External access integrations are account-level objects, so `build_eai` is no longer modeled as a fully-qualified identifier. 