### PR TITLE
Snowflake Apps: hide compute pool option/fields

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* The `snow app setup` `--compute-pool` option and the `build_compute_pool` / `service_compute_pool` fields of a `snowflake-app` entity are now hidden and undocumented (omitted from `--help` and the generated project-definition JSON schema). They remain fully functional: `snow app setup` and `snow app deploy` still honor the `DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL` / `DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL` account parameters and any compute pools configured in `snowflake.yml`. The `ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL` and `ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK` parameter checks (and the related deploy-time warning) have been removed.
 * Upgraded `pip` from 26.1.1 to 26.1.2.
 * `snow app setup` and `snow app deploy` now default to a workspace (instead of a stage) for app code whenever the resolved destination is a personal database (`USER$<user>`), which do not support stages. An explicitly configured `code_stage` is still honored, with a warning when the destination is a personal database.
 * Fixed `snow app deploy` failing on Windows when uploading app code to a workspace (connector error `253006`, `ER_FILE_NOT_EXISTS`) due to a malformed local file URI.

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -229,7 +229,6 @@ def snowflake_app_setup(
         # Drop the account-configured destination database/schema the current
         # role cannot access so resolution falls back to the personal database.
         params = _filter_accessible_remote_defaults(manager, params)
-        managed_compute_pool_enabled = manager.is_managed_compute_pool_enabled()
 
     def _resolve(
         user_input=None,
@@ -299,28 +298,18 @@ def snowflake_app_setup(
             account_param=params.get("query_warehouse"),
             current_session=session_wh,
         ),
-        # TODO: Consider removing --compute-pool argument once services can run
-        # in the system default compute pool (SYSTEM_COMPUTE_POOL_CPU).
-        # When the backend opts the account into managed compute pools we
-        # deliberately skip resolving both ``build_compute_pool`` and
-        # ``service_compute_pool`` so the fields are omitted from the
-        # generated ``snowflake.yml`` and the server picks the pools at
-        # deploy time.
-        "build_compute_pool": (
-            (None, SOURCE_MISSING)
-            if managed_compute_pool_enabled
-            else _resolve(
-                user_input=compute_pool,
-                account_param=params.get("build_compute_pool"),
-            )
+        # Compute pools are resolved from the (hidden) ``--compute-pool`` flag
+        # and the ``DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL`` /
+        # ``DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL`` account parameters.
+        # Both stay omitted from the generated ``snowflake.yml`` when neither
+        # source provides a value, letting the server pick pools at deploy time.
+        "build_compute_pool": _resolve(
+            user_input=compute_pool,
+            account_param=params.get("build_compute_pool"),
         ),
-        "service_compute_pool": (
-            (None, SOURCE_MISSING)
-            if managed_compute_pool_enabled
-            else _resolve(
-                user_input=compute_pool,
-                account_param=params.get("service_compute_pool"),
-            )
+        "service_compute_pool": _resolve(
+            user_input=compute_pool,
+            account_param=params.get("service_compute_pool"),
         ),
         # TODO: Remove --build-eai argument once the builder service no longer
         # requires an external access integration.
@@ -636,33 +625,12 @@ def snowflake_app_deploy(
     storage_schema_override = storage.schema_override
     encryption_type = storage.encryption_type
 
-    # User-supplied compute pools are always passed through to the server
-    # (forwarded as the 4th argument to
+    # Compute pools resolved from ``snowflake.yml`` or the
+    # ``DEFAULT_SNOWFLAKE_APPS_*_COMPUTE_POOL`` account parameters are passed
+    # through to the server: forwarded as the 4th argument to
     # ``SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`` and emitted as
-    # ``IN COMPUTE POOL`` in ``CREATE APPLICATION SERVICE``).  However, when
-    # the account has managed compute pools enforced
-    # (``ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL`` is true and the
-    # companion ``..._FALLBACK`` parameter is false), the server may
-    # reject or override those values.  In that case we warn the user up
-    # front so they know why the deploy might not behave as configured.
-    if (
-        (build_compute_pool or service_compute_pool)
-        and manager.is_managed_compute_pool_enabled()
-        and not manager.is_managed_compute_pool_fallback_enabled()
-    ):
-        if build_compute_pool:
-            cli_console.warning(
-                f"build_compute_pool '{build_compute_pool}' is configured "
-                "but managed compute pools are enforced for this account; "
-                "the server may not honor this value."
-            )
-        if service_compute_pool:
-            cli_console.warning(
-                f"service_compute_pool '{service_compute_pool}' is configured "
-                "but managed compute pools are enforced for this account; "
-                "the server may not honor this value."
-            )
-
+    # ``IN COMPUTE POOL`` in ``CREATE APPLICATION SERVICE``. When neither
+    # source provides a value the server allocates the pools itself.
     ar_name = defaults["artifact_repository"]
     ar_database = defaults["artifact_repo_database"]
     ar_schema = defaults["artifact_repo_schema"]

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -30,11 +30,9 @@ def _generate_snowflake_yml(
 
     Optional keys: ``build_compute_pool``, ``service_compute_pool``,
     ``build_eai``.  When omitted or ``None`` the corresponding block is left
-    out of the generated YAML.  ``build_compute_pool`` and
-    ``service_compute_pool`` should both be omitted when the backend opts
-    the account into managed compute pools (see
-    :data:`MANAGED_COMPUTE_POOL_PARAM`).  ``build_eai`` is omitted when no
-    external access integration is required by the builder service.
+    out of the generated YAML, letting the server allocate compute pools at
+    deploy time.  ``build_eai`` is omitted when no external access
+    integration is required by the builder service.
 
     The artifact repository is omitted from the generated YAML; the CLI
     will default to ``<app-id>_REPO`` at deploy time.

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -167,23 +167,6 @@ _SNOW_APPS_PARAM_MAP = {
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA": "schema",
 }
 
-# Backend parameter that opts an account into Snowflake-managed build compute
-# pools.  When enabled, the CLI omits ``build_compute_pool`` from generated
-# project files and forwards an empty string to
-# ``SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`` so the server allocates a
-# managed pool on the user's behalf.
-MANAGED_COMPUTE_POOL_PARAM = "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL"
-
-# Companion to :data:`MANAGED_COMPUTE_POOL_PARAM`. When the managed-pool
-# parameter is on, this parameter controls whether the server falls back to
-# user-specified compute pools (``true``) or strictly enforces the managed
-# pool (``false``). The CLI uses it to decide whether to honor or strip
-# ``build_compute_pool`` / ``service_compute_pool`` values supplied via
-# ``snowflake.yml`` during ``snow app deploy``.
-MANAGED_COMPUTE_POOL_FALLBACK_PARAM = (
-    "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK"
-)
-
 # Artifact-repo build jobs run as SPCS job services. The container/instance to
 # read logs from is resolved at runtime via ``SHOW SERVICE CONTAINERS IN
 # SERVICE``; when a service exposes multiple containers the one named ``builder``
@@ -1065,46 +1048,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
         """
         desc = self.describe_app_service(service_fqn)
         return self.resolve_application_service_url_from_describe(desc)
-
-    def _is_boolean_param_true(self, param_name: str) -> bool:
-        """Return True when the named boolean backend parameter is set to
-        ``"true"`` for the current session.
-
-        The check is intentionally tolerant: any error (e.g. the parameter
-        is not exposed to the current role) and any unset/non-true value
-        return ``False`` so callers fall back to the conservative default.
-        """
-        try:
-            cursor = self.execute_query(
-                f"SHOW PARAMETERS LIKE '{param_name}'",
-                cursor_class=DictCursor,
-            )
-            for row in cursor:
-                value = (row.get("value") or row.get("VALUE") or "").strip().lower()
-                return value == "true"
-            return False
-        except ProgrammingError:
-            return False
-
-    def is_managed_compute_pool_enabled(self) -> bool:
-        """Return True when the backend parameter
-        :data:`MANAGED_COMPUTE_POOL_PARAM` is set to ``"true"`` for the
-        current session.
-        """
-        return self._is_boolean_param_true(MANAGED_COMPUTE_POOL_PARAM)
-
-    def is_managed_compute_pool_fallback_enabled(self) -> bool:
-        """Return True when the backend parameter
-        :data:`MANAGED_COMPUTE_POOL_FALLBACK_PARAM` is set to ``"true"`` for
-        the current session.
-
-        When this is true (and managed pools are enabled), the server honors
-        user-specified compute pools as a fallback to the managed pool, so
-        the CLI passes ``snowflake.yml`` values through unchanged. When
-        false (the default), the server enforces the managed pool and the
-        CLI strips any user-specified pools with a warning.
-        """
-        return self._is_boolean_param_true(MANAGED_COMPUTE_POOL_FALLBACK_PARAM)
 
     def fetch_snow_apps_parameters(self) -> Dict[str, str]:
         """Fetch Snowflake App Runtime default parameters for the current user.

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -15,6 +15,7 @@
 from typing import Literal, Optional, Union
 
 from pydantic import Field, field_validator, model_validator
+from pydantic.json_schema import SkipJsonSchema
 from snowflake.cli.api.project.schemas.entities.common import (
     EntityModelBaseWithArtifacts,
     MetaField,
@@ -121,11 +122,16 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
         title="Warehouse to use for queries", default=None
     )
 
-    build_compute_pool: Union[ComputePoolReference, None] = Field(
+    # ``build_compute_pool`` and ``service_compute_pool`` remain fully
+    # functional (still parsed from ``snowflake.yml`` and forwarded to the
+    # server when present), but are intentionally hidden/undocumented:
+    # ``SkipJsonSchema`` excludes them from the generated project-definition
+    # JSON schema so editor completion and docs do not advertise them.
+    build_compute_pool: SkipJsonSchema[Union[ComputePoolReference, None]] = Field(
         title="Compute pool for building the app", default=None
     )
 
-    service_compute_pool: Union[ComputePoolReference, None] = Field(
+    service_compute_pool: SkipJsonSchema[Union[ComputePoolReference, None]] = Field(
         title="Compute pool for running the app service", default=None
     )
 

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -169,6 +169,7 @@ def app_setup(
         None,
         "--compute-pool",
         help="Compute pool for building and running the app.",
+        hidden=True,
     ),
     build_eai: Optional[str] = typer.Option(
         None,

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -3339,15 +3339,13 @@
    does not apply to Native App projects.                                         
                                                                                   
   +- Options --------------------------------------------------------------------+
-  | --app-name              TEXT  Name of the Snowflake App Runtime to           |
-  |                               initialize. Defaults to the current directory  |
-  |                               name.                                          |
-  | --dry-run                     Only print the resolved configuration values   |
-  |                               without writing snowflake.yml.                 |
-  | --compute-pool          TEXT  Compute pool for building and running the app. |
-  | --build-eai             TEXT  External access integration used during the    |
-  |                               app build.                                     |
-  | --help          -h            Show this message and exit.                    |
+  | --app-name           TEXT  Name of the Snowflake App Runtime to initialize.  |
+  |                            Defaults to the current directory name.           |
+  | --dry-run                  Only print the resolved configuration values      |
+  |                            without writing snowflake.yml.                    |
+  | --build-eai          TEXT  External access integration used during the app   |
+  |                            build.                                            |
+  | --help       -h            Show this message and exit.                       |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+
   | --connection,--environment    -c      TEXT     Name of the connection, as    |

--- a/tests/app/test_telemetry.py
+++ b/tests/app/test_telemetry.py
@@ -498,7 +498,6 @@ class TestAppFlowTelemetryAttribution:
         """setup is Snowflake-Apps-only; must stamp snowflake_app directly."""
         mock_mgr = mock_manager.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {}
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
         mock_mgr.get_personal_database.return_value = None
 
         runner.invoke(

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -689,7 +689,7 @@ class TestGenerateSnowflakeYml:
         assert "query_warehouse: TEST_WH" in result
         assert "build_eai" in result
 
-    def test_managed_compute_pool_yml_is_valid_project_definition(self):
+    def test_yml_without_compute_pools_is_valid_project_definition(self):
         """A generated YAML without either compute-pool block still parses
         cleanly into a project definition."""
         import yaml
@@ -2224,129 +2224,6 @@ class TestFetchSnowAppsParameters:
         assert result == {"query_warehouse": "MY_WH"}
 
 
-# ── is_managed_compute_pool_enabled tests ─────────────────────────────
-
-
-class TestIsManagedComputePoolEnabled:
-    @pytest.mark.parametrize("value", ["true", "TRUE", "True"])
-    @patch(EXECUTE_QUERY)
-    def test_returns_true_when_param_is_true(self, mock_execute, value):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "key": "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL",
-                        "value": value,
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_enabled() is True
-        query = mock_execute.call_args[0][0]
-        assert "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL" in query
-
-    @pytest.mark.parametrize("value", ["false", "FALSE", "", "anything-else"])
-    @patch(EXECUTE_QUERY)
-    def test_returns_false_when_param_is_not_true(self, mock_execute, value):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "key": "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL",
-                        "value": value,
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_enabled() is False
-
-    @patch(EXECUTE_QUERY)
-    def test_returns_false_when_param_not_set(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(return_value=iter([]))
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_enabled() is False
-
-    @patch(EXECUTE_QUERY, side_effect=ProgrammingError("permission denied"))
-    def test_returns_false_on_error(self, mock_execute):
-        assert SnowflakeAppManager().is_managed_compute_pool_enabled() is False
-
-    @patch(EXECUTE_QUERY)
-    def test_handles_uppercase_column_names(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "KEY": "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL",
-                        "VALUE": "true",
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_enabled() is True
-
-
-# ── is_managed_compute_pool_fallback_enabled tests ────────────────────
-
-
-class TestIsManagedComputePoolFallbackEnabled:
-    @patch(EXECUTE_QUERY)
-    def test_returns_true_when_param_is_true(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "key": (
-                            "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK"
-                        ),
-                        "value": "true",
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_fallback_enabled() is True
-        query = mock_execute.call_args[0][0]
-        assert "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK" in query
-
-    @pytest.mark.parametrize("value", ["false", "FALSE", "", "anything-else"])
-    @patch(EXECUTE_QUERY)
-    def test_returns_false_when_param_is_not_true(self, mock_execute, value):
-        cursor = Mock()
-        cursor.__iter__ = Mock(
-            return_value=iter(
-                [
-                    {
-                        "key": (
-                            "ENABLE_APPLICATION_SERVICE_MANAGED_COMPUTE_POOL_FALLBACK"
-                        ),
-                        "value": value,
-                    }
-                ]
-            )
-        )
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_fallback_enabled() is False
-
-    @patch(EXECUTE_QUERY)
-    def test_returns_false_when_param_not_set(self, mock_execute):
-        cursor = Mock()
-        cursor.__iter__ = Mock(return_value=iter([]))
-        mock_execute.return_value = cursor
-        assert SnowflakeAppManager().is_managed_compute_pool_fallback_enabled() is False
-
-    @patch(EXECUTE_QUERY, side_effect=ProgrammingError("permission denied"))
-    def test_returns_false_on_error(self, mock_execute):
-        assert SnowflakeAppManager().is_managed_compute_pool_fallback_enabled() is False
-
-
 # ── _resolve_deploy_defaults tests ────────────────────────────────────
 
 
@@ -2866,8 +2743,6 @@ class TestSetupCommand:
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_init_creates_file(self, mock_mgr_cls, mock_gen, runner, tmp_path):
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2899,8 +2774,6 @@ class TestSetupCommand:
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2925,8 +2798,6 @@ class TestSetupCommand:
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2946,8 +2817,6 @@ class TestSetupCommand:
         self, mock_mgr_cls, runner, tmp_path
     ):
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2985,8 +2854,6 @@ class TestSetupCommand:
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_dry_run_does_not_create_file(self, mock_mgr_cls, runner, tmp_path):
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3013,8 +2880,6 @@ class TestSetupCommand:
         output should not emit the ``build_eai`` line (which would otherwise
         display ``build_eai: None  (missing)`` and imply it is required)."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3039,8 +2904,6 @@ class TestSetupCommand:
         import json as json_mod
 
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3083,8 +2946,6 @@ class TestSetupCommand:
         import json as json_mod
 
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3122,8 +2983,6 @@ class TestSetupCommand:
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3150,8 +3009,6 @@ class TestSetupCommand:
     def test_flags_beat_parameters(self, mock_mgr_cls, mock_gen, runner, tmp_path):
         """CLI flags should override Snowflake App Runtime parameters."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "build_compute_pool": "PARAM_POOL",
             "service_compute_pool": "PARAM_SVC_POOL",
@@ -3195,8 +3052,6 @@ class TestSetupCommand:
     ):
         """--warehouse CLI flag should override the account parameter and show 'user input' provenance."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3232,8 +3087,6 @@ class TestSetupCommand:
     ):
         """--database CLI flag should override the account parameter and show 'user input' provenance."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3271,8 +3124,6 @@ class TestSetupCommand:
     ):
         """Specifying --database without --schema should fail with a clear error."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3308,8 +3159,6 @@ class TestSetupCommand:
         """Specifying --schema without --database is allowed; the database is
         resolved from account parameters or the connection as usual."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3345,8 +3194,6 @@ class TestSetupCommand:
     ):
         """--schema CLI flag should override the account parameter and show 'user input' provenance."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3382,8 +3229,6 @@ class TestSetupCommand:
     ):
         """--warehouse, --database, and --schema flags should all override account parameters."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3421,8 +3266,6 @@ class TestSetupCommand:
         """--warehouse should prevent the 'Missing warehouse' error even when
         no account parameter or connection default is configured."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3451,8 +3294,6 @@ class TestSetupCommand:
         """--database should prevent the 'Missing database' error even when
         no account parameter, personal DB, or connection default is configured."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_personal_database.return_value = None
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "schema": "PARAM_SCHEMA",
@@ -3487,8 +3328,6 @@ class TestSetupCommand:
     ):
         """Resolved values from Snowflake App Runtime parameters should show 'account parameter' provenance."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "query_warehouse": "PARAM_WH",
             "build_compute_pool": "PARAM_POOL",
@@ -3515,8 +3354,6 @@ class TestSetupCommand:
     ):
         """When no param/session db is set, fall back to the personal DB and PUBLIC schema."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "query_warehouse": "PARAM_WH",
             "build_compute_pool": "PARAM_POOL",
@@ -3546,8 +3383,6 @@ class TestSetupCommand:
         """Session/connection database (not personal DB) should emit code_stage."""
         mock_get_conn.return_value = {"database": "CONN_DB"}
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
@@ -3578,8 +3413,6 @@ class TestSetupCommand:
         stages."""
         mock_get_conn.return_value = {"database": "USER$SNOTEBAERT"}
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "schema": "PUBLIC",
             "query_warehouse": "PARAM_WH",
@@ -3599,16 +3432,41 @@ class TestSetupCommand:
         return_value="definition_version: '2'\n",
     )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_managed_compute_pool_omits_compute_pools(
+    def test_compute_pools_resolved_from_account_params(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
-        """When the backend opts the account into managed compute pools,
-        both ``build_compute_pool`` and ``service_compute_pool`` are skipped
-        and omitted from the generated snowflake.yml even if account
-        parameters or CLI flags provide values."""
+        """``build_compute_pool`` and ``service_compute_pool`` are resolved
+        from the ``DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL`` /
+        ``DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL`` account parameters and
+        forwarded to the generated snowflake.yml."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = True
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+            "build_compute_pool": "PARAM_POOL",
+            "service_compute_pool": "PARAM_SVC_POOL",
+        }
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+            assert result.exit_code == 0, result.output
+
+        resolved = mock_gen.call_args[0][1]
+        assert resolved["build_compute_pool"] == "PARAM_POOL"
+        assert resolved["service_compute_pool"] == "PARAM_SVC_POOL"
+
+    @patch(
+        "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
+        return_value="definition_version: '2'\n",
+    )
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_compute_pool_flag_overrides_account_params(
+        self, mock_mgr_cls, mock_gen, runner, tmp_path
+    ):
+        """The (hidden) ``--compute-pool`` flag takes precedence over the
+        account-parameter compute pools for both build and service pools."""
+        mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3629,33 +3487,40 @@ class TestSetupCommand:
                 ]
             )
             assert result.exit_code == 0, result.output
-            # Both pool fields are silently suppressed in setup output;
-            # neither the field names nor any resolved value should appear.
-            assert "build_compute_pool" not in result.output
-            assert "service_compute_pool" not in result.output
-            assert "PARAM_POOL" not in result.output
-            assert "FLAG_POOL" not in result.output
 
         resolved = mock_gen.call_args[0][1]
-        assert resolved["build_compute_pool"] is None
-        assert resolved["service_compute_pool"] is None
-        # The managed-pool path must not affect ``use_workspace`` selection;
-        # the account-param database here resolves to ``SOURCE_ACCOUNT_PARAM``,
-        # which means a code stage (not a workspace) is generated.
-        assert mock_gen.call_args.kwargs["use_workspace"] is False
+        assert resolved["build_compute_pool"] == "FLAG_POOL"
+        assert resolved["service_compute_pool"] == "FLAG_POOL"
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_managed_compute_pool_dry_run_json_output(
+    def test_compute_pools_omitted_when_no_source_provides_them(
         self, mock_mgr_cls, runner, tmp_path
     ):
-        """In JSON output mode, both compute-pool fields are reported as
-        ``None`` when the managed pool flag is on so downstream tooling can
-        distinguish the managed-pool flow from a missing configuration."""
+        """When neither the flag nor account parameters provide compute pools,
+        both fields are omitted from setup output so the server allocates the
+        pools at deploy time."""
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+            "query_warehouse": "PARAM_WH",
+        }
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                ["app", "setup", "--app-name", "my_app", "--dry-run"]
+            )
+            assert result.exit_code == 0, result.output
+            assert "build_compute_pool" not in result.output
+            assert "service_compute_pool" not in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_compute_pools_dry_run_json_output(self, mock_mgr_cls, runner, tmp_path):
+        """In JSON output mode, the account-parameter compute pools are
+        reported under their resolution keys."""
         import json as json_mod
 
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = True
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3679,8 +3544,8 @@ class TestSetupCommand:
             assert result.exit_code == 0, result.output
 
         parsed = json_mod.loads(result.output)
-        assert parsed["build_compute_pool"] is None
-        assert parsed["service_compute_pool"] is None
+        assert parsed["build_compute_pool"] == "PARAM_POOL"
+        assert parsed["service_compute_pool"] == "PARAM_SVC_POOL"
 
 
 # ── perform_bundle tests ──────────────────────────────────────────────
@@ -3702,8 +3567,6 @@ class TestSetupPrivilegeFallback:
         destination, setup falls back to the personal database (as if no account
         default were set) and warns the user."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3739,8 +3602,6 @@ class TestSetupPrivilegeFallback:
         """When the role has the privileges (no missing), the account-configured
         destination is used as-is."""
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3899,8 +3760,6 @@ class TestValidateCommand:
     @staticmethod
     def _configure_manager_mock(mock_manager_cls):
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.database_exists.return_value = True
         mock_mgr.schema_exists.return_value = True
         return mock_mgr
@@ -4103,8 +3962,6 @@ class TestOpenCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = (
             "https://my-app.snowflakecomputing.app"
         )
@@ -4137,8 +3994,6 @@ class TestOpenCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = (
             "https://my-app.snowflakecomputing.app"
         )
@@ -4169,8 +4024,6 @@ class TestOpenCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = None
 
         with change_directory(tmp_path):
@@ -4245,8 +4098,6 @@ class TestOpenCommand:
         )
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_endpoint_url.return_value = (
             "https://my-app.snowflakecomputing.app"
         )
@@ -4563,8 +4414,6 @@ class TestEventsCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_logs.return_value = "INFO: app started\nINFO: listening"
 
         with change_directory(tmp_path):
@@ -4594,8 +4443,6 @@ class TestEventsCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_logs.return_value = ""
 
         with change_directory(tmp_path):
@@ -4623,8 +4470,6 @@ class TestEventsCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_logs.return_value = "line1"
 
         with change_directory(tmp_path):
@@ -4655,8 +4500,6 @@ class TestEventsCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_logs.side_effect = ProgrammingError("does not exist")
 
         with change_directory(tmp_path):
@@ -4817,8 +4660,6 @@ class TestDeployCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -4880,8 +4721,6 @@ class TestDeployCommand:
         create_error.errno = 2043
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.create_app_service.side_effect = create_error
         mock_mgr.get_service_logs.return_value = (
             "create failed line1\ncreate failed line2"
@@ -4962,8 +4801,6 @@ class TestDeployCommand:
         upgrade_error.errno = 2043
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.create_app_service.side_effect = create_error
         mock_mgr.upgrade_app_service.side_effect = upgrade_error
         mock_mgr.get_service_logs.return_value = (
@@ -5044,8 +4881,6 @@ class TestDeployCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -5111,8 +4946,6 @@ class TestDeployCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.get_service_logs.return_value = "failed line1\nfailed line2"
         mock_mgr.resolve_application_service_url_from_describe.return_value = None
         mock_mgr.describe_app_service.return_value = {
@@ -5196,8 +5029,6 @@ class TestDeployCommand:
         already_exists.errno = 2002
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.create_app_service.side_effect = already_exists
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
@@ -5290,8 +5121,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = project_paths
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -5428,8 +5257,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = project_paths
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -5527,8 +5354,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -5624,8 +5449,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
@@ -5721,8 +5544,6 @@ class TestDeployCommand:
         create_error.errno = 3001
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.stage_exists.return_value = False
         mock_mgr.create_stage.side_effect = create_error
         mock_mgr.current_role.return_value = "APP_DEPLOYER"
@@ -5803,8 +5624,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.stage_exists.return_value = True
         mock_mgr.clear_stage.side_effect = ProgrammingError("Insufficient privileges")
         mock_mgr.current_role.return_value = None
@@ -5883,8 +5702,6 @@ class TestDeployCommand:
         create_error.errno = 3001
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_subdirectory_uri.return_value = (
             "snow://workspace/USER$DEV.PUBLIC.SNOWFLAKE_APPS/versions/live/MY_APP"
         )
@@ -5965,8 +5782,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_subdirectory_uri.return_value = (
             "snow://workspace/USER$DEV.PUBLIC.SNOWFLAKE_APPS/versions/live/MY_APP"
         )
@@ -6058,8 +5873,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
@@ -6157,8 +5970,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = project_paths
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -6261,8 +6072,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = project_paths
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -6345,8 +6154,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = project_paths
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.stage_exists.return_value = False
 
         from tests_common import change_directory
@@ -6410,8 +6217,6 @@ class TestDeployCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -6480,8 +6285,6 @@ class TestDeployCommand:
         mock_get_entity.return_value = entity
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_poll.return_value = {
             "url": "my-app.snowflakecomputing.app",
             "is_upgrading": "false",
@@ -6622,7 +6425,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_managed_compute_pool_warns_but_passes_yml_values_through(
+    def test_compute_pools_passed_through_to_server(
         self,
         mock_resolve,
         mock_get_entity,
@@ -6634,13 +6437,10 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
-        """When managed compute pools are enforced (managed=true,
-        fallback=false) and ``snowflake.yml`` specifies
-        ``build_compute_pool`` and/or ``service_compute_pool``, the CLI
-        warns the user that the server may not honor the values but still
-        forwards them to ``SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`` and
-        emits an ``IN COMPUTE POOL`` clause on
-        ``CREATE APPLICATION SERVICE``."""
+        """Resolved ``build_compute_pool`` / ``service_compute_pool`` values
+        are forwarded to ``SYSTEM$SPCS_TEST_BUILD_APP_ARTIFACT_REPO`` and
+        emitted as an ``IN COMPUTE POOL`` clause on
+        ``CREATE APPLICATION SERVICE``, with no managed-pool warning."""
         from snowflake.cli.api.project.project_paths import ProjectPaths
 
         entity = Mock()
@@ -6669,8 +6469,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = True
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -6694,10 +6492,8 @@ class TestDeployCommand:
             _write_snowflake_app_yml(tmp_path)
             result = runner.invoke(["app", "deploy"])
             assert result.exit_code == 0, result.output
-            assert "build_compute_pool 'YML_BUILD_POOL' is configured" in result.output
-            assert "service_compute_pool 'SVC_POOL' is configured" in result.output
-            assert "managed compute pools are enforced" in result.output
-            assert "the server may not honor this value" in result.output
+            assert "managed compute pools" not in result.output
+            assert "may not honor this value" not in result.output
 
         _, build_kwargs = mock_mgr.build_app_artifact_repo.call_args
         assert build_kwargs["compute_pool"] == "YML_BUILD_POOL"
@@ -6728,7 +6524,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_managed_compute_pool_no_warning_without_yml_values(
+    def test_no_compute_pools_lets_server_allocate(
         self,
         mock_resolve,
         mock_get_entity,
@@ -6740,10 +6536,9 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
-        """When managed compute pools are enforced but ``snowflake.yml``
-        omits both pool fields, deploy should not print any warning and
-        should let the server allocate the managed pools (no
-        ``IN COMPUTE POOL`` clause, empty 4th arg to the build function)."""
+        """When neither ``snowflake.yml`` nor account parameters provide
+        compute pools, deploy forwards ``None`` so the server allocates the
+        pools itself (no ``IN COMPUTE POOL`` clause, empty 4th build arg)."""
         from snowflake.cli.api.project.project_paths import ProjectPaths
 
         entity = Mock()
@@ -6770,8 +6565,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = True
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
@@ -6795,118 +6588,13 @@ class TestDeployCommand:
             _write_snowflake_app_yml(tmp_path)
             result = runner.invoke(["app", "deploy"])
             assert result.exit_code == 0, result.output
-            assert "build_compute_pool" not in result.output
-            assert "service_compute_pool" not in result.output
             assert "managed compute pools" not in result.output
-        # Fallback param should not even be queried when there's nothing to
-        # warn about — check_call_count keeps the helper call cheap.
-        mock_mgr.is_managed_compute_pool_fallback_enabled.assert_not_called()
 
         _, build_kwargs = mock_mgr.build_app_artifact_repo.call_args
         assert build_kwargs["compute_pool"] is None
 
         _, create_kwargs = mock_mgr.create_app_service.call_args
         assert create_kwargs["compute_pool"] is None
-
-    @patch("snowflake.cli._plugins.apps.commands._poll_until")
-    @patch("snowflake.cli._plugins.apps.commands.StageManager")
-    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
-    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    @patch(
-        RESOLVE_DEPLOY_DEFAULTS,
-        return_value={
-            "query_warehouse": "WH",
-            "build_compute_pool": "YML_BUILD_POOL",
-            "service_compute_pool": "YML_SVC_POOL",
-            "build_eai": "MY_EAI",
-            "database": "TEST_DB",
-            "schema": "TEST_SCHEMA",
-            "artifact_repository": "MY_APP_REPO",
-            "artifact_repo_database": "TEST_DB",
-            "artifact_repo_schema": "TEST_SCHEMA",
-        },
-    )
-    @patch("snowflake.cli._plugins.apps.commands._get_entity")
-    @patch(
-        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
-        return_value="my_app",
-    )
-    def test_managed_compute_pool_fallback_honors_yml_values(
-        self,
-        mock_resolve,
-        mock_get_entity,
-        mock_defaults,
-        mock_manager_cls,
-        mock_perform_bundle,
-        mock_stage_manager_cls,
-        mock_poll,
-        runner,
-        tmp_path,
-    ):
-        """When managed compute pools AND fallback are both enabled, the
-        server falls back to user-specified pools, so deploy must pass
-        ``snowflake.yml`` values through unchanged and emit no warning."""
-        from snowflake.cli.api.project.project_paths import ProjectPaths
-
-        entity = Mock()
-        fqn = Mock()
-        fqn.name = "MY_APP"
-        fqn.database = "TEST_DB"
-        fqn.schema = "TEST_SCHEMA"
-        entity.fqn = fqn
-        entity.code_stage = None
-        entity.code_workspace = Mock(database=None, schema_=None)
-        entity.code_workspace.name = "MY_APP_CODE"
-        entity.artifacts = []
-        entity.meta = None
-        entity.runtime_image = "runtime:latest"
-        entity.query_warehouse = "WH"
-        entity.artifact_repository = None
-        entity.build_compute_pool = Mock()
-        entity.build_compute_pool.name = "YML_BUILD_POOL"
-        entity.service_compute_pool = Mock()
-        entity.service_compute_pool.name = "YML_SVC_POOL"
-        entity.build_eai = None
-        mock_get_entity.return_value = entity
-
-        bundle_dir = tmp_path / "output" / "bundle"
-        bundle_dir.mkdir(parents=True)
-        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
-
-        mock_mgr = mock_manager_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = True
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = True
-        mock_mgr.workspace_last_subdirectory_uri.return_value = (
-            _WORKSPACE_BUILD_SOURCE_URI
-        )
-        mock_mgr.artifact_repo_exists.return_value = False
-        mock_mgr.build_app_artifact_repo.return_value = (
-            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
-        )
-        _real_manager = SnowflakeAppManager()
-        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
-            _real_manager.resolve_application_service_url_from_describe
-        )
-        mock_poll.side_effect = [
-            "DONE",
-            {
-                "url": "my-app.snowflakecomputing.app",
-                "is_upgrading": "false",
-            },
-        ]
-
-        with change_directory(tmp_path):
-            _write_snowflake_app_yml(tmp_path)
-            result = runner.invoke(["app", "deploy"])
-            assert result.exit_code == 0, result.output
-            assert "Ignoring build_compute_pool" not in result.output
-            assert "Ignoring service_compute_pool" not in result.output
-
-        _, build_kwargs = mock_mgr.build_app_artifact_repo.call_args
-        assert build_kwargs["compute_pool"] == "YML_BUILD_POOL"
-
-        _, create_kwargs = mock_mgr.create_app_service.call_args
-        assert create_kwargs["compute_pool"] == "YML_SVC_POOL"
 
 
 class TestTeardownCommand:

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -108,6 +108,15 @@ class TestSnowflakeAppEntityModel:
         )
         assert model.build_compute_pool.name == "MY_POOL"
 
+    def test_compute_pool_fields_hidden_from_json_schema(self):
+        """The compute-pool fields stay functional but are excluded from the
+        generated JSON schema (hidden/undocumented via SkipJsonSchema)."""
+        properties = SnowflakeAppEntityModel.model_json_schema()["properties"]
+        assert "build_compute_pool" not in properties
+        assert "service_compute_pool" not in properties
+        # Sibling fields remain documented.
+        assert "query_warehouse" in properties
+
     @pytest.mark.parametrize("value", [None, "null"])
     def test_eai_validator_none_values(self, value):
         """EAI validator accepts None and 'null' as None."""


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description

For `snowflake-app` entities, the compute pool surface is now hidden/undocumented while remaining fully functional.