### PR TITLE
Snowflake Apps: clearer deploy errors and Windows workspace upload fix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
+* Fixed `snow app deploy` failing on Windows when uploading app code to a workspace (connector error `253006`, `ER_FILE_NOT_EXISTS`) due to a malformed local file URI.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -679,12 +679,26 @@ def snowflake_app_deploy(
             with metrics.span("snowflake_app.upload"):
                 if use_workspace:
                     with metrics.span("snowflake_app.upload.prepare_workspace"):
-                        cli_console.step(f"Creating workspace {storage_fqn}")
-                        manager.create_workspace(storage_fqn)
-                        cli_console.step(
-                            f"Clearing existing workspace files in {workspace_source_uri}/"
-                        )
-                        manager.clear_workspace_subdirectory(storage_fqn, app_name)
+                        action = "create workspace"
+                        required_privilege = "CREATE WORKSPACE on the schema"
+                        try:
+                            cli_console.step(f"Creating workspace {storage_fqn}")
+                            manager.create_workspace(storage_fqn)
+                            action = "clear workspace files"
+                            required_privilege = "WRITE on the workspace"
+                            cli_console.step(
+                                f"Clearing existing workspace files in {workspace_source_uri}/"
+                            )
+                            manager.clear_workspace_subdirectory(storage_fqn, app_name)
+                        except ProgrammingError as e:
+                            role = manager.current_role()
+                            role_clause = f"role '{role}'" if role else "your role"
+                            raise CliError(
+                                f"Failed to {action} '{storage_fqn.identifier}': {e}. "
+                                f"Verify that {role_clause} has the required "
+                                f"privileges (USAGE on the database and schema, "
+                                f"and {required_privilege})."
+                            ) from e
                     with metrics.span("snowflake_app.upload.push_workspace_files"):
                         cli_console.step(
                             f"Uploading bundled files to {workspace_source_uri}"
@@ -709,12 +723,35 @@ def snowflake_app_deploy(
                         manager.ensure_workspace_live_version(storage_fqn)
                 else:
                     with metrics.span("snowflake_app.upload.prepare_stage"):
-                        if manager.stage_exists(storage_fqn):
-                            cli_console.step(f"Clearing existing stage @{storage_fqn}")
-                            manager.clear_stage(storage_fqn)
-                        else:
-                            cli_console.step(f"Creating stage @{storage_fqn}")
-                            manager.create_stage(storage_fqn, encryption_type)
+                        stage_already_exists = manager.stage_exists(storage_fqn)
+                        try:
+                            if stage_already_exists:
+                                cli_console.step(
+                                    f"Clearing existing stage @{storage_fqn}"
+                                )
+                                manager.clear_stage(storage_fqn)
+                            else:
+                                cli_console.step(f"Creating stage @{storage_fqn}")
+                                manager.create_stage(storage_fqn, encryption_type)
+                        except ProgrammingError as e:
+                            action = (
+                                "clear existing stage"
+                                if stage_already_exists
+                                else "create stage"
+                            )
+                            required_privilege = (
+                                "WRITE on the stage"
+                                if stage_already_exists
+                                else "CREATE STAGE on the schema"
+                            )
+                            role = manager.current_role()
+                            role_clause = f"role '{role}'" if role else "your role"
+                            raise CliError(
+                                f"Failed to {action} '{storage_fqn.identifier}': {e}. "
+                                f"Verify that {role_clause} has the required "
+                                f"privileges (USAGE on the database and schema, "
+                                f"and {required_privilege})."
+                            ) from e
 
                     with metrics.span("snowflake_app.upload.push_stage_files"):
                         cli_console.step(f"Uploading bundled files to @{storage_fqn}")

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -91,6 +91,33 @@ from snowflake.connector.errors import ProgrammingError
 
 log = logging.getLogger(__name__)
 
+# Characters allowed in a ``file://`` URI without wrapping it in a quoted
+# string literal. Mirrors the stage manager's equivalent so workspace PUT
+# statements escape local paths identically.
+_UNQUOTED_FILE_URI_REGEX = r"[\w/*?\-.=&{}$#[\]\"\\!@%^+:]+"
+
+
+def _local_path_to_file_uri(local_path: str) -> str:
+    """Return a ``file://`` URI for *local_path*, ready to embed in a PUT.
+
+    *local_path* must use the platform's native separators (e.g. backslashes
+    on Windows); do not pass a ``Path.as_posix()`` string, as Snowflake's
+    file-URI parser expects native Windows paths and a forward-slash drive
+    path such as ``file://C:/...`` is rejected on Windows (connector error
+    253006, ER_FILE_NOT_EXISTS).
+
+    The returned value is either a bare URI (when it contains only characters
+    allowed unquoted) or a single-quoted string literal. When quoting is
+    required, backslashes are doubled because Snowflake's file-URI parser
+    treats ``\\`` as an escape prefix even inside a string literal.
+    """
+    from snowflake.cli.api.project.util import to_string_literal
+
+    uri = f"file://{local_path}"
+    if re.fullmatch(_UNQUOTED_FILE_URI_REGEX, uri):
+        return uri
+    return to_string_literal(uri.replace("\\", "\\\\"))
+
 
 def app_fqn(
     *,
@@ -972,9 +999,14 @@ class SnowflakeAppManager(SqlExecutionMixin):
                 if rel_dir != Path(".")
                 else f"{base_uri}/"
             )
-            file_uri = f"file://{path.resolve().as_posix()}"
+            # Build the local file URI from the *native* path (not as_posix):
+            # Snowflake's file-URI parser rejects forward-slash Windows drive
+            # paths like ``file://C:/...`` (raising connector error 253006,
+            # ER_FILE_NOT_EXISTS). ``local_path_to_file_uri`` returns a value
+            # ready to embed directly, so it must not be re-quoted.
+            local_uri = _local_path_to_file_uri(str(path.resolve()))
             self.execute_query(
-                f"PUT {to_string_literal(file_uri)} {to_string_literal(dest_dir)} "
+                f"PUT {local_uri} {to_string_literal(dest_dir)} "
                 f"auto_compress=false overwrite={overwrite_str}"
             )
             yield {"source": str(rel), "target": f"{dest_dir}{path.name}"}

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1211,6 +1211,59 @@ class TestSnowflakeAppManager:
             == "snow://workspace/DB.SCHEMA.WORKSPACE/versions/last/MY_APP"
         )
 
+    @patch(EXECUTE_QUERY)
+    def test_upload_to_workspace_builds_native_file_uri(self, mock_execute, tmp_path):
+        """The PUT source must come from the native local path via
+        ``_local_path_to_file_uri`` and be embedded without an extra layer of
+        quoting. Using ``Path.as_posix()`` here produced ``file://C:/...`` on
+        Windows, which the connector rejects with error 253006."""
+        from snowflake.cli._plugins.apps.manager import _local_path_to_file_uri
+
+        (tmp_path / "app.py").write_text("print('hi')")
+        fqn = FQN(database="DB", schema="SCHEMA", name="WORKSPACE")
+
+        results = list(
+            SnowflakeAppManager().upload_to_workspace(
+                local_root=tmp_path,
+                workspace_fqn=fqn,
+                target_subdirectory="MY_APP",
+                overwrite=True,
+            )
+        )
+
+        assert [r["source"] for r in results] == ["app.py"]
+        expected_uri = _local_path_to_file_uri(str((tmp_path / "app.py").resolve()))
+        put_query = mock_execute.call_args_list[0][0][0]
+        assert put_query == (
+            f"PUT {expected_uri} "
+            f"'snow://workspace/DB.SCHEMA.WORKSPACE/versions/live/MY_APP/' "
+            f"auto_compress=false overwrite=true"
+        )
+        # The helper output is embedded directly, never re-wrapped in another
+        # string literal (which would yield an invalid ``PUT ''file://...''``).
+        assert "''file://" not in put_query
+
+    @pytest.mark.parametrize(
+        "native_path,expected_uri",
+        [
+            # Windows drive path keeps native backslashes; allowed unquoted so
+            # returned bare. The previous as_posix() form ``file://C:/...`` was
+            # the bug.
+            ("C:\\Users\\dev\\bundle\\app.py", "file://C:\\Users\\dev\\bundle\\app.py"),
+            # A space forces a quoted literal with doubled backslashes.
+            (
+                "C:\\My Apps\\bundle\\app.py",
+                "'file://C:\\\\My Apps\\\\bundle\\\\app.py'",
+            ),
+            # POSIX absolute path yields the valid three-slash form.
+            ("/home/dev/bundle/app.py", "file:///home/dev/bundle/app.py"),
+        ],
+    )
+    def test_local_path_to_file_uri(self, native_path, expected_uri):
+        from snowflake.cli._plugins.apps.manager import _local_path_to_file_uri
+
+        assert _local_path_to_file_uri(native_path) == expected_uri
+
     @staticmethod
     def _find_query(call_args_list, substr):
         for call in call_args_list:
@@ -5312,6 +5365,338 @@ class TestDeployCommand:
             build_eai="MY_EAI",
             project_type="",
         )
+
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_create_stage_privilege_error_includes_role_guidance(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """A privilege error while creating the code stage is rewrapped with
+        the failed action, the stage object, the role, and a privileges hint."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = Mock(
+            encryption_type="SNOWFLAKE_SSE",
+            database=None,
+            schema_=None,
+        )
+        entity.code_stage.name = "MY_STAGE"
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        create_error = ProgrammingError("Insufficient privileges")
+        create_error.errno = 3001
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.stage_exists.return_value = False
+        mock_mgr.create_stage.side_effect = create_error
+        mock_mgr.current_role.return_value = "APP_DEPLOYER"
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            _reset_command_metrics()
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 1, result.output
+            assert (
+                "Failed to create stage 'TEST_DB.TEST_SCHEMA.MY_STAGE'" in result.output
+            )
+            assert "role 'APP_DEPLOYER'" in result.output
+            assert "CREATE STAGE on the schema" in result.output
+            prepare_span = _get_completed_span("snowflake_app.upload.prepare_stage")
+            assert prepare_span[CLIMetricsSpan.ERROR_KEY] == CliError.__name__
+
+        mock_mgr.build_app_artifact_repo.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_clear_stage_privilege_error_includes_role_guidance(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """A privilege error while clearing an existing stage reports the clear
+        action and the WRITE privilege hint, and falls back to a generic role
+        phrase when the role cannot be resolved."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = Mock(
+            encryption_type="SNOWFLAKE_SSE",
+            database=None,
+            schema_=None,
+        )
+        entity.code_stage.name = "MY_STAGE"
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.stage_exists.return_value = True
+        mock_mgr.clear_stage.side_effect = ProgrammingError("Insufficient privileges")
+        mock_mgr.current_role.return_value = None
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            _reset_command_metrics()
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 1, result.output
+            assert (
+                "Failed to clear existing stage 'TEST_DB.TEST_SCHEMA.MY_STAGE'"
+                in result.output
+            )
+            assert "your role" in result.output
+            assert "WRITE on the stage" in result.output
+
+        mock_mgr.create_stage.assert_not_called()
+        mock_mgr.build_app_artifact_repo.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "USER$DEV",
+            "schema": "PUBLIC",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "USER$DEV",
+            "artifact_repo_schema": "PUBLIC",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_create_workspace_privilege_error_includes_role_guidance(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """A privilege error while creating the workspace is rewrapped with the
+        failed action, the workspace object, the role, and a privileges hint."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "USER$DEV"
+        fqn.schema = "PUBLIC"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = Mock(database=None, schema_=None)
+        entity.code_workspace.name = "SNOWFLAKE_APPS"
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        create_error = ProgrammingError("Insufficient privileges")
+        create_error.errno = 3001
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.workspace_subdirectory_uri.return_value = (
+            "snow://workspace/USER$DEV.PUBLIC.SNOWFLAKE_APPS/versions/live/MY_APP"
+        )
+        mock_mgr.create_workspace.side_effect = create_error
+        mock_mgr.current_role.return_value = "APP_DEPLOYER"
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            _reset_command_metrics()
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 1, result.output
+            assert (
+                "Failed to create workspace "
+                "'USER$DEV.PUBLIC.SNOWFLAKE_APPS'" in result.output
+            )
+            assert "role 'APP_DEPLOYER'" in result.output
+            assert "CREATE WORKSPACE on the schema" in result.output
+            prepare_span = _get_completed_span("snowflake_app.upload.prepare_workspace")
+            assert prepare_span[CLIMetricsSpan.ERROR_KEY] == CliError.__name__
+
+        mock_mgr.clear_workspace_subdirectory.assert_not_called()
+        mock_mgr.build_app_artifact_repo.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.StageManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "database": "USER$DEV",
+            "schema": "PUBLIC",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "USER$DEV",
+            "artifact_repo_schema": "PUBLIC",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_clear_workspace_privilege_error_includes_role_guidance(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_stage_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """A privilege error while clearing existing workspace files reports the
+        clear action and the WRITE privilege hint, and falls back to a generic
+        role phrase when the role cannot be resolved."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "USER$DEV"
+        fqn.schema = "PUBLIC"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = Mock(database=None, schema_=None)
+        entity.code_workspace.name = "SNOWFLAKE_APPS"
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.is_managed_compute_pool_enabled.return_value = False
+        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.workspace_subdirectory_uri.return_value = (
+            "snow://workspace/USER$DEV.PUBLIC.SNOWFLAKE_APPS/versions/live/MY_APP"
+        )
+        mock_mgr.clear_workspace_subdirectory.side_effect = ProgrammingError(
+            "Insufficient privileges"
+        )
+        mock_mgr.current_role.return_value = None
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            _reset_command_metrics()
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 1, result.output
+            assert (
+                "Failed to clear workspace files "
+                "'USER$DEV.PUBLIC.SNOWFLAKE_APPS'" in result.output
+            )
+            assert "your role" in result.output
+            assert "WRITE on the workspace" in result.output
+
+        mock_mgr.create_workspace.assert_called_once()
+        mock_mgr.build_app_artifact_repo.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.StageManager")

--- a/tests_integration/apps/test_snowflake_apps_deploy.py
+++ b/tests_integration/apps/test_snowflake_apps_deploy.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for the ``snow app deploy`` code-upload phase.
+
+Scope: this module exercises *only* the workspace code-upload path via
+``snow app deploy --upload-only``. That is the code path behind the
+Windows ``file://`` URI fix — each bundled file is sent to the workspace
+live version with a ``PUT file://...``. ``--upload-only`` stops before the
+build and service phases, so the test needs no compute pool or other
+container-service resources and runs cheaply against a real account.
+
+The full deploy flow (build + service) is covered by
+``tests_integration/tests_using_container_services/spcs/test_snowflake_apps.py``;
+do not duplicate it here.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+import uuid
+from pathlib import Path
+
+import pytest
+
+DATABASE = os.environ.get("SNOWFLAKE_CONNECTIONS_INTEGRATION_DATABASE", "SNOWCLI_DB")
+SCHEMA = os.environ.get("SNOWFLAKE_CONNECTIONS_INTEGRATION_SCHEMA", "public")
+WAREHOUSE = os.environ.get("SNOWFLAKE_CONNECTIONS_INTEGRATION_WAREHOUSE", "xsmall")
+
+
+@pytest.fixture()
+def unique_workspace(snowflake_session):
+    """Yield a unique workspace name and drop it on teardown.
+
+    The upload path creates the workspace if it does not exist, so the test
+    only needs to guarantee a non-colliding name and clean it up afterwards.
+    """
+    ws_name = f"SNOW_APP_WS_TEST_{uuid.uuid4().hex[:8]}"
+    yield ws_name
+    try:
+        snowflake_session.execute_string(
+            f"DROP WORKSPACE IF EXISTS {DATABASE}.{SCHEMA}.{ws_name}"
+        )
+    except Exception:
+        pass  # best-effort cleanup
+
+
+@pytest.mark.integration
+def test_deploy_upload_only_uploads_code_to_workspace(
+    runner,
+    temporary_working_directory,
+    unique_workspace,
+):
+    """``snow app deploy --upload-only`` uploads bundled files to a workspace.
+
+    Verifies the workspace ``PUT file://...`` upload (including a nested file)
+    succeeds against a real account, guarding the local-file-URI construction
+    used by ``upload_to_workspace`` from regressions.
+    """
+    ws_name = unique_workspace
+    app_name = f"WS_UPLOAD_APP_{uuid.uuid4().hex[:8]}"
+
+    project_dir = Path(temporary_working_directory)
+    (project_dir / "app" / "nested").mkdir(parents=True)
+    (project_dir / "app" / "main.py").write_text("print('hello from snowflake app')\n")
+    (project_dir / "app" / "nested" / "util.py").write_text("X = 1\n")
+
+    (project_dir / "snowflake.yml").write_text(
+        textwrap.dedent(
+            f"""\
+            definition_version: "2"
+            entities:
+              ws_app:
+                type: snowflake-app
+                identifier:
+                  name: {app_name}
+                  database: {DATABASE}
+                  schema: {SCHEMA}
+                artifacts:
+                  - src: app/*
+                    dest: ./
+                query_warehouse: {WAREHOUSE}
+                code_workspace:
+                  name: {ws_name}
+            """
+        )
+    )
+
+    result = runner.invoke_with_connection(
+        ["app", "deploy", "--entity-id", "ws_app", "--upload-only"]
+    )
+    assert result.exit_code == 0, f"Upload failed:\n{result.output}"
+
+    # The upload-only path reports the workspace destination on success, and
+    # prints one "Uploaded ..." line per file as each PUT completes — so both
+    # the top-level file and the nested file must appear.
+    assert "Artifacts uploaded to" in result.output
+    assert ws_name in result.output
+    assert "main.py" in result.output
+    assert os.path.join("nested", "util.py") in result.output


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

Improves error handling and fixes a Windows-only upload bug in the upload phase of `snow app deploy`.

**Clearer privilege errors during upload**

Previously, an insufficient-privilege failure (`3001 / 42501`) while preparing the code-storage backend bubbled out as a raw connector `ProgrammingError`. Both upload backends now catch `ProgrammingError` and raise an actionable `CliError` that reports:
- the failed action (e.g. "create stage" / "clear existing stage", "create workspace" / "clear workspace files"),
- the object involved,
- the active role (with a "your role" fallback when it cannot be resolved), and
- the required privileges (`USAGE` on the database and schema, plus the action-specific privilege).

This covers both the stage flow (`snowflake_app.upload.prepare_stage`) and the workspace flow (`snowflake_app.upload.prepare_workspace`).

**Windows workspace upload fix (connector error 253006)**

The workspace upload built the local `PUT` source URI as `file://{Path.resolve().as_posix()}`. On Windows this produced `file://C:/...` (the drive letter is parsed as the URI authority), which the connector rejects with `253006 ER_FILE_NOT_EXISTS` even though the file exists locally. The URI is now built from the native path using the same escaping rules as the stage manager (`_local_path_to_file_uri`), producing a valid URI on Windows and POSIX alike.
