### PR TITLE
feat: add --server-session-keep-alive flag for connections

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,7 @@
 ## New additions
 * Added a `--protocol` option (plus matching `SNOWFLAKE_PROTOCOL` env var and `protocol` config key) to `snow connection add` and the global connection overrides. This allows selecting `http` or `https` as the connection protocol without editing `config.toml`, which is primarily useful for local development against `http` deployments.
 * Added `snow helpers generate-project-schema` command to emit a JSON Schema for the `snowflake.yml` project definition file. The output follows [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/schema) and can be plugged into supported editors (e.g. VS Code via the YAML extension) or CI pipelines to get completion and to catch structural mistakes (unknown keys, wrong types, missing required fields) before a deploy. The schema is generated from the CLI's own models, so some cross-field and semantic checks are still only applied at load/deploy time. Use `--definition-version` to select the project definition version (`1`, `1.1`, or `2`; defaults to `2`) and `--output-file`/`-o` to write the schema to a file.
+* Added `--server-session-keep-alive` global connection flag (plus matching `SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE` env var and `server_session_keep_alive` config key) that prevents Snowflake from closing idle sessions. Useful for long-running operations or connections held open between multiple operations.
 
 ## Fixes and improvements
 * Fixed `TooManyFilesError` during `snow streamlit deploy` when `main_file` is a descendant of a directory listed in `artifacts`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 * Added `cli.encoding` config section (and matching `SNOWFLAKE_CLI_ENCODING_*` env vars) to control text encoding in three areas: `file_io` for reading and writing project files (e.g. SQL files, `snowflake.yml`), `subprocess` for decoding output of external processes (e.g. Docker, pip), and `stdout` for encoding CLI output written to stdout. Setting all three to `utf-8` ensures correct Unicode handling on Windows systems where the platform default encoding is not UTF-8.
 * Added `--no-prompt-exit-repl` option and configuration setting to skip the exit confirmation prompt in the SQL REPL.
+* Added `--server-session-keep-alive` global connection flag (plus matching `SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE` env var and `server_session_keep_alive` config key) that prevents Snowflake from closing idle sessions. Useful for long-running operations or connections held open between multiple operations.
 
 ## Fixes and improvements
 * Fixed REST API object operations (e.g. `snow object create`) crashing with `ModuleNotFoundError: No module named 'snowflake.connector.vendored'` when running against the Snowflake Universal Driver (connector-python v5). HTTP error handling now works on both connector v4.x and the Universal Driver v5.
@@ -46,7 +47,6 @@
 ## New additions
 * Added a `--protocol` option (plus matching `SNOWFLAKE_PROTOCOL` env var and `protocol` config key) to `snow connection add` and the global connection overrides. This allows selecting `http` or `https` as the connection protocol without editing `config.toml`, which is primarily useful for local development against `http` deployments.
 * Added `snow helpers generate-project-schema` command to emit a JSON Schema for the `snowflake.yml` project definition file. The output follows [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/schema) and can be plugged into supported editors (e.g. VS Code via the YAML extension) or CI pipelines to get completion and to catch structural mistakes (unknown keys, wrong types, missing required fields) before a deploy. The schema is generated from the CLI's own models, so some cross-field and semantic checks are still only applied at load/deploy time. Use `--definition-version` to select the project definition version (`1`, `1.1`, or `2`; defaults to `2`) and `--output-file`/`-o` to write the schema to a file.
-* Added `--server-session-keep-alive` global connection flag (plus matching `SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE` env var and `server_session_keep_alive` config key) that prevents Snowflake from closing idle sessions. Useful for long-running operations or connections held open between multiple operations.
 
 ## Fixes and improvements
 * Fixed `TooManyFilesError` during `snow streamlit deploy` when `main_file` is a descendant of a directory listed in `artifacts`.

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -90,6 +90,7 @@ SUPPORTED_ENV_OVERRIDES = [
     "oauth_enable_single_use_refresh_tokens",
     "client_store_temporary_credential",
     "secondary_roles",
+    "server_session_keep_alive",
 ]
 
 # mapping of found key -> key to set
@@ -109,6 +110,7 @@ _BOOLEAN_ENV_OVERRIDE_KEYS = frozenset(
         "oauth_enable_refresh_tokens",
         "oauth_enable_single_use_refresh_tokens",
         "client_store_temporary_credential",
+        "server_session_keep_alive",
     }
 )
 

--- a/src/snowflake/cli/_app/snow_connector.py
+++ b/src/snowflake/cli/_app/snow_connector.py
@@ -315,6 +315,15 @@ def _avoid_closing_the_connection_if_it_was_shared(
     using_session_token: bool, using_master_token: bool, connection_parameters: Dict
 ):
     if using_session_token and using_master_token:
+        if (
+            "server_session_keep_alive" in connection_parameters
+            and connection_parameters["server_session_keep_alive"] is False
+        ):
+            log.warning(
+                "Overriding server_session_keep_alive=False to True because "
+                "session/master token authentication requires keep-alive to prevent "
+                "the shared connection from being closed."
+            )
         connection_parameters["server_session_keep_alive"] = True
         connection_parameters["client_session_keep_alive"] = True
         # Workaround: the connector crashes with TypeError when

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -274,7 +274,8 @@ def add(
     ),
     server_session_keep_alive: Optional[bool] = typer.Option(
         None,
-        "--server-session-keep-alive/--no-server-session-keep-alive",
+        "--server-session-keep-alive",
+        is_flag=True,
         help=(
             "Enable server-side session keep-alive to prevent the session from "
             "timing out during long operations."

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -311,8 +311,13 @@ def add(
         "server_session_keep_alive": server_session_keep_alive,
     }
 
+    # Boolean options that should not be prompted interactively
+    _non_interactive_options = {"server_session_keep_alive"}
+
     if not no_interactive:
         for option in connection_options:
+            if option in _non_interactive_options:
+                continue
             if connection_options[option] is None:
                 connection_options[option] = typer.prompt(
                     f"Enter {option.replace('_', ' ')}",

--- a/src/snowflake/cli/_plugins/connection/commands.py
+++ b/src/snowflake/cli/_plugins/connection/commands.py
@@ -272,6 +272,14 @@ def add(
             "session only with the primary role."
         ),
     ),
+    server_session_keep_alive: Optional[bool] = typer.Option(
+        None,
+        "--server-session-keep-alive/--no-server-session-keep-alive",
+        help=(
+            "Enable server-side session keep-alive to prevent the session from "
+            "timing out during long operations."
+        ),
+    ),
     set_as_default: bool = typer.Option(
         False,
         "--default",
@@ -300,6 +308,7 @@ def add(
         "private_key_file": private_key_file,
         "token_file_path": token_file_path,
         "secondary_roles": secondary_roles,
+        "server_session_keep_alive": server_session_keep_alive,
     }
 
     if not no_interactive:

--- a/src/snowflake/cli/api/commands/decorators.py
+++ b/src/snowflake/cli/api/commands/decorators.py
@@ -52,6 +52,7 @@ from snowflake.cli.api.commands.flags import (
     RoleOption,
     SchemaOption,
     SecondaryRolesOption,
+    ServerSessionKeepAliveOption,
     SessionTokenOption,
     SilentOption,
     TemporaryConnectionOption,
@@ -427,6 +428,12 @@ GLOBAL_CONNECTION_OPTIONS = [
         inspect.Parameter.KEYWORD_ONLY,
         annotation=Optional[str],
         default=SecondaryRolesOption,
+    ),
+    inspect.Parameter(
+        "server_session_keep_alive",
+        inspect.Parameter.KEYWORD_ONLY,
+        annotation=Optional[bool],
+        default=ServerSessionKeepAliveOption,
     ),
 ]
 

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -433,6 +433,16 @@ ClientStoreTemporaryCredentialOption = typer.Option(
     rich_help_panel=_CONNECTION_SECTION,
 )
 
+ServerSessionKeepAliveOption = typer.Option(
+    None,
+    "--server-session-keep-alive",
+    help="Keep the session active indefinitely, even if there is no activity from the user.",
+    callback=_connection_callback("server_session_keep_alive"),
+    is_flag=True,
+    show_default=False,
+    rich_help_panel=_CONNECTION_SECTION,
+)
+
 SecondaryRolesOption = typer.Option(
     None,
     "--secondary-roles",

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -435,9 +435,10 @@ ClientStoreTemporaryCredentialOption = typer.Option(
 
 ServerSessionKeepAliveOption = typer.Option(
     None,
-    "--server-session-keep-alive/--no-server-session-keep-alive",
+    "--server-session-keep-alive",
     help="Keep the session active indefinitely, even if there is no activity from the user.",
     callback=_connection_callback("server_session_keep_alive"),
+    is_flag=True,
     show_default=False,
     rich_help_panel=_CONNECTION_SECTION,
 )

--- a/src/snowflake/cli/api/commands/flags.py
+++ b/src/snowflake/cli/api/commands/flags.py
@@ -435,10 +435,9 @@ ClientStoreTemporaryCredentialOption = typer.Option(
 
 ServerSessionKeepAliveOption = typer.Option(
     None,
-    "--server-session-keep-alive",
+    "--server-session-keep-alive/--no-server-session-keep-alive",
     help="Keep the session active indefinitely, even if there is no activity from the user.",
     callback=_connection_callback("server_session_keep_alive"),
-    is_flag=True,
     show_default=False,
     rich_help_panel=_CONNECTION_SECTION,
 )

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -142,6 +142,7 @@ class ConnectionConfig:
     oauth_enable_single_use_refresh_tokens: Optional[bool] = None
     client_store_temporary_credential: Optional[bool] = None
     secondary_roles: Optional[str] = None
+    server_session_keep_alive: Optional[bool] = None
 
     _other_settings: dict = field(default_factory=lambda: {})
 

--- a/src/snowflake/cli/api/config_ng/sources.py
+++ b/src/snowflake/cli/api/config_ng/sources.py
@@ -711,6 +711,7 @@ _ENV_CONFIG_KEYS: Final[list[str]] = [
     "oauth_enable_single_use_refresh_tokens",
     "client_store_temporary_credential",
     "secondary_roles",
+    "server_session_keep_alive",
 ]
 
 _BOOLEAN_ENV_CONFIG_KEYS: Final[set[str]] = {
@@ -718,6 +719,7 @@ _BOOLEAN_ENV_CONFIG_KEYS: Final[set[str]] = {
     "oauth_enable_refresh_tokens",
     "oauth_enable_single_use_refresh_tokens",
     "client_store_temporary_credential",
+    "server_session_keep_alive",
 }
 
 

--- a/src/snowflake/cli/api/connections.py
+++ b/src/snowflake/cli/api/connections.py
@@ -86,6 +86,7 @@ class ConnectionContext:
     oauth_enable_single_use_refresh_tokens: Optional[bool] = None
     client_store_temporary_credential: Optional[bool] = None
     secondary_roles: Optional[str] = None
+    server_session_keep_alive: Optional[bool] = None
 
     # Internal flag to track if config has been loaded
     _config_loaded: bool = field(default=False, repr=False, init=False)

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -43,6 +43,7 @@
     --oauth-enable-single-use-refresh-tokens
     --client-store-temporary-credential
     --secondary-roles <secondary_roles>
+    --server-session-keep-alive
     --format <format>
     --verbose
     --debug
@@ -276,6 +277,12 @@
   <dd>
   
   Secondary roles mode applied when the session starts. Supported values are `ALL` and `NONE`; pass `NONE` to run the session only with the primary role.
+  
+  </dd>
+  <dt>`--server-session-keep-alive`</dt>
+  <dd>
+  
+  Keep the session active indefinitely, even if there is no activity from the user.
   
   </dd>
   <dt>`--format [TABLE|JSON|JSON_EXT|CSV]`</dt>

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -4687,6 +4687,10 @@
   |                                                 NONE; pass NONE to run the   |
   |                                                 session only with the        |
   |                                                 primary role.                |
+  | --server-session-keep-alive                     Enable server-side session   |
+  |                                                 keep-alive to prevent the    |
+  |                                                 session from timing out      |
+  |                                                 during long operations.      |
   | --default                                       If provided the connection   |
   |                                                 will be configured as        |
   |                                                 default connection.          |

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -331,6 +331,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -490,6 +493,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -731,6 +737,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -906,6 +915,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -1152,6 +1164,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -1319,6 +1334,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -1485,6 +1503,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -1647,6 +1668,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -1814,6 +1838,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -1980,6 +2007,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -2141,6 +2171,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -2333,6 +2366,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -2506,6 +2542,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -2675,6 +2714,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -2853,6 +2895,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -3017,6 +3062,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -3294,6 +3342,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -3450,6 +3501,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -3655,6 +3709,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -3824,6 +3881,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -4056,6 +4116,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -4246,6 +4309,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -4404,6 +4470,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -4768,6 +4837,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -4915,6 +4987,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -5195,6 +5270,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -5480,6 +5558,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -5629,6 +5710,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -5780,6 +5864,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -5939,6 +6026,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -6124,6 +6214,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -6309,6 +6402,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -6494,6 +6590,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -6679,6 +6778,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -6864,6 +6966,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -7049,6 +7154,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -7234,6 +7342,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -7419,6 +7530,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -7604,6 +7718,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -7789,6 +7906,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -7974,6 +8094,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -8159,6 +8282,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -8343,6 +8469,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -8524,6 +8653,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -8687,6 +8819,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -8844,6 +8979,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9010,6 +9148,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9169,6 +9310,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9326,6 +9470,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9488,6 +9635,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9650,6 +9800,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9813,6 +9966,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -9994,6 +10150,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -10155,6 +10314,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -10315,6 +10477,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -10475,6 +10640,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -10673,6 +10841,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -10822,6 +10993,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -10973,6 +11147,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -11144,6 +11321,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -11294,6 +11474,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -11448,6 +11631,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -11603,6 +11789,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -11757,6 +11946,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -11915,6 +12107,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -12077,6 +12272,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -12329,6 +12527,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -12482,6 +12683,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -12644,6 +12848,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -12794,6 +13001,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -12944,6 +13154,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -13094,6 +13307,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -13286,6 +13502,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -13443,6 +13662,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -13602,6 +13824,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -13772,6 +13997,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -14108,6 +14336,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -14274,6 +14505,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -14429,6 +14663,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -14586,6 +14823,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -14743,6 +14983,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -14905,6 +15148,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -15069,6 +15315,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -15218,6 +15467,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -15370,6 +15622,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -15629,6 +15884,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -15784,6 +16042,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -15934,6 +16195,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -16086,6 +16350,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -16236,6 +16503,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -16386,6 +16656,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -16556,6 +16829,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -16707,6 +16983,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -16857,6 +17136,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17008,6 +17290,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17167,6 +17452,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17348,6 +17636,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17496,6 +17787,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17653,6 +17947,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17827,6 +18124,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -17980,6 +18280,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -18132,6 +18435,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -18286,6 +18592,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -18442,6 +18751,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -18600,6 +18912,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -18750,6 +19065,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -18974,6 +19292,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -19181,6 +19502,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -19337,6 +19661,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -19486,6 +19813,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -19640,6 +19970,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -19815,6 +20148,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -19964,6 +20300,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -20113,6 +20452,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -20262,6 +20604,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -20411,6 +20756,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -20569,6 +20917,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -20730,6 +21081,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -20889,6 +21243,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -21038,6 +21395,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -21234,6 +21594,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -21387,6 +21750,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -21536,6 +21902,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -21702,6 +22071,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -21853,6 +22225,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -22167,6 +22542,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -22348,6 +22726,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -22506,6 +22887,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -22655,6 +23039,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -22806,6 +23193,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -22957,6 +23347,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -23125,6 +23518,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -23278,6 +23674,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -23436,6 +23835,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -23587,6 +23989,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -23784,6 +24189,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -23934,6 +24342,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -24086,6 +24497,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -24236,6 +24650,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -24387,6 +24804,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -24545,6 +24965,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -24717,6 +25140,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -24869,6 +25295,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
@@ -25289,6 +25718,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |

--- a/tests/api/commands/__snapshots__/test_snow_typer.ambr
+++ b/tests/api/commands/__snapshots__/test_snow_typer.ambr
@@ -113,6 +113,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |

--- a/tests/config_ng/test_configuration.py
+++ b/tests/config_ng/test_configuration.py
@@ -171,6 +171,47 @@ def test_general_env_boolean_values_cast(config_ng_setup):
         assert conn["client_store_temporary_credential"] is True
 
 
+def test_server_session_keep_alive_env_var_true(config_ng_setup):
+    """SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE=true should be coerced to bool."""
+    env_vars = {
+        "SNOWFLAKE_ACCOUNT": "env-account",
+        "SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE": "true",
+    }
+
+    with config_ng_setup(env_vars=env_vars):
+        from snowflake.cli.api.config import get_connection_dict
+
+        conn = get_connection_dict("default")
+        assert conn["server_session_keep_alive"] is True
+
+
+def test_server_session_keep_alive_env_var_false(config_ng_setup):
+    """SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE=false should be coerced to bool."""
+    env_vars = {
+        "SNOWFLAKE_ACCOUNT": "env-account",
+        "SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE": "false",
+    }
+
+    with config_ng_setup(env_vars=env_vars):
+        from snowflake.cli.api.config import get_connection_dict
+
+        conn = get_connection_dict("default")
+        assert conn["server_session_keep_alive"] is False
+
+
+def test_connection_specific_server_session_keep_alive_env_var(config_ng_setup):
+    """Connection-specific SNOWFLAKE_CONNECTIONS_<NAME>_SERVER_SESSION_KEEP_ALIVE should work."""
+    env_vars = {
+        "SNOWFLAKE_CONNECTIONS_TEST_SERVER_SESSION_KEEP_ALIVE": "1",
+    }
+
+    with config_ng_setup(env_vars=env_vars):
+        from snowflake.cli.api.config import get_connection_dict
+
+        conn = get_connection_dict("test")
+        assert conn["server_session_keep_alive"] is True
+
+
 def test_complete_7_level_chain(config_ng_setup):
     """All 7 levels with different keys showing complete precedence"""
     snowsql_config = """

--- a/tests/output/__snapshots__/test_silent_output.ambr
+++ b/tests/output/__snapshots__/test_silent_output.ambr
@@ -118,6 +118,9 @@
   |                                                NONE; pass NONE to run the    |
   |                                                session only with the primary |
   |                                                role.                         |
+  | --server-session-keep-alive                    Keep the session active       |
+  |                                                indefinitely, even if there   |
+  |                                                is no activity from the user. |
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |

--- a/tests/test_common_decorators.py
+++ b/tests/test_common_decorators.py
@@ -62,6 +62,7 @@ _KNOWN_SIG_GLOBAL_PARAMETERS_WITH_CONNECTION = [
     "oauth_enable_single_use_refresh_tokens",
     "client_store_temporary_credential",
     "secondary_roles",
+    "server_session_keep_alive",
 ] + _KNOWN_SIG_GLOBAL_PARAMETERS
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -90,6 +90,48 @@ def test_new_connection_can_be_added_with_protocol(runner, os_agnostic_snapshot)
     assert content == os_agnostic_snapshot
 
 
+def test_new_connection_can_be_added_with_server_session_keep_alive(runner):
+    with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
+            [
+                "connection",
+                "add",
+                "--connection-name",
+                "conn-keepalive",
+                "--username",
+                "user1",
+                "--account",
+                "account1",
+                "--server-session-keep-alive",
+            ],
+        )
+        content = tmp_file.read()
+    assert result.exit_code == 0, result.output
+    assert "server_session_keep_alive = true" in content
+
+
+def test_new_connection_can_be_added_with_no_server_session_keep_alive(runner):
+    with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
+        result = runner.invoke_with_config_file(
+            tmp_file.name,
+            [
+                "connection",
+                "add",
+                "--connection-name",
+                "conn-no-keepalive",
+                "--username",
+                "user1",
+                "--account",
+                "account1",
+                "--no-server-session-keep-alive",
+            ],
+        )
+        content = tmp_file.read()
+    assert result.exit_code == 0, result.output
+    assert "server_session_keep_alive = false" in content
+
+
 def test_new_connection_can_be_added_as_default(runner, os_agnostic_snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
         result = runner.invoke_with_config_file(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -111,27 +111,6 @@ def test_new_connection_can_be_added_with_server_session_keep_alive(runner):
     assert "server_session_keep_alive = true" in content
 
 
-def test_new_connection_can_be_added_with_no_server_session_keep_alive(runner):
-    with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
-        result = runner.invoke_with_config_file(
-            tmp_file.name,
-            [
-                "connection",
-                "add",
-                "--connection-name",
-                "conn-no-keepalive",
-                "--username",
-                "user1",
-                "--account",
-                "account1",
-                "--no-server-session-keep-alive",
-            ],
-        )
-        content = tmp_file.read()
-    assert result.exit_code == 0, result.output
-    assert "server_session_keep_alive = false" in content
-
-
 def test_new_connection_can_be_added_as_default(runner, os_agnostic_snapshot):
     with NamedTemporaryFile("w+", suffix=".toml") as tmp_file:
         result = runner.invoke_with_config_file(

--- a/tests/test_snow_connector.py
+++ b/tests/test_snow_connector.py
@@ -698,3 +698,101 @@ def test_externalbrowser_authenticator_is_case_insensitive(
 
     # For externalbrowser, stdout should mirror to stderr
     assert stdout_stream._mirror is not None  # noqa: SLF001
+
+
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+@mock.patch("snowflake.cli._app.snow_connector.get_connection_dict")
+@mock.patch("snowflake.connector.connect")
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_server_session_keep_alive_passed_to_connector(
+    mock_connect, mock_get_connection_dict, mock_command_info
+):
+    """Test that server_session_keep_alive from config is passed to connector."""
+    from snowflake.cli._app.snow_connector import connect_to_snowflake
+
+    mock_command_info.return_value = "SNOWCLI.TEST"
+    mock_get_connection_dict.return_value = {
+        "account": "test_account",
+        "user": "test_user",
+        "password": "test_password",
+        "server_session_keep_alive": True,
+    }
+
+    connect_to_snowflake(connection_name="test_connection")
+
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args[1]
+    assert call_kwargs["server_session_keep_alive"] is True
+
+
+@mock.patch("snowflake.cli._app.snow_connector.command_info")
+@mock.patch("snowflake.cli._app.snow_connector.get_connection_dict")
+@mock.patch("snowflake.connector.connect")
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_server_session_keep_alive_false_passed_to_connector(
+    mock_connect, mock_get_connection_dict, mock_command_info
+):
+    """Test that server_session_keep_alive=False from config is passed to connector."""
+    from snowflake.cli._app.snow_connector import connect_to_snowflake
+
+    mock_command_info.return_value = "SNOWCLI.TEST"
+    mock_get_connection_dict.return_value = {
+        "account": "test_account",
+        "user": "test_user",
+        "password": "test_password",
+        "server_session_keep_alive": False,
+    }
+
+    connect_to_snowflake(connection_name="test_connection")
+
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args[1]
+    assert call_kwargs["server_session_keep_alive"] is False
+
+
+@mock.patch("snowflake.cli._app.snow_connector.log")
+def test_warning_logged_when_overriding_server_session_keep_alive(mock_log):
+    """Test that a warning is logged when server_session_keep_alive=False is overridden."""
+    from snowflake.cli._app.snow_connector import (
+        _avoid_closing_the_connection_if_it_was_shared,
+    )
+
+    connection_parameters = {"server_session_keep_alive": False}
+
+    _avoid_closing_the_connection_if_it_was_shared(
+        using_session_token=True,
+        using_master_token=True,
+        connection_parameters=connection_parameters,
+    )
+
+    mock_log.warning.assert_called_once()
+    warning_message = mock_log.warning.call_args[0][0]
+    assert "Overriding server_session_keep_alive=False to True" in warning_message
+    assert connection_parameters["server_session_keep_alive"] is True
+
+
+@mock.patch("snowflake.cli._app.snow_connector.log")
+def test_no_warning_when_server_session_keep_alive_not_explicitly_false(mock_log):
+    """Test that no warning is logged when server_session_keep_alive is not explicitly False."""
+    from snowflake.cli._app.snow_connector import (
+        _avoid_closing_the_connection_if_it_was_shared,
+    )
+
+    # Case 1: server_session_keep_alive not in parameters
+    connection_parameters = {}
+    _avoid_closing_the_connection_if_it_was_shared(
+        using_session_token=True,
+        using_master_token=True,
+        connection_parameters=connection_parameters,
+    )
+    mock_log.warning.assert_not_called()
+
+    # Case 2: server_session_keep_alive already True
+    mock_log.reset_mock()
+    connection_parameters = {"server_session_keep_alive": True}
+    _avoid_closing_the_connection_if_it_was_shared(
+        using_session_token=True,
+        using_master_token=True,
+        connection_parameters=connection_parameters,
+    )
+    mock_log.warning.assert_not_called()


### PR DESCRIPTION
## Summary

- Add new `--server-session-keep-alive` CLI flag that prevents Snowflake from closing idle sessions
- Works with both named connections and temporary connections (`-x`)
- Can also be set via `SNOWFLAKE_SERVER_SESSION_KEEP_ALIVE` env var
- Passes `server_session_keep_alive=True` to the Snowflake connector

## Test plan

- [x] Unit tests pass (7572 passed in docker)
- [x] Verified flag appears in `--help` output
- [x] Tested with temporary connection: `snow sql -q "SELECT 1" -x --server-session-keep-alive ...`
- [x] Verified connector logs `Parameter server_session_keep_alive was set to True - skipping session logout`

🤖 Generated with [Claude Code](https://claude.ai/code)