### PR TITLE
Snowflake Apps: skip system-default parameters in fetch_snow_apps_parameters

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* Fixed `snow app setup` incorrectly treating system-default parameter values as admin-configured values. After running `ALTER ACCOUNT UNSET` on `DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL` or `DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL`, those fields no longer appear in the generated `snowflake.yml` or `--dry-run` output.
 * Upgraded `pip` from 26.1.1 to 26.1.2.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
 * The `build_eai` field of a `snowflake-app` entity can now be specified as a bare string (e.g. `build_eai: MY_EAI`) in addition to the existing `build_eai:\n  name: MY_EAI` object form.

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -1093,8 +1093,15 @@ class SnowflakeAppManager(SqlExecutionMixin):
             for row in cursor:
                 param_name = (row.get("key") or row.get("KEY") or "").upper()
                 param_value = row.get("value") or row.get("VALUE") or ""
+                # Skip parameters at the system-default level. Snowflake
+                # returns an empty string for ``level`` when a parameter has
+                # never been explicitly set at the account or user level;
+                # a non-empty ``value`` in that case is merely the built-in
+                # default (e.g. ``SYSTEM_COMPUTE_POOL_CPU``) and should not
+                # be treated as an admin-configured value.
+                param_level = row.get("level") or row.get("LEVEL") or ""
                 mapped_key = _SNOW_APPS_PARAM_MAP.get(param_name)
-                if mapped_key and param_value:
+                if mapped_key and param_value and param_level:
                     result[mapped_key] = param_value
             return result
         except ProgrammingError:

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2074,26 +2074,35 @@ class TestFetchSnowAppsParameters:
         cursor.__iter__ = Mock(
             return_value=iter(
                 [
-                    {"key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "value": "MY_WH"},
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE",
+                        "value": "MY_WH",
+                        "level": "ACCOUNT",
+                    },
                     {
                         "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
                         "value": "MY_POOL",
+                        "level": "ACCOUNT",
                     },
                     {
                         "key": "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL",
                         "value": "SVC_POOL",
+                        "level": "ACCOUNT",
                     },
                     {
                         "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION",
                         "value": "MY_EAI",
+                        "level": "ACCOUNT",
                     },
                     {
                         "key": "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE",
                         "value": "MY_DB",
+                        "level": "ACCOUNT",
                     },
                     {
                         "key": "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA",
                         "value": "MY_SCHEMA",
+                        "level": "ACCOUNT",
                     },
                 ]
             )
@@ -2117,8 +2126,16 @@ class TestFetchSnowAppsParameters:
         cursor.__iter__ = Mock(
             return_value=iter(
                 [
-                    {"key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "value": "MY_WH"},
-                    {"key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL", "value": ""},
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE",
+                        "value": "MY_WH",
+                        "level": "ACCOUNT",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
+                        "value": "",
+                        "level": "ACCOUNT",
+                    },
                 ]
             )
         )
@@ -2133,8 +2150,16 @@ class TestFetchSnowAppsParameters:
         cursor.__iter__ = Mock(
             return_value=iter(
                 [
-                    {"key": "DEFAULT_SNOWFLAKE_APPS_UNKNOWN_PARAM", "value": "FOO"},
-                    {"key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "value": "MY_WH"},
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_UNKNOWN_PARAM",
+                        "value": "FOO",
+                        "level": "ACCOUNT",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE",
+                        "value": "MY_WH",
+                        "level": "ACCOUNT",
+                    },
                 ]
             )
         )
@@ -2163,12 +2188,53 @@ class TestFetchSnowAppsParameters:
         cursor = Mock()
         cursor.__iter__ = Mock(
             return_value=iter(
-                [{"KEY": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE", "VALUE": "MY_WH"}]
+                [
+                    {
+                        "KEY": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE",
+                        "VALUE": "MY_WH",
+                        "LEVEL": "ACCOUNT",
+                    }
+                ]
             )
         )
         mock_execute.return_value = cursor
         result = SnowflakeAppManager().fetch_snow_apps_parameters()
         assert result == {"query_warehouse": "MY_WH"}
+
+    @patch(EXECUTE_QUERY)
+    def test_ignores_system_default_level_parameters(self, mock_execute):
+        """Parameters with an empty level are system defaults, not explicitly
+        configured values, and must be ignored even when value is non-empty."""
+        cursor = Mock()
+        cursor.__iter__ = Mock(
+            return_value=iter(
+                [
+                    # level="" means Snowflake is reporting the built-in default
+                    # (e.g. after ALTER ACCOUNT UNSET). Should be skipped.
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
+                        "value": "SYSTEM_COMPUTE_POOL_CPU",
+                        "level": "",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL",
+                        "value": "SYSTEM_COMPUTE_POOL_CPU",
+                        "level": "",
+                    },
+                    # Explicitly set at account level — should be included.
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE",
+                        "value": "MY_WH",
+                        "level": "ACCOUNT",
+                    },
+                ]
+            )
+        )
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {"query_warehouse": "MY_WH"}
+        assert "build_compute_pool" not in result
+        assert "service_compute_pool" not in result
 
 
 # ── is_managed_compute_pool_enabled tests ─────────────────────────────


### PR DESCRIPTION
## Summary

- `SHOW PARAMETERS` returns a non-empty `value` with an empty `level` when a parameter has never been explicitly set (system default). The CLI was treating these as admin-configured values, causing `build_compute_pool` and `service_compute_pool` to appear in `snow app setup --dry-run` output even after `ALTER ACCOUNT UNSET`.
- Fix: skip rows where `level` is empty in `fetch_snow_apps_parameters`. Only `ACCOUNT` or `USER` level values are treated as explicitly configured.
- Updated existing tests to include `level` in mock cursor rows; added `test_ignores_system_default_level_parameters` to cover the regression directly.

## Test plan

- [x] `uv run pytest tests/apps/test_commands.py::TestFetchSnowAppsParameters` passes (7/7)
- [x] Run `snow app setup --dry-run` on an account where compute pool params have been unset: neither field should appear in output

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)