### PR TITLE
Snowflake Apps: rename `--deploy-only` to `--promote-only`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,7 +33,7 @@
 * `snow dcm` commands now use the system temporary folder to bundle project files before uploading, rather than creating the `output` project directory and dropping it afterward
 * `snow dbt` no longer rejects valid `--dbt-version` values (e.g. `2.0.0-preview.175`) that don't match a hard-coded client-side regex. Versions are now validated against the server's supported list, with unsupported versions failing fast and listing the actual supported set.
 * Fixed `snow app deploy` and `snow app validate` failing on Windows with a `UnicodeDecodeError` when `snowflake.yml` contained non-ASCII characters (e.g. a non-Latin app title or description). The project definition file is now always read as UTF-8 instead of falling back to the platform default code page (cp1252 on Windows), regardless of the `cli.encoding.file_io` setting.
-* The `--deploy-only` flag of `snow app deploy` (Snowflake Apps Deploy) has been renamed to `--promote-only`. The previous `--deploy-only` name continues to work as a hidden, backward-compatible alias.
+* The `--deploy-only` flag of `snow app deploy` has been renamed to `--promote-only`. The previous `--deploy-only` name continues to work as a hidden alias for now, but this backward compatibility is temporary and will be removed soon.
 
 
 # v3.20.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,7 @@
 * `snow dcm` commands now use the system temporary folder to bundle project files before uploading, rather than creating the `output` project directory and dropping it afterward
 * `snow dbt` no longer rejects valid `--dbt-version` values (e.g. `2.0.0-preview.175`) that don't match a hard-coded client-side regex. Versions are now validated against the server's supported list, with unsupported versions failing fast and listing the actual supported set.
 * Fixed `snow app deploy` and `snow app validate` failing on Windows with a `UnicodeDecodeError` when `snowflake.yml` contained non-ASCII characters (e.g. a non-Latin app title or description). The project definition file is now always read as UTF-8 instead of falling back to the platform default code page (cp1252 on Windows), regardless of the `cli.encoding.file_io` setting.
+* The `--deploy-only` flag of `snow app deploy` (Snowflake Apps Deploy) has been renamed to `--promote-only`. The previous `--deploy-only` name continues to work as a hidden, backward-compatible alias.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -565,19 +565,19 @@ def snowflake_app_deploy(
     entity_id: Optional[str],
     upload_only: bool,
     build_only: bool,
-    deploy_only: bool,
+    promote_only: bool,
     interactive: Optional[bool] = None,
 ) -> CommandResult:
     """Build and deploy a Snowflake App Runtime through upload, build, and deploy phases."""
-    phase_flags = sum((upload_only, build_only, deploy_only))
+    phase_flags = sum((upload_only, build_only, promote_only))
     if phase_flags > 1:
         raise ClickException(
-            "Only one of --upload-only, --build-only, or --deploy-only "
+            "Only one of --upload-only, --build-only, or --promote-only "
             "may be specified."
         )
 
-    run_upload = not build_only and not deploy_only
-    run_build = not upload_only and not deploy_only
+    run_upload = not build_only and not promote_only
+    run_build = not upload_only and not promote_only
     run_deploy = not upload_only and not build_only
     resolved_entity_id = _resolve_entity_id(entity_id)
     entity = _get_entity(resolved_entity_id)

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -498,11 +498,17 @@ def app_deploy(
         help="(Snowflake App Runtime only) Run only the build phase (assumes artifacts have already been uploaded). "
         "Skips the upload and deploy phases.",
     ),
+    promote_only: bool = typer.Option(
+        False,
+        "--promote-only",
+        help="(Snowflake App Runtime only) Run only the deploy phase (assumes a previous build phase has already completed). "
+        "Skips the upload and build phases.",
+    ),
     deploy_only: bool = typer.Option(
         False,
         "--deploy-only",
-        help="(Snowflake App Runtime only) Run only the deploy phase (assumes a previous build phase has already completed). "
-        "Skips the upload and build phases.",
+        hidden=True,
+        help="Deprecated alias for --promote-only.",
     ),
     **options,
 ) -> CommandResult:
@@ -519,7 +525,7 @@ def app_deploy(
       Uploads bundled source artifacts, runs the server-side artifact repository
       build, then deploys the application service. The pipeline has three phases
       (upload, build, deploy). By default all three run in sequence; use
-      ``--upload-only`` / ``--build-only`` / ``--deploy-only`` to run a single
+      ``--upload-only`` / ``--build-only`` / ``--promote-only`` to run a single
       phase.
     """
     app_flow: AppFlow = options["app_flow"]
@@ -536,7 +542,7 @@ def app_deploy(
             options.get("entity_id") or None,
             upload_only,
             build_only,
-            deploy_only,
+            promote_only or deploy_only,
             interactive=interactive,
         )
 
@@ -545,7 +551,7 @@ def app_deploy(
         **{
             "--upload-only": True if upload_only else None,
             "--build-only": True if build_only else None,
-            "--deploy-only": True if deploy_only else None,
+            "--promote-only": True if (promote_only or deploy_only) else None,
         },
     )
 

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -125,7 +125,7 @@
    source artifacts, runs the server-side artifact repository build, then deploys 
    the application service. The pipeline has three phases (upload, build,         
    deploy). By default all three run in sequence; use --upload-only /             
-   --build-only / --deploy-only to run a single phase.                            
+   --build-only / --promote-only to run a single phase.                           
                                                                                   
   +- Arguments ------------------------------------------------------------------+
   |   paths      [PATHS]...  (Native App only) Paths, relative to the project    |
@@ -193,7 +193,7 @@
   |                                                    have already been         |
   |                                                    uploaded). Skips the      |
   |                                                    upload and deploy phases. |
-  | --deploy-only                                      (Snowflake App Runtime    |
+  | --promote-only                                     (Snowflake App Runtime    |
   |                                                    only) Run only the deploy |
   |                                                    phase (assumes a previous |
   |                                                    build phase has already   |

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -4834,7 +4834,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_only_skips_upload_and_build_phase(
+    def test_promote_only_skips_upload_and_build_phase(
         self,
         mock_resolve,
         mock_get_entity,
@@ -4865,7 +4865,7 @@ class TestDeployCommand:
 
         with change_directory(tmp_path):
             _write_snowflake_app_yml(tmp_path)
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--promote-only"])
             assert result.exit_code == 0, result.output
             mock_mgr.build_app_artifact_repo.assert_not_called()
             mock_mgr.artifact_repo_exists.assert_not_called()
@@ -4934,7 +4934,7 @@ class TestDeployCommand:
         ):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--promote-only"])
             assert result.exit_code == 1
             assert (
                 "Deployment failed while creating application service" in result.output
@@ -5015,7 +5015,7 @@ class TestDeployCommand:
         ):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--promote-only"])
             assert result.exit_code == 1
             assert (
                 "Deployment failed while upgrading application service" in result.output
@@ -5086,7 +5086,7 @@ class TestDeployCommand:
 
         with change_directory(tmp_path):
             _write_snowflake_app_yml(tmp_path)
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--promote-only"])
             assert result.exit_code == 0, result.output
 
         _, kwargs = mock_poll.call_args
@@ -5157,7 +5157,7 @@ class TestDeployCommand:
             patch("snowflake.cli._plugins.apps.commands.log") as mock_log,
         ):
             _write_snowflake_app_yml(tmp_path)
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--promote-only"])
 
         assert result.exit_code == 1
         assert "Application service deployment failed." in result.output
@@ -5236,7 +5236,7 @@ class TestDeployCommand:
         with change_directory(tmp_path):
             _write_snowflake_app_yml(tmp_path)
             _reset_command_metrics()
-            result = runner.invoke(["app", "deploy", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--promote-only"])
             assert result.exit_code == 0, result.output
             create_span = _get_completed_span("snowflake_app.deploy_service.create")
             upgrade_span = _get_completed_span("snowflake_app.deploy_service.upgrade")
@@ -6203,11 +6203,11 @@ class TestDeployCommand:
             assert result.exit_code == 1
             assert "Only one of" in result.output
 
-            result = runner.invoke(["app", "deploy", "--upload-only", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--upload-only", "--promote-only"])
             assert result.exit_code == 1
             assert "Only one of" in result.output
 
-            result = runner.invoke(["app", "deploy", "--build-only", "--deploy-only"])
+            result = runner.invoke(["app", "deploy", "--build-only", "--promote-only"])
             assert result.exit_code == 1
             assert "Only one of" in result.output
 
@@ -6459,7 +6459,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_only_runs_deploy_and_stops(
+    def test_promote_only_runs_deploy_and_stops(
         self,
         mock_resolve,
         mock_get_entity,
@@ -6469,6 +6469,70 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        from tests_common import change_directory
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--promote-only"])
+            assert result.exit_code == 0, result.output
+            assert "App ready at" in result.output
+
+        mock_mgr.create_app_service.assert_called_once()
+        mock_mgr.build_app_artifact_repo.assert_not_called()
+        mock_mgr.stage_exists.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_only_alias_still_runs_promote_phase(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        # ``--deploy-only`` is a hidden, backward-compatible alias for
+        # ``--promote-only`` and must behave identically.
         entity = Mock()
         fqn = Mock()
         fqn.name = "MY_APP"


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
Renames the `snow app deploy` `--deploy-only` flag to `--promote-only`.

- `--promote-only` is now the documented flag and appears in `snow app deploy --help`.
- `--deploy-only` is retained as a **hidden, backward-compatible alias** so existing scripts continue to work unchanged. It behaves identically to `--promote-only`.
- Help text, the implementation parameter, the mutual-exclusion error message (`Only one of --upload-only, --build-only, or --promote-only`), and the Native-App option-rejection list are all updated to reference `--promote-only`.
