### PR TITLE
feat: make snow dbt --env-vars use SQL string-literal syntax

### DIFF
--- a/src/snowflake/cli/_plugins/dbt/commands.py
+++ b/src/snowflake/cli/_plugins/dbt/commands.py
@@ -250,6 +250,18 @@ def before_callback(
         "but appear in the SQL text and query history; to avoid that, use "
         "the secrets: block in env.yml.",
     ),
+    use_shell_env_vars: bool = typer.Option(
+        False,
+        "--use-shell-env-vars",
+        show_default=False,
+        hidden=not FeatureFlag.ENABLE_DBT_PROJECT_ENV_VARS.is_enabled(),
+        help="Forward exported shell environment variables (DBT_* prefix, "
+        "excluding DBT_ENV_SECRET_*) as ENV_VARS=(). Overridden by "
+        "--env-vars on collisions. WARNING: forwarded values are embedded "
+        "as literals in the query and appear in Snowflake query history. "
+        "Never put credentials, tokens, passwords, or other confidential "
+        "data in shell environment variables starting with the DBT_* prefix.",
+    ),
     **options,
 ):
     """Handles global options passed before the command and takes pipeline name to be accessed through child context later."""
@@ -276,6 +288,7 @@ for cmd in DBT_COMMANDS:
         dbt_version = ctx.parent.params.get("dbt_version")
         environment = ctx.parent.params.get("environment")
         env_vars = ctx.parent.params.get("env_vars")
+        use_shell_env_vars = ctx.parent.params.get("use_shell_env_vars", False)
         execute_args = (
             dbt_command,
             name,
@@ -283,6 +296,7 @@ for cmd in DBT_COMMANDS:
             dbt_version,
             environment,
             env_vars,
+            use_shell_env_vars,
             *dbt_cli_args,
         )
         dbt_manager = DBTManager()

--- a/src/snowflake/cli/_plugins/dbt/commands.py
+++ b/src/snowflake/cli/_plugins/dbt/commands.py
@@ -241,15 +241,13 @@ def before_callback(
         "--env-vars",
         show_default=False,
         hidden=not FeatureFlag.ENABLE_DBT_PROJECT_ENV_VARS.is_enabled(),
-        help="Environment variable overrides as a YAML/JSON object, e.g. "
-        '\'{"DBT_FOO": "1", "DBT_BAR": "2"}\'. '
-        "Values must be strings; numbers, booleans, null, nested objects, "
-        "and arrays are rejected (quote scalars, e.g. 'DBT_FOO: \"1\"'). "
-        "Keys must be uppercase, start with 'DBT_', and contain only "
-        "letters, digits, and underscores. Variables with the "
-        "DBT_ENV_SECRET_ prefix are accepted but appear in the SQL text "
-        "and query history; to avoid that, use the secrets: block in "
-        "env.yml.",
+        help="Environment variable overrides as a parenthesized list of "
+        "single-quoted key=value pairs (Snowflake string-literal syntax; use "
+        "'' to escape a quote), e.g. \"('DBT_FOO'='1', 'DBT_BAR'='2')\". "
+        "Keys must be uppercase, start with 'DBT_', and contain only letters, "
+        "digits, and underscores. Variables with the DBT_ENV_SECRET_ prefix "
+        "are accepted but appear in the SQL text and query history; to avoid "
+        "that, use the secrets: block in env.yml.",
     ),
     use_shell_env_vars: bool = typer.Option(
         False,

--- a/src/snowflake/cli/_plugins/dbt/commands.py
+++ b/src/snowflake/cli/_plugins/dbt/commands.py
@@ -245,22 +245,25 @@ def before_callback(
         '\'{"DBT_FOO": "1", "DBT_BAR": "2"}\'. '
         "Values must be strings; numbers, booleans, null, nested objects, "
         "and arrays are rejected (quote scalars, e.g. 'DBT_FOO: \"1\"'). "
-        "Keys must start with 'DBT_' and contain only letters, digits, and "
-        "underscores. Variables with the DBT_ENV_SECRET_ prefix are accepted "
-        "but appear in the SQL text and query history; to avoid that, use "
-        "the secrets: block in env.yml.",
+        "Keys must be uppercase, start with 'DBT_', and contain only "
+        "letters, digits, and underscores. Variables with the "
+        "DBT_ENV_SECRET_ prefix are accepted but appear in the SQL text "
+        "and query history; to avoid that, use the secrets: block in "
+        "env.yml.",
     ),
     use_shell_env_vars: bool = typer.Option(
         False,
         "--use-shell-env-vars",
         show_default=False,
         hidden=not FeatureFlag.ENABLE_DBT_PROJECT_ENV_VARS.is_enabled(),
-        help="Forward exported shell environment variables (DBT_* prefix, "
-        "excluding DBT_ENV_SECRET_*) as ENV_VARS=(). Overridden by "
-        "--env-vars on collisions. WARNING: forwarded values are embedded "
-        "as literals in the query and appear in Snowflake query history. "
-        "Never put credentials, tokens, passwords, or other confidential "
-        "data in shell environment variables starting with the DBT_* prefix.",
+        help="Forward exported shell environment variables with uppercase "
+        "names starting with DBT_ (excluding the DBT_ENV_SECRET_ prefix) as "
+        "ENV_VARS=(); non-uppercase or otherwise invalid names are skipped. "
+        "Overridden by --env-vars on collisions. WARNING: forwarded values "
+        "are embedded as literals in the query and appear in Snowflake query "
+        "history. Never put credentials, tokens, passwords, or other "
+        "confidential data in shell environment variables with the DBT_ "
+        "prefix.",
     ),
     **options,
 ):
@@ -296,20 +299,23 @@ for cmd in DBT_COMMANDS:
             dbt_version,
             environment,
             env_vars,
-            use_shell_env_vars,
             *dbt_cli_args,
         )
         dbt_manager = DBTManager()
 
         if run_async is True:
-            result = dbt_manager.execute(*execute_args)
+            result = dbt_manager.execute(
+                *execute_args, use_shell_env_vars=use_shell_env_vars
+            )
             return MessageResult(
                 f"Command submitted. You can check the result with `snow sql -q \"select execution_status from table(information_schema.query_history_by_user()) where query_id in ('{result.sfqid}');\"`"
             )
 
         with cli_console.spinner() as spinner:
             spinner.add_task(description=f"Executing 'dbt {dbt_command}'", total=None)
-            result = dbt_manager.execute(*execute_args)
+            result = dbt_manager.execute(
+                *execute_args, use_shell_env_vars=use_shell_env_vars
+            )
 
             try:
                 columns = [column.name for column in result.description]

--- a/src/snowflake/cli/_plugins/dbt/manager.py
+++ b/src/snowflake/cli/_plugins/dbt/manager.py
@@ -56,22 +56,37 @@ def _reject_control_chars(value: Optional[str], flag_name: str) -> Optional[str]
     return value
 
 
-def _collect_shell_env_vars() -> tuple[Dict[str, str], int]:
+def _collect_shell_env_vars() -> tuple[Dict[str, str], int, int]:
     """Collect DBT_* environment variables from os.environ for --use-shell-env-vars.
 
     Returns (forwarded vars sorted by key, count of dropped DBT_ENV_SECRET_*
-    keys). Sorting makes the resulting SQL text deterministic across shells.
+    keys, count of skipped malformed keys). Only fully-uppercase, DBT_-prefixed
+    keys with valid characters and control-char-free values are forwarded —
+    matching exactly what the server accepts in ENV_VARS=(), so a malformed
+    shell var never triggers a server-side rejection of the whole run.
+    Secret-prefixed keys are detected case-insensitively and dropped (never
+    sent), so a secret cannot leak into query history. Sorting makes the
+    resulting SQL text deterministic across shells.
     """
     forwarded: Dict[str, str] = {}
     dropped_secret_count = 0
+    skipped_count = 0
     for key, value in os.environ.items():
-        if not key.startswith(_ENV_VAR_KEY_PREFIX):
+        upper = key.upper()
+        if not upper.startswith(_ENV_VAR_KEY_PREFIX):
             continue
-        if key.startswith(DBT_ENV_SECRET_PREFIX):
+        if upper.startswith(DBT_ENV_SECRET_PREFIX):
             dropped_secret_count += 1
             continue
-        forwarded[key] = value
-    return dict(sorted(forwarded.items())), dropped_secret_count
+        if (
+            key == upper
+            and _ENV_VAR_KEY_RE.match(key)
+            and not _CONTROL_CHAR_RE.search(value)
+        ):
+            forwarded[key] = value
+        else:
+            skipped_count += 1
+    return dict(sorted(forwarded.items())), dropped_secret_count, skipped_count
 
 
 class _NoDuplicatesSafeLoader(yaml.SafeLoader):
@@ -545,8 +560,8 @@ class DBTManager(SqlExecutionMixin):
         dbt_version: Optional[str] = None,
         environment: Optional[str] = None,
         env_vars: Optional[str] = None,
-        use_shell_env_vars: bool = False,
         *dbt_cli_args,
+        use_shell_env_vars: bool = False,
     ) -> SnowflakeCursor:
         if dbt_cli_args:
             processed_args = self._process_dbt_args(dbt_cli_args)
@@ -559,7 +574,7 @@ class DBTManager(SqlExecutionMixin):
 
         merged: Dict[str, str] = {}
         if use_shell_env_vars:
-            shell_vars, dropped_secret_count = _collect_shell_env_vars()
+            shell_vars, dropped_secret_count, skipped_count = _collect_shell_env_vars()
             if dropped_secret_count:
                 cli_console.message(
                     f"--use-shell-env-vars: dropped {dropped_secret_count} "
@@ -568,24 +583,26 @@ class DBTManager(SqlExecutionMixin):
                     "env.yml referencing a Snowflake SECRET object, or pass "
                     "them explicitly via --env-vars."
                 )
+            if skipped_count:
+                cli_console.message(
+                    f"--use-shell-env-vars: skipped {skipped_count} DBT_* shell "
+                    "environment variable(s) that can't be forwarded; keys "
+                    "must be uppercase and contain only letters, digits, and "
+                    "underscores (e.g. export DBT_FOO, not DBT_Foo)."
+                )
             if shell_vars:
                 cli_console.warning(
                     f"--use-shell-env-vars: forwarded {len(shell_vars)} shell "
                     "environment variable(s) into query text. Never put "
                     "credentials, tokens, passwords, or other confidential "
-                    "data in shell environment variables starting with the "
-                    "DBT_* prefix."
+                    "data in shell environment variables with the DBT_ prefix."
                 )
-            else:
+            elif not dropped_secret_count and not skipped_count:
                 cli_console.message(
                     "--use-shell-env-vars: no DBT_* environment variables "
-                    "found in shell. To export, use:\n"
-                    "  bash/zsh:   export DBT_FOO=value\n"
-                    "  fish:       set -gx DBT_FOO value\n"
-                    '  PowerShell: $env:DBT_FOO = "value"\n'
-                    "  cmd.exe:    set DBT_FOO=value\n"
-                    "If running under sudo, use `sudo -E` to preserve the "
-                    "environment."
+                    "found in the shell. Make sure the variables are exported "
+                    "(see your shell's documentation for how to export "
+                    "environment variables)."
                 )
             merged.update(shell_vars)
         if env_vars:
@@ -639,6 +656,10 @@ class DBTManager(SqlExecutionMixin):
             if not k.startswith(_ENV_VAR_KEY_PREFIX):
                 raise CliError(
                     f"--env-vars key {k!r} must start with " f"{_ENV_VAR_KEY_PREFIX!r}"
+                )
+            if k != k.upper():
+                raise CliError(
+                    f"--env-vars key {k!r} must be uppercase (e.g. {k.upper()!r})"
                 )
             if v is None:
                 raise CliError(f"--env-vars value for {k!r} must not be null")

--- a/src/snowflake/cli/_plugins/dbt/manager.py
+++ b/src/snowflake/cli/_plugins/dbt/manager.py
@@ -45,6 +45,9 @@ DBT_ENV_SECRET_PREFIX = "DBT_ENV_SECRET_"
 _ENV_VAR_KEY_PREFIX = "DBT_"
 _ENV_VAR_KEY_RE = re.compile(r"^[A-Za-z0-9_]+$")
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+# A single-quoted SQL string literal (with '' escaping a quote), optionally
+# surrounded by horizontal whitespace. Group 1 is the still-escaped contents.
+_ENV_VAR_SQL_LITERAL_RE = re.compile(r"[ \t]*'((?:[^']|'')*)'[ \t]*")
 
 
 def _reject_control_chars(value: Optional[str], flag_name: str) -> Optional[str]:
@@ -632,50 +635,89 @@ class DBTManager(SqlExecutionMixin):
 
     @staticmethod
     def _parse_env_vars(raw: str) -> Dict[str, str]:
-        try:
-            parsed = yaml.load(raw, Loader=_NoDuplicatesSafeLoader)
-        except yaml.constructor.ConstructorError as e:
-            raise CliError(f"Failed to parse --env-vars: {e.problem}")
-        except yaml.YAMLError as e:
-            raise CliError(f"--env-vars must be valid YAML/JSON: {e}")
-        if not isinstance(parsed, dict):
+        """Parse --env-vars in the SQL string-literal form.
+
+        Example: "('DBT_FOO'='1', 'DBT_BAR'='2')". Keys and values are
+        single-quoted string literals, with a doubled single quote ('')
+        escaping a literal quote, mirroring Snowflake string-literal syntax.
+        This is the same form the CLI emits into the ENV_VARS=(...) clause, so
+        a clause copied from a query can be passed straight back in. Keys must
+        be uppercase, start with 'DBT_', and contain only ASCII letters,
+        digits, and underscores.
+        """
+        s = raw.strip()
+        if not (s.startswith("(") and s.endswith(")")):
             raise CliError(
-                "--env-vars must be a YAML/JSON object, " f"got {type(parsed).__name__}"
+                "--env-vars must be wrapped in parentheses, "
+                "e.g. \"('DBT_FOO'='1', 'DBT_BAR'='2')\""
             )
+        inner = s[1:-1]
+        n = len(inner)
+
+        def read_literal(pos: int):
+            """Match a single-quoted literal at pos; return (unescaped, next_pos)."""
+            m = _ENV_VAR_SQL_LITERAL_RE.match(inner, pos)
+            if m:
+                return m.group(1).replace("''", "'"), m.end()
+            rest = inner[pos:].lstrip(" \t")
+            if rest.startswith("'"):
+                raise CliError(f"--env-vars: unterminated string literal in {raw!r}")
+            hint = (
+                " (use single quotes for SQL string literals)"
+                if rest.startswith('"')
+                else ""
+            )
+            raise CliError(
+                f"--env-vars: expected a single-quoted string literal "
+                f"in {raw!r}{hint}"
+            )
+
         result: Dict[str, str] = {}
-        for k, v in parsed.items():
-            if not isinstance(k, str):
-                raise CliError(f"--env-vars key must be a string, got {k!r}")
-            if not k:
-                raise CliError("--env-vars key must not be empty")
-            if not _ENV_VAR_KEY_RE.match(k):
+        if not inner.strip(" \t"):  # "()" — no pairs
+            return result
+        pos = 0
+        while True:
+            key, pos = read_literal(pos)
+            if pos >= n or inner[pos] != "=":
                 raise CliError(
-                    f"--env-vars key {k!r} must contain only ASCII letters, "
-                    f"digits, and underscores"
+                    f"--env-vars: expected '=' after key {key!r} in {raw!r}"
                 )
-            if not k.startswith(_ENV_VAR_KEY_PREFIX):
+            value, pos = read_literal(pos + 1)
+            DBTManager._validate_env_var(key, value)
+            if key in result:
+                raise CliError(f"--env-vars: duplicate key {key!r}")
+            result[key] = value
+            if pos >= n:
+                break
+            if inner[pos] != ",":
                 raise CliError(
-                    f"--env-vars key {k!r} must start with " f"{_ENV_VAR_KEY_PREFIX!r}"
+                    f"--env-vars: expected ',' between pairs in {raw!r}"
                 )
-            if k != k.upper():
-                raise CliError(
-                    f"--env-vars key {k!r} must be uppercase (e.g. {k.upper()!r})"
-                )
-            if v is None:
-                raise CliError(f"--env-vars value for {k!r} must not be null")
-            if not isinstance(v, str):
-                raise CliError(
-                    f"--env-vars value for {k!r} must be a string, "
-                    f"got {type(v).__name__}; quote scalars in YAML/JSON "
-                    f"(e.g. '{k}: \"1\"' instead of '{k}: 1')"
-                )
-            if _CONTROL_CHAR_RE.search(v):
-                raise CliError(
-                    f"--env-vars value for {k!r} must not contain control "
-                    f"characters (newlines, tabs, etc.)"
-                )
-            result[k] = v
+            pos += 1
         return result
+
+    @staticmethod
+    def _validate_env_var(key: str, value: str) -> None:
+        if not key:
+            raise CliError("--env-vars key must not be empty")
+        if not _ENV_VAR_KEY_RE.match(key):
+            raise CliError(
+                f"--env-vars key {key!r} must contain only ASCII letters, "
+                f"digits, and underscores"
+            )
+        if not key.startswith(_ENV_VAR_KEY_PREFIX):
+            raise CliError(
+                f"--env-vars key {key!r} must start with {_ENV_VAR_KEY_PREFIX!r}"
+            )
+        if key != key.upper():
+            raise CliError(
+                f"--env-vars key {key!r} must be uppercase (e.g. {key.upper()!r})"
+            )
+        if _CONTROL_CHAR_RE.search(value):
+            raise CliError(
+                f"--env-vars value for {key!r} must not contain control "
+                f"characters (newlines, tabs, etc.)"
+            )
 
     @staticmethod
     def _process_dbt_args(dbt_cli_args: tuple) -> str:

--- a/src/snowflake/cli/_plugins/dbt/manager.py
+++ b/src/snowflake/cli/_plugins/dbt/manager.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from collections import defaultdict
 from dataclasses import dataclass
@@ -53,6 +54,24 @@ def _reject_control_chars(value: Optional[str], flag_name: str) -> Optional[str]
             f"(newlines, tabs, etc.)"
         )
     return value
+
+
+def _collect_shell_env_vars() -> tuple[Dict[str, str], int]:
+    """Collect DBT_* environment variables from os.environ for --use-shell-env-vars.
+
+    Returns (forwarded vars sorted by key, count of dropped DBT_ENV_SECRET_*
+    keys). Sorting makes the resulting SQL text deterministic across shells.
+    """
+    forwarded: Dict[str, str] = {}
+    dropped_secret_count = 0
+    for key, value in os.environ.items():
+        if not key.startswith(_ENV_VAR_KEY_PREFIX):
+            continue
+        if key.startswith(DBT_ENV_SECRET_PREFIX):
+            dropped_secret_count += 1
+            continue
+        forwarded[key] = value
+    return dict(sorted(forwarded.items())), dropped_secret_count
 
 
 class _NoDuplicatesSafeLoader(yaml.SafeLoader):
@@ -526,6 +545,7 @@ class DBTManager(SqlExecutionMixin):
         dbt_version: Optional[str] = None,
         environment: Optional[str] = None,
         env_vars: Optional[str] = None,
+        use_shell_env_vars: bool = False,
         *dbt_cli_args,
     ) -> SnowflakeCursor:
         if dbt_cli_args:
@@ -536,17 +556,48 @@ class DBTManager(SqlExecutionMixin):
             query += f" dbt_version={to_string_literal(dbt_version)}"
         if environment:
             query += f" ENVIRONMENT={to_string_literal(environment)}"
-        env_vars_clause = self._format_env_vars_clause(env_vars)
+
+        merged: Dict[str, str] = {}
+        if use_shell_env_vars:
+            shell_vars, dropped_secret_count = _collect_shell_env_vars()
+            if dropped_secret_count:
+                cli_console.message(
+                    f"--use-shell-env-vars: dropped {dropped_secret_count} "
+                    f"{DBT_ENV_SECRET_PREFIX}* environment variable(s) from "
+                    "shell. To forward secrets, use the secrets: block in "
+                    "env.yml referencing a Snowflake SECRET object, or pass "
+                    "them explicitly via --env-vars."
+                )
+            if shell_vars:
+                cli_console.warning(
+                    f"--use-shell-env-vars: forwarded {len(shell_vars)} shell "
+                    "environment variable(s) into query text. Never put "
+                    "credentials, tokens, passwords, or other confidential "
+                    "data in shell environment variables starting with the "
+                    "DBT_* prefix."
+                )
+            else:
+                cli_console.message(
+                    "--use-shell-env-vars: no DBT_* environment variables "
+                    "found in shell. To export, use:\n"
+                    "  bash/zsh:   export DBT_FOO=value\n"
+                    "  fish:       set -gx DBT_FOO value\n"
+                    '  PowerShell: $env:DBT_FOO = "value"\n'
+                    "  cmd.exe:    set DBT_FOO=value\n"
+                    "If running under sudo, use `sudo -E` to preserve the "
+                    "environment."
+                )
+            merged.update(shell_vars)
+        if env_vars:
+            merged.update(self._parse_env_vars(env_vars))
+        env_vars_clause = self._format_env_vars_clause_from_dict(merged)
         if env_vars_clause:
             query += env_vars_clause
         query += f" args={to_string_literal(dbt_command)}"
         return self.execute_query(query, _exec_async=run_async)
 
     @staticmethod
-    def _format_env_vars_clause(env_vars: Optional[str]) -> str:
-        if not env_vars:
-            return ""
-        pairs = DBTManager._parse_env_vars(env_vars)
+    def _format_env_vars_clause_from_dict(pairs: Dict[str, str]) -> str:
         if not pairs:
             return ""
         secret_keys = [k for k in pairs if k.startswith(DBT_ENV_SECRET_PREFIX)]

--- a/tests/dbt/conftest.py
+++ b/tests/dbt/conftest.py
@@ -1,8 +1,24 @@
+import os
 from unittest import mock
 
 import pytest
 import yaml
 from snowflake.cli._plugins.dbt.constants import ENV_FILENAME, PROFILES_FILENAME
+
+
+@pytest.fixture
+def clean_dbt_env(monkeypatch):
+    """Strip every DBT_* env var from os.environ for the duration of the test.
+
+    monkeypatch.setenv only adds; it does NOT clear pre-existing ones. CI
+    runners and dev shells often have stray DBT_* vars (DBT_LOG_PATH,
+    DBT_TARGET_PATH, etc.) that would leak into --use-shell-env-vars
+    behavior under test.
+    """
+    for key in list(os.environ):
+        if key.startswith("DBT_"):
+            monkeypatch.delenv(key, raising=False)
+    yield monkeypatch
 
 
 @pytest.fixture

--- a/tests/dbt/test_dbt_commands.py
+++ b/tests/dbt/test_dbt_commands.py
@@ -1135,6 +1135,262 @@ class TestDBTExecute:
             "ENV_VARS=('DBT_FOO'='1') args='compile'"
         )
 
+    def test_use_shell_env_vars_basic(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_FOO", "1")
+        clean_dbt_env.setenv("DBT_BAR", "2")
+        clean_dbt_env.setenv("PATH_OVERRIDE", "should-not-appear")
+        clean_dbt_env.setenv("AWS_ACCESS_KEY", "should-not-appear")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
+            "ENV_VARS=('DBT_BAR'='2', 'DBT_FOO'='1') args='run'"
+        )
+        assert "forwarded 2 shell environment variable(s)" in result.output
+
+    def test_use_shell_env_vars_drops_secret_prefix(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_FOO", "1")
+        clean_dbt_env.setenv("DBT_ENV_SECRET_TOKEN", "should-not-appear")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        query = mock_connect.mocked_ctx.get_query()
+        assert query == (
+            "EXECUTE DBT PROJECT pipeline_name " "ENV_VARS=('DBT_FOO'='1') args='run'"
+        )
+        assert "should-not-appear" not in query
+        assert "should-not-appear" not in result.output
+        assert "dropped 1 DBT_ENV_SECRET_* environment variable(s)" in result.output
+
+    def test_use_shell_env_vars_only_secrets_present(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_ENV_SECRET_TOKEN", "should-not-appear")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        # No ENV_VARS=() clause emitted; nothing to forward.
+        assert (
+            mock_connect.mocked_ctx.get_query()
+            == "EXECUTE DBT PROJECT pipeline_name args='run'"
+        )
+        assert "dropped 1 DBT_ENV_SECRET_* environment variable(s)" in result.output
+        assert "no DBT_* environment variables found in shell" in result.output
+        assert "forwarded" not in result.output
+
+    def test_use_shell_env_vars_empty_shell(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_connect.mocked_ctx.get_query()
+            == "EXECUTE DBT PROJECT pipeline_name args='run'"
+        )
+        assert "no DBT_* environment variables found in shell" in result.output
+        assert "bash/zsh:" in result.output
+        assert "fish:" in result.output
+        assert "PowerShell:" in result.output
+        assert "cmd.exe:" in result.output
+        assert "sudo -E" in result.output
+
+    def test_use_shell_env_vars_explicit_overrides_shell(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_FOO", "fromshell")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "--env-vars",
+                '{"DBT_FOO": "explicit"}',
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
+            "ENV_VARS=('DBT_FOO'='explicit') args='run'"
+        )
+
+    def test_use_shell_env_vars_merge_with_explicit(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_FOO", "fromshell")
+        clean_dbt_env.setenv("DBT_BAR", "fromshell")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "--env-vars",
+                '{"DBT_BAR": "explicit", "DBT_NEW": "new"}',
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        # Shell side sorted (DBT_BAR, DBT_FOO); --env-vars merges on top:
+        # DBT_BAR is overwritten in place; DBT_NEW appended at end.
+        assert (
+            mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
+            "ENV_VARS=('DBT_BAR'='explicit', 'DBT_FOO'='fromshell', "
+            "'DBT_NEW'='new') args='run'"
+        )
+
+    def test_use_shell_env_vars_with_no_env(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_FOO", "1")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--env=NO_ENV",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_connect.mocked_ctx.get_query()
+            == "EXECUTE DBT PROJECT pipeline_name ENVIRONMENT='NO_ENV' "
+            "ENV_VARS=('DBT_FOO'='1') args='run'"
+        )
+
+    def test_use_shell_env_vars_value_with_single_quote(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_MSG", "it's")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
+            "ENV_VARS=('DBT_MSG'='it''s') args='run'"
+        )
+
+    def test_use_shell_env_vars_async(self, mock_connect, runner, clean_dbt_env):
+        clean_dbt_env.setenv("DBT_FOO", "1")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--run-async",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "compile",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_connect.mocked_ctx.kwargs[0]["_exec_async"] is True
+        assert (
+            mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
+            "ENV_VARS=('DBT_FOO'='1') args='compile'"
+        )
+
     def test_dbt_execute_with_dotted_prerelease_version(
         self, mock_connect, mock_cursor, runner
     ):

--- a/tests/dbt/test_dbt_commands.py
+++ b/tests/dbt/test_dbt_commands.py
@@ -26,6 +26,8 @@ from snowflake.cli._plugins.dbt.constants import (
 from snowflake.cli.api.exceptions import CliArgumentError
 from snowflake.cli.api.secure_path import SecurePath
 
+from tests_common import IS_WINDOWS
+
 
 class TestDBTList:
     def test_list_command_alias(self, mock_connect, runner):
@@ -1052,6 +1054,16 @@ class TestDBTExecute:
                 "must not contain control characters",
                 id="value-control-char",
             ),
+            pytest.param(
+                '{"DBT_foo": "1"}',
+                "must be uppercase",
+                id="key-not-uppercase-suffix",
+            ),
+            pytest.param(
+                '{"DBT_Foo": "1"}',
+                "must be uppercase",
+                id="key-not-uppercase-mixed",
+            ),
         ],
     )
     def test_dbt_execute_env_vars_invalid_input(
@@ -1222,7 +1234,10 @@ class TestDBTExecute:
             == "EXECUTE DBT PROJECT pipeline_name args='run'"
         )
         assert "dropped 1 DBT_ENV_SECRET_* environment variable(s)" in result.output
-        assert "no DBT_* environment variables found in shell" in result.output
+        # The dropped-secret message explains the empty result; the generic
+        # "no DBT_* found / how to export" hint must NOT fire (the user clearly
+        # knows how to export — they exported a secret).
+        assert "no DBT_* environment variables found" not in result.output
         assert "forwarded" not in result.output
 
     def test_use_shell_env_vars_empty_shell(
@@ -1249,12 +1264,48 @@ class TestDBTExecute:
             mock_connect.mocked_ctx.get_query()
             == "EXECUTE DBT PROJECT pipeline_name args='run'"
         )
-        assert "no DBT_* environment variables found in shell" in result.output
-        assert "bash/zsh:" in result.output
-        assert "fish:" in result.output
-        assert "PowerShell:" in result.output
-        assert "cmd.exe:" in result.output
-        assert "sudo -E" in result.output
+        assert "no DBT_* environment variables found in the shell" in result.output
+        assert "exported" in result.output
+        # Per-shell export table was intentionally dropped (maintainability).
+        assert "bash/zsh:" not in result.output
+        assert "PowerShell:" not in result.output
+
+    @pytest.mark.skipif(
+        IS_WINDOWS,
+        reason="os.environ is case-insensitive on Windows and normalizes names "
+        "to uppercase, so a non-uppercase DBT_ env var cannot exist there and "
+        "the skip path is unreachable.",
+    )
+    def test_use_shell_env_vars_skips_non_uppercase(
+        self, mock_connect, mock_cursor, runner, clean_dbt_env
+    ):
+        cursor = mock_cursor(
+            rows=[(True, "very detailed logs")],
+            columns=[RESULT_COLUMN_NAME, OUTPUT_COLUMN_NAME],
+        )
+        mock_connect.mocked_ctx.cs = cursor
+        clean_dbt_env.setenv("DBT_FOO", "1")
+        clean_dbt_env.setenv("DBT_Bar", "mixed")
+
+        result = runner.invoke(
+            [
+                "dbt",
+                "execute",
+                "--use-shell-env-vars",
+                "pipeline_name",
+                "run",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        # Only the uppercase key is forwarded; the mixed-case one is skipped.
+        assert (
+            mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
+            "ENV_VARS=('DBT_FOO'='1') args='run'"
+        )
+        assert "skipped 1 DBT_* shell environment variable(s)" in result.output
+        # Forwarding still happened, so the empty-state hint must not fire.
+        assert "no DBT_* environment variables found" not in result.output
 
     def test_use_shell_env_vars_explicit_overrides_shell(
         self, mock_connect, mock_cursor, runner, clean_dbt_env

--- a/tests/dbt/test_dbt_commands.py
+++ b/tests/dbt/test_dbt_commands.py
@@ -870,64 +870,51 @@ class TestDBTExecute:
                     "dbt",
                     "execute",
                     "--env-vars",
-                    '{"DBT_FOO": "1"}',
+                    "('DBT_FOO'='1')",
                     "pipeline_name",
                     "run",
                 ],
                 "EXECUTE DBT PROJECT pipeline_name ENV_VARS=('DBT_FOO'='1') args='run'",
-                id="env-vars-json-single",
+                id="env-vars-sql-single",
             ),
             pytest.param(
                 [
                     "dbt",
                     "execute",
                     "--env-vars",
-                    '{"DBT_FOO": "1", "DBT_BAR": "2"}',
-                    "pipeline_name",
-                    "run",
-                ],
-                "EXECUTE DBT PROJECT pipeline_name "
-                "ENV_VARS=('DBT_FOO'='1', 'DBT_BAR'='2') args='run'",
-                id="env-vars-json-multi",
-            ),
-            pytest.param(
-                [
-                    "dbt",
-                    "execute",
-                    "--env-vars",
-                    "{DBT_FOO: '1', DBT_BAR: '2'}",
-                    "pipeline_name",
-                    "run",
-                ],
-                "EXECUTE DBT PROJECT pipeline_name "
-                "ENV_VARS=('DBT_FOO'='1', 'DBT_BAR'='2') args='run'",
-                id="env-vars-yaml-quoted-strings",
-            ),
-            pytest.param(
-                [
-                    "dbt",
-                    "execute",
-                    "--env-vars",
-                    '{"DBT_URL": "https://example.com/?a=b"}',
+                    "('DBT_URL'='https://example.com/?a=b')",
                     "pipeline_name",
                     "run",
                 ],
                 "EXECUTE DBT PROJECT pipeline_name "
                 "ENV_VARS=('DBT_URL'='https://example.com/?a=b') args='run'",
-                id="env-vars-value-with-equals",
+                id="env-vars-sql-value-with-equals",
             ),
             pytest.param(
                 [
                     "dbt",
                     "execute",
                     "--env-vars",
-                    'DBT_MSG: "it\'s"',
+                    "('DBT_FOO'='1', 'DBT_BAR'='2')",
+                    "pipeline_name",
+                    "run",
+                ],
+                "EXECUTE DBT PROJECT pipeline_name "
+                "ENV_VARS=('DBT_FOO'='1', 'DBT_BAR'='2') args='run'",
+                id="env-vars-sql-multi",
+            ),
+            pytest.param(
+                [
+                    "dbt",
+                    "execute",
+                    "--env-vars",
+                    "('DBT_MSG'='it''s')",
                     "pipeline_name",
                     "run",
                 ],
                 "EXECUTE DBT PROJECT pipeline_name "
                 "ENV_VARS=('DBT_MSG'='it''s') args='run'",
-                id="env-vars-value-with-single-quote-escaped",
+                id="env-vars-sql-escaped-quote",
             ),
             pytest.param(
                 [
@@ -936,7 +923,7 @@ class TestDBTExecute:
                     "--dbt-version=1.9.0",
                     "--env=prod",
                     "--env-vars",
-                    '{"DBT_FOO": "1"}',
+                    "('DBT_FOO'='1')",
                     "pipeline_name",
                     "run",
                 ],
@@ -950,7 +937,7 @@ class TestDBTExecute:
                     "execute",
                     "--env=dev",
                     "--env-vars",
-                    '{"DBT_OVERRIDE": "1"}',
+                    "('DBT_OVERRIDE'='1')",
                     "pipeline_name",
                     "run",
                     "--vars",
@@ -980,89 +967,69 @@ class TestDBTExecute:
         "raw_value,expected_error",
         [
             pytest.param(
-                '"just_a_string"',
-                "must be a YAML/JSON object",
-                id="non-mapping-string",
-            ),
-            pytest.param(
-                "[1, 2, 3]",
-                "must be a YAML/JSON object",
-                id="non-mapping-list",
-            ),
-            pytest.param(
-                '{"DBT_X": null}',
-                "must not be null",
-                id="null-value",
-            ),
-            pytest.param(
-                '{"DBT_X": 1}',
-                "must be a string",
-                id="int-value",
-            ),
-            pytest.param(
-                '{"DBT_X": 1.5}',
-                "must be a string",
-                id="float-value",
-            ),
-            pytest.param(
-                '{"DBT_X": true}',
-                "must be a string",
-                id="bool-value",
-            ),
-            pytest.param(
-                '{"DBT_X": {"nested": "1"}}',
-                "must be a string",
-                id="nested-object",
-            ),
-            pytest.param(
-                '{"DBT_X": ["1", "2"]}',
-                "must be a string",
-                id="nested-array",
-            ),
-            pytest.param(
-                "{not: valid: yaml: at: all",
-                "must be valid YAML/JSON",
-                id="malformed-yaml",
-            ),
-            pytest.param(
-                '{"DBT_FOO": "1", "DBT_FOO": "2"}',
-                "duplicate key",
-                id="duplicate-key",
-            ),
-            pytest.param(
-                '{"": "v"}',
+                "(''='v')",
                 "must not be empty",
                 id="empty-key",
             ),
             pytest.param(
-                '{"FOO": "1"}',
+                "('FOO'='1')",
                 "must start with",
                 id="key-missing-dbt-prefix",
             ),
             pytest.param(
-                '{"DBT-FOO": "1"}',
+                "('DBT-FOO'='1')",
                 "ASCII letters",
                 id="key-invalid-chars-hyphen",
             ),
             pytest.param(
-                '{"DBT FOO": "1"}',
+                "('DBT FOO'='1')",
                 "ASCII letters",
                 id="key-invalid-chars-space",
             ),
             pytest.param(
-                '{"DBT_FOO": "value\\nwith\\nnewlines"}',
+                "('DBT_FOO'='a\nb')",
                 "must not contain control characters",
                 id="value-control-char",
             ),
             pytest.param(
-                '{"DBT_foo": "1"}',
+                "('DBT_foo'='1')",
                 "must be uppercase",
                 id="key-not-uppercase-suffix",
             ),
             pytest.param(
-                '{"DBT_Foo": "1"}',
+                "('DBT_Foo'='1')",
                 "must be uppercase",
                 id="key-not-uppercase-mixed",
+            ),
+            pytest.param(
+                "('DBT_FOO'='1'",
+                "wrapped in parentheses",
+                id="sql-missing-closing-paren",
+            ),
+            pytest.param(
+                "('DBT_FOO')",
+                "expected '='",
+                id="sql-missing-equals",
+            ),
+            pytest.param(
+                "('DBT_FOO'='unterminated)",
+                "unterminated string literal",
+                id="sql-unterminated-literal",
+            ),
+            pytest.param(
+                '("DBT_FOO"="1")',
+                "single quotes",
+                id="sql-double-quotes-rejected",
+            ),
+            pytest.param(
+                "(DBT_FOO=1)",
+                "single-quoted string literal",
+                id="sql-unquoted",
+            ),
+            pytest.param(
+                "('DBT_FOO'='1', 'DBT_FOO'='2')",
+                "duplicate key",
+                id="sql-duplicate-key",
             ),
         ],
     )
@@ -1111,7 +1078,7 @@ class TestDBTExecute:
                 "dbt",
                 "execute",
                 "--env-vars",
-                '{"DBT_ENV_SECRET_TOKEN": "xyz"}',
+                "('DBT_ENV_SECRET_TOKEN'='xyz')",
                 "pipeline_name",
                 "run",
             ]
@@ -1133,7 +1100,7 @@ class TestDBTExecute:
                 "--run-async",
                 "--env=dev",
                 "--env-vars",
-                '{"DBT_FOO": "1"}',
+                "('DBT_FOO'='1')",
                 "pipeline_name",
                 "compile",
             ]
@@ -1323,7 +1290,7 @@ class TestDBTExecute:
                 "execute",
                 "--use-shell-env-vars",
                 "--env-vars",
-                '{"DBT_FOO": "explicit"}',
+                "('DBT_FOO'='explicit')",
                 "pipeline_name",
                 "run",
             ]
@@ -1352,7 +1319,7 @@ class TestDBTExecute:
                 "execute",
                 "--use-shell-env-vars",
                 "--env-vars",
-                '{"DBT_BAR": "explicit", "DBT_NEW": "new"}',
+                "('DBT_BAR'='explicit', 'DBT_NEW'='new')",
                 "pipeline_name",
                 "run",
             ]

--- a/tests/dbt/test_manager.py
+++ b/tests/dbt/test_manager.py
@@ -1728,3 +1728,67 @@ class TestExecute:
             "ENV_VARS=('DBT_FOO'='1') args='compile'",
             _exec_async=True,
         )
+
+
+class TestCollectShellEnvVars:
+    """Direct manager-level coverage of _collect_shell_env_vars."""
+
+    def test_returns_sorted_dict_and_zero_dropped(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_ZULU", "z")
+        clean_dbt_env.setenv("DBT_ALPHA", "a")
+        clean_dbt_env.setenv("DBT_MIKE", "m")
+
+        forwarded, dropped = _collect_shell_env_vars()
+
+        assert list(forwarded.items()) == [
+            ("DBT_ALPHA", "a"),
+            ("DBT_MIKE", "m"),
+            ("DBT_ZULU", "z"),
+        ]
+        assert dropped == 0
+
+    def test_excludes_non_dbt_keys(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_FOO", "1")
+        clean_dbt_env.setenv("PATH", "/bin")
+        clean_dbt_env.setenv("AWS_ACCESS_KEY", "key")
+        clean_dbt_env.setenv("DBTFOO", "no-underscore")  # missing underscore
+        clean_dbt_env.setenv("XDBT_FOO", "wrong-prefix")
+
+        forwarded, dropped = _collect_shell_env_vars()
+
+        assert forwarded == {"DBT_FOO": "1"}
+        assert dropped == 0
+
+    def test_drops_secret_prefixed_keys(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_FOO", "1")
+        clean_dbt_env.setenv("DBT_ENV_SECRET_TOKEN", "shhh")
+        clean_dbt_env.setenv("DBT_ENV_SECRET_API_KEY", "shhh2")
+
+        forwarded, dropped = _collect_shell_env_vars()
+
+        assert forwarded == {"DBT_FOO": "1"}
+        assert dropped == 2
+
+    def test_empty_environment_returns_empty(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        forwarded, dropped = _collect_shell_env_vars()
+
+        assert forwarded == {}
+        assert dropped == 0
+
+    def test_only_secrets_returns_empty_dict_with_count(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_ENV_SECRET_TOKEN", "shhh")
+
+        forwarded, dropped = _collect_shell_env_vars()
+
+        assert forwarded == {}
+        assert dropped == 1

--- a/tests/dbt/test_manager.py
+++ b/tests/dbt/test_manager.py
@@ -1532,49 +1532,55 @@ class TestExecute:
                 id="environment-no-env-sentinel",
             ),
             pytest.param(
-                {"env_vars": '{"DBT_FOO": "1"}'},
+                {"env_vars": "('DBT_FOO'='1')"},
                 (),
                 "EXECUTE DBT PROJECT pipeline ENV_VARS=('DBT_FOO'='1') args='run'",
-                id="env-vars-json-single",
+                id="env-vars-sql-single",
             ),
             pytest.param(
-                {"env_vars": '{"DBT_FOO": "1", "DBT_BAR": "2"}'},
+                {"env_vars": "('DBT_FOO'='1', 'DBT_BAR'='2')"},
                 (),
                 "EXECUTE DBT PROJECT pipeline "
                 "ENV_VARS=('DBT_FOO'='1', 'DBT_BAR'='2') args='run'",
-                id="env-vars-json-multi",
+                id="env-vars-sql-multi",
             ),
             pytest.param(
-                {"env_vars": "{DBT_FOO: '1', DBT_BAR: '2'}"},
+                {"env_vars": "  ( 'DBT_FOO' = '1' ,  'DBT_BAR'='2' )  "},
                 (),
                 "EXECUTE DBT PROJECT pipeline "
                 "ENV_VARS=('DBT_FOO'='1', 'DBT_BAR'='2') args='run'",
-                id="env-vars-yaml-quoted-strings",
+                id="env-vars-sql-whitespace-tolerant",
             ),
             pytest.param(
-                {"env_vars": '{"DBT_URL": "https://example.com/?a=b"}'},
+                {"env_vars": "('DBT_URL'='https://example.com/?a=b')"},
                 (),
                 "EXECUTE DBT PROJECT pipeline "
                 "ENV_VARS=('DBT_URL'='https://example.com/?a=b') args='run'",
-                id="env-vars-value-with-equals",
+                id="env-vars-sql-value-with-equals",
             ),
             pytest.param(
-                {"env_vars": 'DBT_MSG: "it\'s"'},
+                {"env_vars": "('DBT_MSG'='it''s')"},
                 (),
                 "EXECUTE DBT PROJECT pipeline "
                 "ENV_VARS=('DBT_MSG'='it''s') args='run'",
-                id="env-vars-value-with-single-quote-escaped",
+                id="env-vars-sql-escaped-quote",
+            ),
+            pytest.param(
+                {"env_vars": "()"},
+                (),
+                "EXECUTE DBT PROJECT pipeline args='run'",
+                id="env-vars-sql-empty",
             ),
             pytest.param(
                 {
                     "dbt_version": "1.9.0",
                     "environment": "prod",
-                    "env_vars": '{"DBT_FOO": "1"}',
+                    "env_vars": "('DBT_FOO'='1')",
                 },
                 (),
                 "EXECUTE DBT PROJECT pipeline dbt_version='1.9.0' "
                 "ENVIRONMENT='prod' ENV_VARS=('DBT_FOO'='1') args='run'",
-                id="all-options-ordering",
+                id="env-vars-sql-all-options-ordering",
             ),
         ],
     )
@@ -1604,79 +1610,69 @@ class TestExecute:
         "raw_value,expected_error",
         [
             pytest.param(
-                '"just_a_string"',
-                "must be a YAML/JSON object",
-                id="non-mapping-string",
-            ),
-            pytest.param(
-                "[1, 2, 3]",
-                "must be a YAML/JSON object",
-                id="non-mapping-list",
-            ),
-            pytest.param(
-                '{"DBT_X": null}',
-                "must not be null",
-                id="null-value",
-            ),
-            pytest.param(
-                '{"DBT_X": 1}',
-                "must be a string",
-                id="int-value",
-            ),
-            pytest.param(
-                '{"DBT_X": 1.5}',
-                "must be a string",
-                id="float-value",
-            ),
-            pytest.param(
-                '{"DBT_X": true}',
-                "must be a string",
-                id="bool-value",
-            ),
-            pytest.param(
-                '{"DBT_X": {"nested": "1"}}',
-                "must be a string",
-                id="nested-object",
-            ),
-            pytest.param(
-                '{"DBT_X": ["1", "2"]}',
-                "must be a string",
-                id="nested-array",
-            ),
-            pytest.param(
-                "{not: valid: yaml: at: all",
-                "must be valid YAML/JSON",
-                id="malformed-yaml",
-            ),
-            pytest.param(
-                '{"DBT_FOO": "1", "DBT_FOO": "2"}',
-                "duplicate key",
-                id="duplicate-key",
-            ),
-            pytest.param(
-                '{"": "v"}',
+                "(''='v')",
                 "must not be empty",
                 id="empty-key",
             ),
             pytest.param(
-                '{"FOO": "1"}',
-                "must start with",
-                id="key-missing-dbt-prefix",
-            ),
-            pytest.param(
-                '{"DBT-FOO": "1"}',
+                "('DBT-FOO'='1')",
                 "ASCII letters",
                 id="key-invalid-chars-hyphen",
             ),
             pytest.param(
-                '{"DBT FOO": "1"}',
+                "('DBT FOO'='1')",
                 "ASCII letters",
                 id="key-invalid-chars-space",
             ),
             pytest.param(
-                '{"DBT_FOO": "value\\nwith\\nnewlines"}',
+                "('DBT_FOO'='a\nb')",
                 "must not contain control characters",
                 id="value-control-char",
+            ),
+            pytest.param(
+                '("DBT_FOO"="1")',
+                "single quotes",
+                id="sql-double-quotes-rejected",
+            ),
+            pytest.param(
+                "('DBT_FOO'='1'",
+                "wrapped in parentheses",
+                id="sql-missing-closing-paren",
+            ),
+            pytest.param(
+                "('DBT_FOO')",
+                "expected '='",
+                id="sql-missing-equals",
+            ),
+            pytest.param(
+                "('DBT_FOO'='1' 'DBT_BAR'='2')",
+                "expected ','",
+                id="sql-missing-comma",
+            ),
+            pytest.param(
+                "(DBT_FOO=1)",
+                "single-quoted string literal",
+                id="sql-unquoted",
+            ),
+            pytest.param(
+                "('DBT_FOO'='unterminated)",
+                "unterminated string literal",
+                id="sql-unterminated-literal",
+            ),
+            pytest.param(
+                "('DBT_FOO'='1', 'DBT_FOO'='2')",
+                "duplicate key",
+                id="sql-duplicate-key",
+            ),
+            pytest.param(
+                "('FOO'='1')",
+                "must start with",
+                id="sql-key-missing-dbt-prefix",
+            ),
+            pytest.param(
+                "('DBT_Foo'='1')",
+                "must be uppercase",
+                id="sql-key-not-uppercase",
             ),
         ],
     )
@@ -1703,7 +1699,7 @@ class TestExecute:
             False,
             None,
             None,
-            '{"DBT_ENV_SECRET_TOKEN": "xyz"}',
+            "('DBT_ENV_SECRET_TOKEN'='xyz')",
         )
 
         captured = capsys.readouterr()
@@ -1722,7 +1718,7 @@ class TestExecute:
             True,
             None,
             "dev",
-            '{"DBT_FOO": "1"}',
+            "('DBT_FOO'='1')",
         )
 
         mock_execute_query.assert_called_once_with(

--- a/tests/dbt/test_manager.py
+++ b/tests/dbt/test_manager.py
@@ -17,6 +17,8 @@ from snowflake.cli.api.identifiers import FQN
 from snowflake.cli.api.secure_path import SecurePath
 from snowflake.connector import ProgrammingError
 
+from tests_common import IS_WINDOWS
+
 
 def _supported_versions_payload(*versions: str) -> str:
     return json.dumps([{"dbt_version": v} for v in versions])
@@ -1729,6 +1731,32 @@ class TestExecute:
             _exec_async=True,
         )
 
+    def test_execute_forwards_shell_env_vars_with_cli_args(
+        self, mock_execute_query, clean_dbt_env
+    ):
+        # use_shell_env_vars is keyword-only, so positional dbt CLI args
+        # ("--select", "my_model") still map to *dbt_cli_args rather than
+        # being misbound to the flag.
+        clean_dbt_env.setenv("DBT_FOO", "1")
+
+        DBTManager().execute(
+            "run",
+            FQN.from_string("pipeline"),
+            False,
+            None,
+            None,
+            None,
+            "--select",
+            "my_model",
+            use_shell_env_vars=True,
+        )
+
+        mock_execute_query.assert_called_once_with(
+            "EXECUTE DBT PROJECT pipeline "
+            "ENV_VARS=('DBT_FOO'='1') args='run --select my_model'",
+            _exec_async=False,
+        )
+
 
 class TestCollectShellEnvVars:
     """Direct manager-level coverage of _collect_shell_env_vars."""
@@ -1740,7 +1768,7 @@ class TestCollectShellEnvVars:
         clean_dbt_env.setenv("DBT_ALPHA", "a")
         clean_dbt_env.setenv("DBT_MIKE", "m")
 
-        forwarded, dropped = _collect_shell_env_vars()
+        forwarded, dropped, skipped = _collect_shell_env_vars()
 
         assert list(forwarded.items()) == [
             ("DBT_ALPHA", "a"),
@@ -1748,6 +1776,7 @@ class TestCollectShellEnvVars:
             ("DBT_ZULU", "z"),
         ]
         assert dropped == 0
+        assert skipped == 0
 
     def test_excludes_non_dbt_keys(self, clean_dbt_env):
         from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
@@ -1758,10 +1787,13 @@ class TestCollectShellEnvVars:
         clean_dbt_env.setenv("DBTFOO", "no-underscore")  # missing underscore
         clean_dbt_env.setenv("XDBT_FOO", "wrong-prefix")
 
-        forwarded, dropped = _collect_shell_env_vars()
+        forwarded, dropped, skipped = _collect_shell_env_vars()
 
         assert forwarded == {"DBT_FOO": "1"}
         assert dropped == 0
+        # DBTFOO and XDBT_FOO do not start with the DBT_ prefix → not DBT-ish,
+        # ignored silently (not counted as skipped).
+        assert skipped == 0
 
     def test_drops_secret_prefixed_keys(self, clean_dbt_env):
         from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
@@ -1770,25 +1802,85 @@ class TestCollectShellEnvVars:
         clean_dbt_env.setenv("DBT_ENV_SECRET_TOKEN", "shhh")
         clean_dbt_env.setenv("DBT_ENV_SECRET_API_KEY", "shhh2")
 
-        forwarded, dropped = _collect_shell_env_vars()
+        forwarded, dropped, skipped = _collect_shell_env_vars()
 
         assert forwarded == {"DBT_FOO": "1"}
         assert dropped == 2
+        assert skipped == 0
+
+    def test_drops_mixed_case_secret_prefixed_keys(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        # Mixed-case secret prefix is detected case-insensitively and counted
+        # as a dropped secret (not a generic skip), so the user gets the
+        # secrets-block guidance and the value never reaches query history.
+        clean_dbt_env.setenv("DBT_Env_Secret_TOKEN", "shhh")
+
+        forwarded, dropped, skipped = _collect_shell_env_vars()
+
+        assert forwarded == {}
+        assert dropped == 1
+        assert skipped == 0
+
+    @pytest.mark.skipif(
+        IS_WINDOWS,
+        reason="os.environ is case-insensitive on Windows and normalizes names "
+        "to uppercase, so a non-uppercase DBT_ env var cannot exist there and "
+        "the skip path is unreachable.",
+    )
+    def test_skips_non_uppercase_keys(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_FOO", "ok")
+        clean_dbt_env.setenv("DBT_Foo", "mixed")  # not uppercase → skipped
+        clean_dbt_env.setenv("dbt_bar", "lower")  # DBT-ish but lowercase → skipped
+
+        forwarded, dropped, skipped = _collect_shell_env_vars()
+
+        assert forwarded == {"DBT_FOO": "ok"}
+        assert dropped == 0
+        assert skipped == 2
+
+    def test_skips_invalid_char_keys(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_FOO", "ok")
+        clean_dbt_env.setenv("DBT_FOO-BAR", "dash")  # invalid char → skipped
+
+        forwarded, dropped, skipped = _collect_shell_env_vars()
+
+        assert forwarded == {"DBT_FOO": "ok"}
+        assert dropped == 0
+        assert skipped == 1
+
+    def test_skips_control_char_values(self, clean_dbt_env):
+        from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
+
+        clean_dbt_env.setenv("DBT_FOO", "ok")
+        clean_dbt_env.setenv("DBT_BAR", "bad\nvalue")  # control char → skipped
+
+        forwarded, dropped, skipped = _collect_shell_env_vars()
+
+        assert forwarded == {"DBT_FOO": "ok"}
+        assert dropped == 0
+        assert skipped == 1
 
     def test_empty_environment_returns_empty(self, clean_dbt_env):
         from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
 
-        forwarded, dropped = _collect_shell_env_vars()
+        forwarded, dropped, skipped = _collect_shell_env_vars()
 
         assert forwarded == {}
         assert dropped == 0
+        assert skipped == 0
 
     def test_only_secrets_returns_empty_dict_with_count(self, clean_dbt_env):
         from snowflake.cli._plugins.dbt.manager import _collect_shell_env_vars
 
         clean_dbt_env.setenv("DBT_ENV_SECRET_TOKEN", "shhh")
 
-        forwarded, dropped = _collect_shell_env_vars()
+        forwarded, dropped, skipped = _collect_shell_env_vars()
 
         assert forwarded == {}
         assert dropped == 1
+        assert skipped == 0

--- a/tests_integration/test_dbt.py
+++ b/tests_integration/test_dbt.py
@@ -20,8 +20,8 @@ from unittest import mock
 import pytest
 import yaml
 
-from snowflake.cli.api.identifiers import FQN
 from snowflake.cli._plugins.dbt.constants import ENV_FILENAME, PROFILES_FILENAME
+from snowflake.cli.api.identifiers import FQN
 
 
 def _setup_dbt_profile(root_dir: Path, snowflake_session):
@@ -881,3 +881,95 @@ def test_execute_with_env_and_env_vars(
         row = _run_and_fetch(["--env-vars", '{"DBT_FOO": "only_foo"}'])
         assert row["FOO"] == "only_foo", row
         assert row["BAR"] == "dev_bar", row
+
+
+@pytest.mark.integration
+@pytest.mark.qa_only
+def test_execute_with_use_shell_env_vars(
+    runner,
+    snowflake_session,
+    test_database,
+    project_directory,
+    monkeypatch,
+):
+    """Exercise --use-shell-env-vars against a real Snowflake DBT PROJECT.
+
+    Reuses the sibling's `dbt_project_with_env_vars` fixture project. The
+    integration runner uses an in-process CliRunner, so monkeypatch.setenv
+    is visible to os.environ inside the CLI code.
+
+    Verifies:
+      * shell DBT_FOO/DBT_BAR forwarded → overrides env.yml's prod block
+      * shell + --env-vars → explicit --env-vars wins on collision
+      * shell + --env=NO_ENV → shell vars apply, env.yml skipped
+      * DBT_ENV_SECRET_* in shell → silently dropped client-side
+      * empty shell + --use-shell-env-vars → env.yml provides values
+    """
+    # Strip any stray DBT_* leakage from the runner's env first.
+    for k in list(os.environ):
+        if k.startswith("DBT_"):
+            monkeypatch.delenv(k, raising=False)
+
+    with project_directory("dbt_project_with_env_vars") as root_dir:
+        ts = int(datetime.datetime.now().timestamp())
+        name = f"dbt_project_shell_env_{ts}"
+
+        _setup_dbt_profile(root_dir, snowflake_session)
+        result = runner.invoke_with_connection_json(["dbt", "deploy", name])
+        assert result.exit_code == 0, result.output
+
+        def _run_and_fetch(extra_args: list[str]) -> dict:
+            run_result = runner.invoke_passthrough_with_connection(
+                args=["dbt", "execute", *extra_args],
+                passthrough_args=[name, "run"],
+            )
+            assert run_result.exit_code == 0, run_result.output
+
+            query_result = runner.invoke_with_connection_json(
+                ["sql", "-q", "select foo, bar from my_first_dbt_model;"]
+            )
+            assert query_result.exit_code == 0, query_result.output
+            assert len(query_result.json) == 1, query_result.json
+            return query_result.json[0]
+
+        # 1. shell vars forwarded; override env.yml's prod block.
+        monkeypatch.setenv("DBT_FOO", "shell_foo")
+        monkeypatch.setenv("DBT_BAR", "shell_bar")
+        row = _run_and_fetch(["--use-shell-env-vars", "--env=prod"])
+        assert row["FOO"] == "shell_foo", row
+        assert row["BAR"] == "shell_bar", row
+
+        # 2. --env-vars beats shell on collision; shell still provides BAR.
+        row = _run_and_fetch(
+            [
+                "--use-shell-env-vars",
+                "--env-vars",
+                '{"DBT_FOO": "explicit_foo"}',
+                "--env=prod",
+            ]
+        )
+        assert row["FOO"] == "explicit_foo", row
+        assert row["BAR"] == "shell_bar", row
+
+        # 3. --env=NO_ENV skips env.yml; shell still forwards.
+        monkeypatch.delenv("DBT_BAR", raising=False)
+        row = _run_and_fetch(["--use-shell-env-vars", "--env=NO_ENV"])
+        assert row["FOO"] == "shell_foo", row
+        assert row["BAR"] == "unset", row
+
+        # 4. DBT_ENV_SECRET_* dropped client-side; doesn't reach the server.
+        monkeypatch.setenv("DBT_ENV_SECRET_TOKEN", "should_not_appear")
+        run_result = runner.invoke_passthrough_with_connection(
+            args=["dbt", "execute", "--use-shell-env-vars", "--env=NO_ENV"],
+            passthrough_args=[name, "run"],
+        )
+        assert run_result.exit_code == 0, run_result.output
+        assert "should_not_appear" not in run_result.output
+        monkeypatch.delenv("DBT_ENV_SECRET_TOKEN", raising=False)
+
+        # 5. Empty shell + --use-shell-env-vars → env.yml provides values,
+        # pipeline succeeds with the empty-state info message.
+        monkeypatch.delenv("DBT_FOO", raising=False)
+        row = _run_and_fetch(["--use-shell-env-vars", "--env=prod"])
+        assert row["FOO"] == "prod_foo", row
+        assert row["BAR"] == "prod_bar", row

--- a/tests_integration/test_dbt.py
+++ b/tests_integration/test_dbt.py
@@ -866,7 +866,7 @@ def test_execute_with_env_and_env_vars(
 
         # 3. --env-vars overrides one key from the prod block
         row = _run_and_fetch(
-            ["--env=prod", "--env-vars", '{"DBT_FOO": "override_foo"}']
+            ["--env=prod", "--env-vars", "('DBT_FOO'='override_foo')"]
         )
         assert row["FOO"] == "override_foo", row
         assert row["BAR"] == "prod_bar", row
@@ -878,7 +878,7 @@ def test_execute_with_env_and_env_vars(
 
         # 5. --env-vars without --env still applies (and env.yml's
         # default_environment 'dev' provides the un-overridden var)
-        row = _run_and_fetch(["--env-vars", '{"DBT_FOO": "only_foo"}'])
+        row = _run_and_fetch(["--env-vars", "('DBT_FOO'='only_foo')"])
         assert row["FOO"] == "only_foo", row
         assert row["BAR"] == "dev_bar", row
 
@@ -944,7 +944,7 @@ def test_execute_with_use_shell_env_vars(
             [
                 "--use-shell-env-vars",
                 "--env-vars",
-                '{"DBT_FOO": "explicit_foo"}',
+                "('DBT_FOO'='explicit_foo')",
                 "--env=prod",
             ]
         )


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
--env-vars now takes the Snowflake string-literal form instead of the YAML/JSON object form:

    --env-vars "('DBT_FOO'='only_foo', 'DBT_BAR'='it''s_me')"

Keys and values are single-quoted string literals, with a doubled single quote ('') escaping a literal quote. This is exactly the form the CLI emits into the ENV_VARS=(...) clause, so a clause copied from a query can be passed straight back in.

_parse_env_vars is now a small hand-written scanner for that grammar: whitespace-tolerant, "()" -> no clause, with explicit duplicate-key detection and clear errors for unterminated literals, missing '='/',', and unquoted tokens (a double quote produces a single-quote hint). Key validation (DBT_ prefix, ASCII letters/digits/underscores) and the value control-character check are unchanged. The previous YAML/JSON parsing path and its loader-based dedup are removed.

The feature remains hidden behind the ENABLE_DBT_PROJECT_ENV_VARS flag (Private Preview), so no RELEASE-NOTES entry per PrPr lifecycle rules.
