### PR TITLE
Add --no-prompt-exit-repl option to snow sql REPL

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ## Deprecations
 
 ## New additions
+* Added `--no-prompt-exit-repl` option and configuration setting to skip the exit confirmation prompt in the SQL REPL.
 
 ## Fixes and improvements
 * Upgraded `pip` from 26.1.1 to 26.1.2.

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -29,6 +29,7 @@ from snowflake.cli.api.commands.flags import (
 )
 from snowflake.cli.api.commands.overrideable_parameter import OverrideableOption
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
+from snowflake.cli.api.config import get_config_value
 from snowflake.cli.api.exceptions import CliArgumentError
 from snowflake.cli.api.output.types import (
     CommandResult,
@@ -135,10 +136,12 @@ def execute_sql(
         ),
         is_flag=True,
     ),
-    no_prompt_exit: bool = typer.Option(
-        False,
+    no_prompt_exit: Optional[bool] = typer.Option(
+        None,
         "--no-prompt-exit",
         help="Do not prompt before exiting.",
+        envvar="SNOWFLAKE_NO_PROMPT_EXIT",
+        show_default=False,
     ),
     **options,
 ) -> CommandResult:
@@ -163,6 +166,9 @@ def execute_sql(
     single_transaction = bool(single_transaction)
     std_in = bool(std_in)
     local_only = bool(local_only)
+
+    if no_prompt_exit is None:
+        no_prompt_exit = get_config_value("cli", key="no_prompt_exit", default=False)
 
     no_source_provided = not any([query, files, std_in])
     if no_source_provided and not sys.stdin.isatty():

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -139,7 +139,7 @@ def execute_sql(
     no_prompt_exit_repl: Optional[bool] = typer.Option(
         None,
         "--no-prompt-exit-repl",
-        help="Do not prompt before exiting.",
+        help="Do not prompt before exiting the REPL.",
         envvar="SNOWFLAKE_NO_PROMPT_EXIT_REPL",
         show_default=False,
     ),

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -136,11 +136,11 @@ def execute_sql(
         ),
         is_flag=True,
     ),
-    no_prompt_exit: Optional[bool] = typer.Option(
+    no_prompt_exit_repl: Optional[bool] = typer.Option(
         None,
-        "--no-prompt-exit",
+        "--no-prompt-exit-repl",
         help="Do not prompt before exiting.",
-        envvar="SNOWFLAKE_NO_PROMPT_EXIT",
+        envvar="SNOWFLAKE_NO_PROMPT_EXIT_REPL",
         show_default=False,
     ),
     **options,
@@ -167,8 +167,10 @@ def execute_sql(
     std_in = bool(std_in)
     local_only = bool(local_only)
 
-    if no_prompt_exit is None:
-        no_prompt_exit = get_config_value("cli", key="no_prompt_exit", default=False)
+    if no_prompt_exit_repl is None:
+        no_prompt_exit_repl = get_config_value(
+            "cli", key="no_prompt_exit_repl", default=False
+        )
 
     no_source_provided = not any([query, files, std_in])
     if no_source_provided and not sys.stdin.isatty():
@@ -188,7 +190,7 @@ def execute_sql(
             retain_comments=retain_comments,
             template_syntax_config=template_syntax_config,
             local_only=local_only,
-            no_prompt_exit=no_prompt_exit,
+            no_prompt_exit_repl=no_prompt_exit_repl,
         ).run()
         sys.exit(0)
 

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -29,7 +29,7 @@ from snowflake.cli.api.commands.flags import (
 )
 from snowflake.cli.api.commands.overrideable_parameter import OverrideableOption
 from snowflake.cli.api.commands.snow_typer import SnowTyperFactory
-from snowflake.cli.api.config import get_config_value
+from snowflake.cli.api.config import get_config_bool_value
 from snowflake.cli.api.exceptions import CliArgumentError
 from snowflake.cli.api.output.types import (
     CommandResult,
@@ -140,7 +140,6 @@ def execute_sql(
         None,
         "--no-prompt-exit-repl",
         help="Do not prompt before exiting the REPL.",
-        envvar="SNOWFLAKE_NO_PROMPT_EXIT_REPL",
         show_default=False,
     ),
     **options,
@@ -168,7 +167,7 @@ def execute_sql(
     local_only = bool(local_only)
 
     if no_prompt_exit_repl is None:
-        no_prompt_exit_repl = get_config_value(
+        no_prompt_exit_repl = get_config_bool_value(
             "cli", key="no_prompt_exit_repl", default=False
         )
 

--- a/src/snowflake/cli/_plugins/sql/commands.py
+++ b/src/snowflake/cli/_plugins/sql/commands.py
@@ -135,6 +135,11 @@ def execute_sql(
         ),
         is_flag=True,
     ),
+    no_prompt_exit: bool = typer.Option(
+        False,
+        "--no-prompt-exit",
+        help="Do not prompt before exiting.",
+    ),
     **options,
 ) -> CommandResult:
     """
@@ -177,6 +182,7 @@ def execute_sql(
             retain_comments=retain_comments,
             template_syntax_config=template_syntax_config,
             local_only=local_only,
+            no_prompt_exit=no_prompt_exit,
         ).run()
         sys.exit(0)
 

--- a/src/snowflake/cli/_plugins/sql/repl.py
+++ b/src/snowflake/cli/_plugins/sql/repl.py
@@ -61,6 +61,7 @@ class Repl:
         retain_comments: bool = False,
         template_syntax_config: SQLTemplateSyntaxConfig = SQLTemplateSyntaxConfig(),
         local_only: bool = False,
+        no_prompt_exit: bool = False,
     ):
         """Requires a `SqlManager` instance to execute queries.
 
@@ -74,6 +75,7 @@ class Repl:
         self._retain_comments = retain_comments
         self._template_syntax_config = template_syntax_config
         self._local_only = local_only
+        self._no_prompt_exit = no_prompt_exit
         self._history = FileHistory(_get_history_file())
         self._lexer = PygmentsLexer(CliLexer)
         self._completer = cli_completer
@@ -196,17 +198,6 @@ class Repl:
             if self._next_input == default_text:
                 self._next_input = None
 
-    def yn_prompt(self, msg: str) -> str:
-        """Yes/No prompt."""
-        return self.session.prompt(
-            msg,
-            lexer=None,
-            completer=None,
-            multiline=False,
-            wrap_lines=False,
-            key_bindings=self._yes_no_keybindings,
-        )
-
     @property
     def _welcome_banner(self) -> str:
         return "Welcome to Snowflake-CLI REPL\nType 'exit' or 'quit' to leave"
@@ -274,9 +265,10 @@ class Repl:
 
             except EOFError:  # a.k.a Ctrl-D
                 log.debug("user interrupted with Ctrl-D")
-                should_exit = self.ask_yn("Do you want to leave?")
-                log.debug("user answered: %r", should_exit)
-                if should_exit:
+
+                if self._no_prompt_exit:
+                    raise EOFError
+                elif self.ask_yn("Do you want to leave?"):
                     raise EOFError
                 continue
 
@@ -304,7 +296,14 @@ class Repl:
         try:
             while True:
                 log.debug("asking user: %s", question)
-                answer = self.yn_prompt(f"{question} (y/n): ")
+                answer = self.session.prompt(
+                    f"{question} (y/n): ",
+                    lexer=None,
+                    completer=None,
+                    multiline=False,
+                    wrap_lines=False,
+                    key_bindings=self._yes_no_keybindings,
+                )
                 log.debug("user answered: %s", answer)
 
                 return answer == "y"

--- a/src/snowflake/cli/_plugins/sql/repl.py
+++ b/src/snowflake/cli/_plugins/sql/repl.py
@@ -61,7 +61,7 @@ class Repl:
         retain_comments: bool = False,
         template_syntax_config: SQLTemplateSyntaxConfig = SQLTemplateSyntaxConfig(),
         local_only: bool = False,
-        no_prompt_exit: bool = False,
+        no_prompt_exit_repl: bool = False,
     ):
         """Requires a `SqlManager` instance to execute queries.
 
@@ -75,7 +75,7 @@ class Repl:
         self._retain_comments = retain_comments
         self._template_syntax_config = template_syntax_config
         self._local_only = local_only
-        self._no_prompt_exit = no_prompt_exit
+        self._no_prompt_exit_repl = no_prompt_exit_repl
         self._history = FileHistory(_get_history_file())
         self._lexer = PygmentsLexer(CliLexer)
         self._completer = cli_completer
@@ -266,7 +266,7 @@ class Repl:
             except EOFError:  # a.k.a Ctrl-D
                 log.debug("user interrupted with Ctrl-D")
 
-                if self._no_prompt_exit:
+                if self._no_prompt_exit_repl:
                     raise EOFError
                 elif self.ask_yn("Do you want to leave?"):
                     raise EOFError

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -21973,83 +21973,98 @@
    The command supports variable substitution that happens on client-side.        
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --query           -q                      TEXT             Query to execute. |
-  | --filename        -f                      FILE             File to execute.  |
-  | --stdin           -i                                       Read the query    |
-  |                                                            from standard     |
-  |                                                            input. Use it     |
-  |                                                            when piping input |
-  |                                                            to this command.  |
-  | --variable        -D                      TEXT             String in format  |
-  |                                                            of key=value. If  |
-  |                                                            provided the SQL  |
-  |                                                            content will be   |
-  |                                                            treated as        |
-  |                                                            template and      |
-  |                                                            rendered using    |
-  |                                                            provided data.    |
-  | --retain-commen…                                           Retains comments  |
-  |                                                            in queries passed |
-  |                                                            to Snowflake      |
-  | --single-transa…      --no-single-tra…                     Connects with     |
-  |                                                            autocommit        |
-  |                                                            disabled. Wraps   |
-  |                                                            BEGIN/COMMIT      |
-  |                                                            around statements |
-  |                                                            to execute them   |
-  |                                                            as a single       |
-  |                                                            transaction,      |
-  |                                                            ensuring all      |
-  |                                                            commands complete |
-  |                                                            successfully or   |
-  |                                                            no change is      |
-  |                                                            applied.          |
-  |                                                            [default:         |
-  |                                                            no-single-transa… |
-  | --enable-templa…                          [LEGACY|STANDAR  Syntax used to    |
-  |                                           D|JINJA|ALL|NON  resolve variables |
-  |                                           E]               before passing    |
-  |                                                            queries to        |
-  |                                                            Snowflake.        |
-  |                                                            [default: LEGACY, |
-  |                                                            STANDARD]         |
-  | --local-only                                               Restrict !source  |
-  |                                                            and !load to      |
-  |                                                            local files. When |
-  |                                                            set,              |
-  |                                                            !source/!load     |
-  |                                                            directives that   |
-  |                                                            reference http:// |
-  |                                                            or https:// URLs  |
-  |                                                            are rejected      |
-  |                                                            instead of being  |
-  |                                                            fetched. Use this |
-  |                                                            flag in           |
-  |                                                            environments      |
-  |                                                            where SQL inputs  |
-  |                                                            should not        |
-  |                                                            trigger outbound  |
-  |                                                            network requests, |
-  |                                                            or when running   |
-  |                                                            SQL files whose   |
-  |                                                            content should be |
-  |                                                            reviewed locally  |
-  |                                                            before execution. |
-  | --project         -p                      TEXT             Path where the    |
-  |                                                            Snowflake project |
-  |                                                            is stored.        |
-  |                                                            Defaults to the   |
-  |                                                            current working   |
-  |                                                            directory.        |
-  | --env                                     TEXT             String in the     |
-  |                                                            format key=value. |
-  |                                                            Overrides         |
-  |                                                            variables from    |
-  |                                                            the env section   |
-  |                                                            used for          |
-  |                                                            templates.        |
-  | --help            -h                                       Show this message |
-  |                                                            and exit.         |
+  | --query            -q                     TEXT              Query to         |
+  |                                                             execute.         |
+  | --filename         -f                     FILE              File to execute. |
+  | --stdin            -i                                       Read the query   |
+  |                                                             from standard    |
+  |                                                             input. Use it    |
+  |                                                             when piping      |
+  |                                                             input to this    |
+  |                                                             command.         |
+  | --variable         -D                     TEXT              String in format |
+  |                                                             of key=value. If |
+  |                                                             provided the SQL |
+  |                                                             content will be  |
+  |                                                             treated as       |
+  |                                                             template and     |
+  |                                                             rendered using   |
+  |                                                             provided data.   |
+  | --retain-comments                                           Retains comments |
+  |                                                             in queries       |
+  |                                                             passed to        |
+  |                                                             Snowflake        |
+  | --single-transac…      --no-single-tr…                      Connects with    |
+  |                                                             autocommit       |
+  |                                                             disabled. Wraps  |
+  |                                                             BEGIN/COMMIT     |
+  |                                                             around           |
+  |                                                             statements to    |
+  |                                                             execute them as  |
+  |                                                             a single         |
+  |                                                             transaction,     |
+  |                                                             ensuring all     |
+  |                                                             commands         |
+  |                                                             complete         |
+  |                                                             successfully or  |
+  |                                                             no change is     |
+  |                                                             applied.         |
+  |                                                             [default:        |
+  |                                                             no-single-trans… |
+  | --enable-templat…                         [LEGACY|STANDARD  Syntax used to   |
+  |                                           |JINJA|ALL|NONE]  resolve          |
+  |                                                             variables before |
+  |                                                             passing queries  |
+  |                                                             to Snowflake.    |
+  |                                                             [default:        |
+  |                                                             LEGACY,          |
+  |                                                             STANDARD]        |
+  | --local-only                                                Restrict !source |
+  |                                                             and !load to     |
+  |                                                             local files.     |
+  |                                                             When set,        |
+  |                                                             !source/!load    |
+  |                                                             directives that  |
+  |                                                             reference        |
+  |                                                             http:// or       |
+  |                                                             https:// URLs    |
+  |                                                             are rejected     |
+  |                                                             instead of being |
+  |                                                             fetched. Use     |
+  |                                                             this flag in     |
+  |                                                             environments     |
+  |                                                             where SQL inputs |
+  |                                                             should not       |
+  |                                                             trigger outbound |
+  |                                                             network          |
+  |                                                             requests, or     |
+  |                                                             when running SQL |
+  |                                                             files whose      |
+  |                                                             content should   |
+  |                                                             be reviewed      |
+  |                                                             locally before   |
+  |                                                             execution.       |
+  | --no-prompt-exit…                                           Do not prompt    |
+  |                                                             before exiting   |
+  |                                                             the REPL.        |
+  | --project          -p                     TEXT              Path where the   |
+  |                                                             Snowflake        |
+  |                                                             project is       |
+  |                                                             stored. Defaults |
+  |                                                             to the current   |
+  |                                                             working          |
+  |                                                             directory.       |
+  | --env                                     TEXT              String in the    |
+  |                                                             format           |
+  |                                                             key=value.       |
+  |                                                             Overrides        |
+  |                                                             variables from   |
+  |                                                             the env section  |
+  |                                                             used for         |
+  |                                                             templates.       |
+  | --help             -h                                       Show this        |
+  |                                                             message and      |
+  |                                                             exit.            |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/sql/test_repl.py
+++ b/tests/sql/test_repl.py
@@ -562,16 +562,16 @@ class TestReplPasteHandling:
     "command_args, env_var, config_value, ask_yn_called",
     [
         # test command arg
-        (["--no-prompt-exit-repl"], {}, False, False),
+        (["--no-prompt-exit-repl"], {}, {}, False),
         # test env var
-        ([], {"SNOWFLAKE_CLI_NO_PROMPT_EXIT_REPL": "true"}, False, False),
+        ([], {"SNOWFLAKE_CLI_NO_PROMPT_EXIT_REPL": "true"}, {}, False),
         # test config value
-        ([], {}, True, False),
+        ([], {}, {"no_prompt_exit_repl": "true"}, False),
         # test default
-        ([], {}, False, True),
+        ([], {}, {}, True),
     ],
 )
-@mock.patch("snowflake.cli._plugins.sql.commands.get_config_bool_value")
+@mock.patch("snowflake.cli.api.config.get_config_section")
 @mock.patch("snowflake.cli._plugins.sql.repl.Repl.ask_yn")
 @mock.patch("snowflake.cli._plugins.sql.repl.Repl.repl_prompt")
 @mock.patch("snowflake.cli._plugins.sql.repl.Repl._initialize_connection")
@@ -579,16 +579,16 @@ def test_no_prompt_exit_repl(
     mock__initialize_connection,
     mock_repl_prompt,
     mock_ask_yn,
-    mock_get_config_bool_value,
+    mock_get_config_section,
     runner,
     command_args,
     env_var,
     config_value,
     ask_yn_called,
 ):
-    mock_ask_yn.return_value = True
     mock_repl_prompt.side_effect = EOFError
-    mock_get_config_bool_value.return_value = config_value
+    mock_ask_yn.return_value = True
+    mock_get_config_section.return_value = config_value
 
     with mock.patch.dict(os.environ, env_var):
         runner.invoke(["sql", *command_args])

--- a/tests/sql/test_repl.py
+++ b/tests/sql/test_repl.py
@@ -564,14 +564,14 @@ class TestReplPasteHandling:
         # test command arg
         (["--no-prompt-exit-repl"], {}, False, False),
         # test env var
-        ([], {"SNOWFLAKE_NO_PROMPT_EXIT_REPL": "true"}, False, False),
+        ([], {"SNOWFLAKE_CLI_NO_PROMPT_EXIT_REPL": "true"}, False, False),
         # test config value
         ([], {}, True, False),
         # test default
         ([], {}, False, True),
     ],
 )
-@mock.patch("snowflake.cli._plugins.sql.commands.get_config_value")
+@mock.patch("snowflake.cli._plugins.sql.commands.get_config_bool_value")
 @mock.patch("snowflake.cli._plugins.sql.repl.Repl.ask_yn")
 @mock.patch("snowflake.cli._plugins.sql.repl.Repl.repl_prompt")
 @mock.patch("snowflake.cli._plugins.sql.repl.Repl._initialize_connection")
@@ -579,7 +579,7 @@ def test_no_prompt_exit_repl(
     mock__initialize_connection,
     mock_repl_prompt,
     mock_ask_yn,
-    mock_get_config_value,
+    mock_get_config_bool_value,
     runner,
     command_args,
     env_var,
@@ -588,7 +588,7 @@ def test_no_prompt_exit_repl(
 ):
     mock_ask_yn.return_value = True
     mock_repl_prompt.side_effect = EOFError
-    mock_get_config_value.return_value = config_value
+    mock_get_config_bool_value.return_value = config_value
 
     with mock.patch.dict(os.environ, env_var):
         runner.invoke(["sql", *command_args])

--- a/tests/sql/test_repl.py
+++ b/tests/sql/test_repl.py
@@ -556,3 +556,41 @@ class TestReplPasteHandling:
         enter_handler(enter_event)
 
         buffer.validate_and_handle.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "command_args, env_var, config_value, ask_yn_called",
+    [
+        # test command arg
+        (["--no-prompt-exit-repl"], {}, False, False),
+        # test env var
+        ([], {"SNOWFLAKE_NO_PROMPT_EXIT_REPL": "true"}, False, False),
+        # test config value
+        ([], {}, True, False),
+        # test default
+        ([], {}, False, True),
+    ],
+)
+@mock.patch("snowflake.cli._plugins.sql.commands.get_config_value")
+@mock.patch("snowflake.cli._plugins.sql.repl.Repl.ask_yn")
+@mock.patch("snowflake.cli._plugins.sql.repl.Repl.repl_prompt")
+@mock.patch("snowflake.cli._plugins.sql.repl.Repl._initialize_connection")
+def test_no_prompt_exit_repl(
+    mock__initialize_connection,
+    mock_repl_prompt,
+    mock_ask_yn,
+    mock_get_config_value,
+    runner,
+    command_args,
+    env_var,
+    config_value,
+    ask_yn_called,
+):
+    mock_ask_yn.return_value = True
+    mock_repl_prompt.side_effect = EOFError
+    mock_get_config_value.return_value = config_value
+
+    with mock.patch.dict(os.environ, env_var):
+        runner.invoke(["sql", *command_args])
+
+    assert mock_ask_yn.called is ask_yn_called


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
Community contribution from @remisalmon (cherry-picked from #2758, preserving original authorship).

Closes #2758