### PR TITLE
chore: improve permissions in github actions

### DIFF
--- a/.github/workflows/changes.yaml
+++ b/.github/workflows/changes.yaml
@@ -16,7 +16,7 @@ on:
         value: ${{ jobs.detect.outputs.code }}
 
 permissions:
-  contents: none
+  contents: read
 
 jobs:
   detect:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,12 +44,22 @@ jobs:
         run: python -m pip install pre-commit tomlkit click==8.2.1 hatch==1.15.1 virtualenv==20.39.1 uv
       - name: Check if pyproject.toml was changed
         id: pyproject_changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          git fetch origin ${{ github.base_ref }}
-          if git diff --name-only $(git merge-base FETCH_HEAD HEAD)...${{ github.sha }} | grep '^pyproject.toml$'; then
-            echo "pyproject_changed=true" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          # Non-PR events (push to main / tags / features/*) always run the full suite
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "pyproject_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | grep -q '^pyproject\.toml$'; then
+            echo "pyproject_changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "pyproject_changed=false" >> $GITHUB_OUTPUT
+            echo "pyproject_changed=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Run pre-commit (full)
         if: steps.pyproject_changed.outputs.pyproject_changed == 'true'

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: none
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: none
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/test_trusted.yaml
+++ b/.github/workflows/test_trusted.yaml
@@ -25,7 +25,7 @@ on:
         default: "true"
 
 permissions:
-  contents: none
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
Updates workflow permissions from `contents: none` to `contents: read` to ensure workflows can reliably access repository contents. Also improves the lint workflow's detection of `pyproject.toml` changes to eliminate unnecessary git fetch operations by using GitHub's built-in event context variables instead.
