### PR TITLE
Snowflake Apps: support warehouse, database and schema overrides in "snow app setup"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 * Upgraded `pip` from 26.1.1 to 26.1.2.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
 * The `build_eai` field of a `snowflake-app` entity can now be specified as a bare string (e.g. `build_eai: MY_EAI`) in addition to the existing `build_eai:\n  name: MY_EAI` object form.
+* `snow app setup` now honors the `--warehouse`, `--database`, and `--schema` connection options as explicit overrides for the generated `snowflake.yml`, taking precedence over account parameters and the connection defaults. This lets users target a warehouse, database, or schema other than the account defaults.
 
 
 # v3.20.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,7 +24,7 @@
 * Upgraded `pip` from 26.1.1 to 26.1.2.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
 * The `build_eai` field of a `snowflake-app` entity can now be specified as a bare string (e.g. `build_eai: MY_EAI`) in addition to the existing `build_eai:\n  name: MY_EAI` object form.
-* `snow app setup` now honors the `--warehouse`, `--database`, and `--schema` connection options as explicit overrides for the generated `snowflake.yml`, taking precedence over account parameters and the connection defaults. This lets users target a warehouse, database, or schema other than the account defaults.
+* `snow app setup` now honors the `--warehouse`, `--database`, and `--schema` connection options as explicit overrides for the generated `snowflake.yml`, taking precedence over account parameters and the connection defaults. This lets users target a warehouse, database, or schema other than the account defaults. When `--database` is specified, `--schema` must also be specified.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -261,6 +261,16 @@ def snowflake_app_setup(
     cli_db = getattr(conn, "database", None) or None
     cli_schema = getattr(conn, "schema", None) or None
 
+    # A user-supplied database must be paired with an explicit schema: schema
+    # resolution would otherwise fall back to an account parameter or the
+    # personal-database default, silently placing the app in a schema that does
+    # not belong to the requested database.
+    if cli_db and not cli_schema:
+        raise CliError(
+            "--schema is required when --database is specified. "
+            "Provide --schema to select the schema within the requested database."
+        )
+
     session_wh = conn_config.get("warehouse") or None
     session_db = conn_config.get("database") or None
     session_schema = conn_config.get("schema") or None

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -253,11 +253,17 @@ def snowflake_app_setup(
 
     # ── Pre-compute current session values ─────────────────────────────
     conn = ctx.connection_context
-    session_wh = (
-        getattr(conn, "warehouse", None) or conn_config.get("warehouse") or None
-    )
-    session_db = getattr(conn, "database", None) or conn_config.get("database") or None
-    session_schema = getattr(conn, "schema", None) or conn_config.get("schema") or None
+    # ``conn.warehouse/database/schema`` are only non-None when the user
+    # explicitly passed the corresponding connection-override flag on the
+    # command line (e.g. ``--warehouse MY_WH``).  Values from the
+    # connection config file come through ``conn_config`` instead.
+    cli_wh = getattr(conn, "warehouse", None) or None
+    cli_db = getattr(conn, "database", None) or None
+    cli_schema = getattr(conn, "schema", None) or None
+
+    session_wh = conn_config.get("warehouse") or None
+    session_db = conn_config.get("database") or None
+    session_schema = conn_config.get("schema") or None
 
     personal_db = manager.get_personal_database()
     personal_schema = DEFAULT_PERSONAL_SCHEMA if personal_db else None
@@ -265,6 +271,7 @@ def snowflake_app_setup(
     # ── Resolve each field ────────────────────────────────────────────
     resolved = {
         "database": _resolve(
+            user_input=cli_db,
             account_param=params.get("database"),
             default_value=personal_db,
             current_session=session_db,
@@ -272,11 +279,13 @@ def snowflake_app_setup(
         # TODO: Support per-app schema (e.g. APPS.APP_<app_id>) instead of
         # a single shared schema for all apps.
         "schema": _resolve(
+            user_input=cli_schema,
             account_param=params.get("schema"),
             default_value=personal_schema,
             current_session=session_schema,
         ),
         "warehouse": _resolve(
+            user_input=cli_wh,
             account_param=params.get("query_warehouse"),
             current_session=session_wh,
         ),
@@ -312,19 +321,17 @@ def snowflake_app_setup(
     }
 
     # ── Validate required values ─────────────────────────────────────
-    # TODO: database, warehouse, and schema cannot be passed as arguments
-    # yet — they must come from account parameters or the current session.
     if not resolved["database"][0]:
         raise ClickException(
-            "Missing database. Set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE account parameter or check your connection."
+            "Missing database. Provide --database, set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE account parameter, or check your connection."
         )
     if not resolved["schema"][0]:
         raise ClickException(
-            "Missing schema. Set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA account parameter or check your connection."
+            "Missing schema. Provide --schema, set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA account parameter, or check your connection."
         )
     if not resolved["warehouse"][0]:
         raise ClickException(
-            "Missing warehouse. Set the DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE account parameter or check your connection."
+            "Missing warehouse. Provide --warehouse, set the DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE account parameter, or check your connection."
         )
 
     resolved_values = {k: v[0] for k, v in resolved.items()}

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -3137,6 +3137,220 @@ class TestSetupCommand:
         return_value="definition_version: '2'\n",
     )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_warehouse_flag_beats_account_param(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """--warehouse CLI flag should override the account parameter and show 'user input' provenance."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--warehouse",
+                    "MY_WAREHOUSE",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["warehouse"] == "MY_WAREHOUSE"
+        assert "warehouse: MY_WAREHOUSE  (user input)" in result.output
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_database_flag_beats_account_param(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """--database CLI flag should override the account parameter and show 'user input' provenance."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--database",
+                    "MY_DATABASE",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["database"] == "MY_DATABASE"
+        assert "database: MY_DATABASE  (user input)" in result.output
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_schema_flag_beats_account_param(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """--schema CLI flag should override the account parameter and show 'user input' provenance."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--schema",
+                    "MY_SCHEMA",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["schema"] == "MY_SCHEMA"
+        assert "schema: MY_SCHEMA  (user input)" in result.output
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_all_three_flags_beat_account_params(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """--warehouse, --database, and --schema flags should all override account parameters."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--warehouse",
+                    "MY_WH",
+                    "--database",
+                    "MY_DB",
+                    "--schema",
+                    "MY_SCHEMA",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["warehouse"] == "MY_WH"
+        assert resolved["database"] == "MY_DB"
+        assert resolved["schema"] == "MY_SCHEMA"
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_warehouse_flag_satisfies_missing_warehouse_requirement(
+        self, mock_mgr_cls, runner, tmp_path
+    ):
+        """--warehouse should prevent the 'Missing warehouse' error even when
+        no account parameter or connection default is configured."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--warehouse",
+                    "EXPLICIT_WH",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+            assert "Missing warehouse" not in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_database_flag_satisfies_missing_database_requirement(
+        self, mock_mgr_cls, runner, tmp_path
+    ):
+        """--database should prevent the 'Missing database' error even when
+        no account parameter, personal DB, or connection default is configured."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.get_personal_database.return_value = None
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--database",
+                    "EXPLICIT_DB",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+            assert "Missing database" not in result.output
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_setup_shows_parameter_provenance(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -3198,6 +3198,8 @@ class TestSetupCommand:
                     "my_app",
                     "--database",
                     "MY_DATABASE",
+                    "--schema",
+                    "MY_SCHEMA",
                 ]
             )
             assert result.exit_code == 0, result.output
@@ -3205,6 +3207,80 @@ class TestSetupCommand:
         resolved = mock_gen.call_args[0][1]
         assert resolved["database"] == "MY_DATABASE"
         assert "database: MY_DATABASE  (user input)" in result.output
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_database_without_schema_is_rejected(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """Specifying --database without --schema should fail with a clear error."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--database",
+                    "MY_DATABASE",
+                ]
+            )
+            assert result.exit_code != 0
+            assert "--schema is required when --database is specified" in result.output
+        # The validation must fail before any snowflake.yml is generated.
+        mock_gen.assert_not_called()
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_schema_without_database_is_allowed(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """Specifying --schema without --database is allowed; the database is
+        resolved from account parameters or the connection as usual."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                [
+                    "app",
+                    "setup",
+                    "--app-name",
+                    "my_app",
+                    "--schema",
+                    "MY_SCHEMA",
+                ]
+            )
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["schema"] == "MY_SCHEMA"
+        assert resolved["database"] == "PARAM_DB"
 
     @patch(
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
@@ -3341,6 +3417,8 @@ class TestSetupCommand:
                     "my_app",
                     "--database",
                     "EXPLICIT_DB",
+                    "--schema",
+                    "EXPLICIT_SCHEMA",
                 ]
             )
             assert result.exit_code == 0, result.output


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

This change makes `snow app setup` honor the existing global `--warehouse`, `--database`, and `--schema` connection options as explicit overrides when generating `snowflake.yml`:

No new CLI options were added — the change reuses the connection-override flags that `snow app setup` already inherits, so help output and snapshots are unchanged.
