### PR TITLE
SNOW-2457402 Encoding handling fixes

### DIFF
--- a/src/snowflake/cli/_app/__main__.py
+++ b/src/snowflake/cli/_app/__main__.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import codecs
 import os
 import sys
 
@@ -29,6 +30,10 @@ def _apply_stdout_encoding_from_env() -> None:
     """
     enc = os.environ.get("SNOWFLAKE_CLI_ENCODING_STDOUT")
     if not enc:
+        return
+    try:
+        codecs.lookup(enc)
+    except LookupError:
         return
     try:
         sys.stdout.reconfigure(encoding=enc)  # type: ignore[attr-defined,union-attr]

--- a/src/snowflake/cli/_app/__main__.py
+++ b/src/snowflake/cli/_app/__main__.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import codecs
+import io
 import os
 import sys
 
@@ -34,10 +35,13 @@ def _apply_stdout_encoding_from_env() -> None:
     try:
         codecs.lookup(enc)
     except LookupError:
+        # Silently skip — the invalid value will be caught again by
+        # get_stdout_encoding() → _validate_encoding() during config_init,
+        # which raises a proper ClickException with context.
         return
     try:
         sys.stdout.reconfigure(encoding=enc)  # type: ignore[attr-defined,union-attr]
-    except (AttributeError, Exception):
+    except (AttributeError, io.UnsupportedOperation):
         pass
 
 

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -711,7 +711,9 @@ def _dump_config(config_and_connections: Dict):
         else:
             config_toml_dict.pop("connections", None)
 
-    with SecurePath(get_config_manager().file_path).open("w+") as fh:
+    with SecurePath(get_config_manager().file_path).open(
+        "w+", use_file_io_encoding=False
+    ) as fh:
         dump(config_toml_dict, fh)
 
 
@@ -783,32 +785,25 @@ def get_feature_flags_section() -> Dict[str, bool | Literal["UNKNOWN"]]:
     return {k: _bool_or_unknown(v) for k, v in flags.items()}
 
 
-def _get_file_io_encoding_env_only() -> Optional[str]:
-    """Read file I/O encoding from the env var only, without accessing the config file.
-
-    Used when opening the config file itself to avoid a chicken-and-egg problem
-    (can't read the encoding setting from the file we haven't opened yet).
-    Returns None when the env var is not set, which preserves the platform-default
-    behavior that existed before encoding support was added.
-    """
-    value = get_env_value(*ENCODING_SECTION_PATH, key="file_io")
-    return _validate_encoding(value, "cli.encoding.file_io")
-
-
 def _read_config_file_toml() -> dict:
-    return tomlkit.loads(
-        get_config_manager().file_path.read_text(
-            encoding=_get_file_io_encoding_env_only()
-        )
-    ).unwrap()
+    # config.toml is read by the connector (via read_config()) with platform
+    # default encoding, and _dump_config writes it with PLATFORM_DEFAULT_ENCODING
+    # for the same reason — keeping CLI read/write consistent with the connector.
+    return tomlkit.loads(get_config_manager().file_path.read_text()).unwrap()
 
 
 def _read_connections_toml() -> dict:
-    return tomlkit.loads(
-        get_connections_file().read_text(encoding=get_file_io_encoding())
-    ).unwrap()
+    # connections.toml is a shared file: the snowflake-connector reads it via
+    # its own read_config() using read_text() with no explicit encoding
+    # (platform default). Applying a custom file_io encoding here would make
+    # the CLI and connector read the same file with different codecs, corrupting
+    # non-ASCII content for one of them. Use platform default to stay consistent
+    # with the connector.
+    return tomlkit.loads(get_connections_file().read_text()).unwrap()
 
 
 def _update_connections_toml(connections: dict):
-    with open(get_connections_file(), "w", encoding=get_file_io_encoding()) as f:
+    # Same rationale as _read_connections_toml: platform default keeps CLI
+    # writes consistent with the connector's reads.
+    with open(get_connections_file(), "w") as f:
         f.write(tomlkit.dumps(connections))

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -783,19 +783,32 @@ def get_feature_flags_section() -> Dict[str, bool | Literal["UNKNOWN"]]:
     return {k: _bool_or_unknown(v) for k, v in flags.items()}
 
 
+def _get_file_io_encoding_env_only() -> Optional[str]:
+    """Read file I/O encoding from the env var only, without accessing the config file.
+
+    Used when opening the config file itself to avoid a chicken-and-egg problem
+    (can't read the encoding setting from the file we haven't opened yet).
+    Returns None when the env var is not set, which preserves the platform-default
+    behavior that existed before encoding support was added.
+    """
+    value = get_env_value(*ENCODING_SECTION_PATH, key="file_io")
+    return _validate_encoding(value, "cli.encoding.file_io")
+
+
 def _read_config_file_toml() -> dict:
-    # TOML files are always UTF-8 by spec; don't apply user's file_io encoding
     return tomlkit.loads(
-        get_config_manager().file_path.read_text(encoding="utf-8")
+        get_config_manager().file_path.read_text(
+            encoding=_get_file_io_encoding_env_only()
+        )
     ).unwrap()
 
 
 def _read_connections_toml() -> dict:
-    # TOML files are always UTF-8 by spec; don't apply user's file_io encoding
-    return tomlkit.loads(get_connections_file().read_text(encoding="utf-8")).unwrap()
+    return tomlkit.loads(
+        get_connections_file().read_text(encoding=get_file_io_encoding())
+    ).unwrap()
 
 
 def _update_connections_toml(connections: dict):
-    # TOML files are always UTF-8 by spec; don't apply user's file_io encoding
-    with open(get_connections_file(), "w", encoding="utf-8") as f:
+    with open(get_connections_file(), "w", encoding=get_file_io_encoding()) as f:
         f.write(tomlkit.dumps(connections))

--- a/src/snowflake/cli/api/secure_path.py
+++ b/src/snowflake/cli/api/secure_path.py
@@ -168,7 +168,12 @@ class SecurePath:
         self._path.mkdir(mode=permissions_mask, exist_ok=exist_ok)
 
     def read_text(
-        self, file_size_limit_mb: int, encoding: Optional[str] = None, *args, **kwargs
+        self,
+        file_size_limit_mb: int,
+        encoding: Optional[str] = None,
+        use_file_io_encoding: bool = True,
+        *args,
+        **kwargs,
     ) -> str:
         """
         Return the decoded contents of the file as a string.
@@ -180,7 +185,7 @@ class SecurePath:
         self._assert_exists_and_is_file()
         self._assert_file_size_limit(file_size_limit_mb)
 
-        if encoding is None:
+        if encoding is None and use_file_io_encoding:
             from snowflake.cli.api.config import get_file_io_encoding
 
             encoding = get_file_io_encoding()
@@ -192,7 +197,14 @@ class SecurePath:
         )
         return self._path.read_text(encoding, *args, **kwargs)
 
-    def write_text(self, data: str, encoding: Optional[str] = None, *args, **kwargs):
+    def write_text(
+        self,
+        data: str,
+        encoding: Optional[str] = None,
+        use_file_io_encoding: bool = True,
+        *args,
+        **kwargs,
+    ):
         """
         Open the file pointed to in text mode, write data to it, and close the file.
 
@@ -202,7 +214,7 @@ class SecurePath:
         if not self.exists():
             self.touch()
 
-        if encoding is None:
+        if encoding is None and use_file_io_encoding:
             from snowflake.cli.api.config import get_file_io_encoding
 
             encoding = get_file_io_encoding()
@@ -220,6 +232,7 @@ class SecurePath:
         mode="r",
         read_file_limit_mb: Optional[int] = None,
         encoding: Optional[str] = None,
+        use_file_io_encoding: bool = True,
         **open_kwargs,
     ) -> Generator[IO[Any], None, None]:
         """
@@ -241,7 +254,7 @@ class SecurePath:
         else:
             self.touch()  # makes sure permissions of freshly-created file are strict
 
-        if "b" not in mode and encoding is None:
+        if "b" not in mode and encoding is None and use_file_io_encoding:
             from snowflake.cli.api.config import get_file_io_encoding
 
             encoding = get_file_io_encoding()

--- a/tests/api/test_secure_path.py
+++ b/tests/api/test_secure_path.py
@@ -563,12 +563,13 @@ def test_file_size_limit_calculation(temporary_directory):
 
 
 @pytest.mark.parametrize(
-    "env_encoding,explicit_encoding,content,expected_log_encoding",
+    "env_encoding,explicit_encoding,use_file_io_encoding,content,expected_log_encoding",
     [
-        (None, "utf-8", "Hello 世界", "utf-8"),
-        (None, None, "Hello", "platform default"),
-        ("utf-8", None, "Hello 世界", "utf-8"),
-        ("cp1252", "utf-8", "Hello 世界", "utf-8"),  # explicit overrides env
+        (None, "utf-8", True, "Hello 世界", "utf-8"),
+        (None, None, True, "Hello", "platform default"),
+        ("utf-8", None, True, "Hello 世界", "utf-8"),
+        ("cp1252", "utf-8", True, "Hello 世界", "utf-8"),  # explicit overrides env
+        ("cp1252", None, False, "Hello", "platform default"),  # flag bypasses file_io
     ],
 )
 def test_read_text_encoding(
@@ -577,6 +578,7 @@ def test_read_text_encoding(
     monkeypatch,
     env_encoding,
     explicit_encoding,
+    use_file_io_encoding,
     content,
     expected_log_encoding,
 ):
@@ -589,7 +591,7 @@ def test_read_text_encoding(
     path.write_text(content, encoding="utf-8")
 
     spath = SecurePath(path)
-    kwargs = {"file_size_limit_mb": 1}
+    kwargs = {"file_size_limit_mb": 1, "use_file_io_encoding": use_file_io_encoding}
     if explicit_encoding:
         kwargs["encoding"] = explicit_encoding
     result = spath.read_text(**kwargs)
@@ -605,12 +607,13 @@ def test_read_text_encoding(
 
 
 @pytest.mark.parametrize(
-    "env_encoding,explicit_encoding,content,expected_log_encoding",
+    "env_encoding,explicit_encoding,use_file_io_encoding,content,expected_log_encoding",
     [
-        (None, "utf-8", "Hello 世界", "utf-8"),
-        (None, None, "Hello", "platform default"),
-        ("utf-8", None, "Hello 世界", "utf-8"),
-        ("cp1252", "utf-8", "Hello 世界", "utf-8"),  # explicit overrides env
+        (None, "utf-8", True, "Hello 世界", "utf-8"),
+        (None, None, True, "Hello", "platform default"),
+        ("utf-8", None, True, "Hello 世界", "utf-8"),
+        ("cp1252", "utf-8", True, "Hello 世界", "utf-8"),  # explicit overrides env
+        ("cp1252", None, False, "Hello", "platform default"),  # flag bypasses file_io
     ],
 )
 def test_write_text_encoding(
@@ -619,6 +622,7 @@ def test_write_text_encoding(
     monkeypatch,
     env_encoding,
     explicit_encoding,
+    use_file_io_encoding,
     content,
     expected_log_encoding,
 ):
@@ -632,7 +636,7 @@ def test_write_text_encoding(
     if explicit_encoding:
         spath.write_text(content, encoding=explicit_encoding)
     else:
-        spath.write_text(content)
+        spath.write_text(content, use_file_io_encoding=use_file_io_encoding)
 
     assert path.read_text(encoding="utf-8") == content
     _assert_count_matching_logs(
@@ -645,12 +649,13 @@ def test_write_text_encoding(
 
 
 @pytest.mark.parametrize(
-    "env_encoding,explicit_encoding,content,expected_log_encoding",
+    "env_encoding,explicit_encoding,use_file_io_encoding,content,expected_log_encoding",
     [
-        (None, "utf-8", "Hello 世界", "utf-8"),
-        (None, None, "Hello", "platform default"),
-        ("utf-8", None, "Hello 世界", "utf-8"),
-        ("cp1252", "utf-8", "Hello 世界", "utf-8"),  # explicit overrides env
+        (None, "utf-8", True, "Hello 世界", "utf-8"),
+        (None, None, True, "Hello", "platform default"),
+        ("utf-8", None, True, "Hello 世界", "utf-8"),
+        ("cp1252", "utf-8", True, "Hello 世界", "utf-8"),  # explicit overrides env
+        ("cp1252", None, False, "Hello", "platform default"),  # flag bypasses file_io
     ],
 )
 def test_open_encoding(
@@ -659,6 +664,7 @@ def test_open_encoding(
     monkeypatch,
     env_encoding,
     explicit_encoding,
+    use_file_io_encoding,
     content,
     expected_log_encoding,
 ):
@@ -670,7 +676,7 @@ def test_open_encoding(
     path = Path(temporary_directory) / "file.txt"
     spath = SecurePath(path)
 
-    open_kwargs = {}
+    open_kwargs = {"use_file_io_encoding": use_file_io_encoding}
     if explicit_encoding:
         open_kwargs["encoding"] = explicit_encoding
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1044,49 +1044,20 @@ show_warnings = false
             config_init(cfg)
 
 
-def test_get_file_io_encoding_env_only_returns_none_when_unset(monkeypatch):
-    """_get_file_io_encoding_env_only returns None when env var not set."""
-    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", raising=False)
-    from snowflake.cli.api.config import _get_file_io_encoding_env_only
+def test_read_config_file_toml_uses_platform_default_encoding():
+    """_read_config_file_toml always uses platform default encoding regardless of file_io config."""
+    from snowflake.cli.api.config import _read_config_file_toml
 
-    assert _get_file_io_encoding_env_only() is None
-
-
-def test_get_file_io_encoding_env_only_returns_env_value(monkeypatch):
-    """_get_file_io_encoding_env_only returns the env var value without reading config."""
-    monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "cp1252")
-    from snowflake.cli.api.config import _get_file_io_encoding_env_only
-
-    assert _get_file_io_encoding_env_only() == "cp1252"
+    mock_path = mock.MagicMock()
+    mock_path.read_text.return_value = ""
+    with mock.patch("snowflake.cli.api.config.get_config_manager") as mock_mgr:
+        mock_mgr.return_value.file_path = mock_path
+        _read_config_file_toml()
+        mock_path.read_text.assert_called_once_with()
 
 
-def test_get_file_io_encoding_env_only_rejects_invalid_encoding(monkeypatch):
-    """_get_file_io_encoding_env_only raises ClickException for an invalid codec."""
-    monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "not-a-real-encoding")
-    from snowflake.cli.api.config import _get_file_io_encoding_env_only
-
-    with pytest.raises(ClickException, match="Invalid encoding 'not-a-real-encoding'"):
-        _get_file_io_encoding_env_only()
-
-
-def test_read_config_file_toml_uses_env_only_encoding(monkeypatch, config_file):
-    """_read_config_file_toml uses env-var encoding, not the config-file encoding setting."""
-    config_content = '[cli.encoding]\nfile_io = "latin-1"\n'
-    with config_file(config_content) as cfg:
-        config_init(cfg)
-        from snowflake.cli.api.config import _read_config_file_toml
-
-        monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "utf-8")
-        mock_path = mock.MagicMock()
-        mock_path.read_text.return_value = ""
-        with mock.patch("snowflake.cli.api.config.get_config_manager") as mock_mgr:
-            mock_mgr.return_value.file_path = mock_path
-            _read_config_file_toml()
-            mock_path.read_text.assert_called_once_with(encoding="utf-8")
-
-
-def test_read_connections_toml_uses_file_io_encoding(monkeypatch, config_file):
-    """_read_connections_toml passes the configured file_io encoding to read_text."""
+def test_read_connections_toml_uses_platform_default_encoding(monkeypatch, config_file):
+    """_read_connections_toml always uses platform default encoding regardless of file_io config."""
     config_content = '[cli.encoding]\nfile_io = "cp1252"\n'
     with config_file(config_content) as cfg:
         config_init(cfg)
@@ -1099,30 +1070,13 @@ def test_read_connections_toml_uses_file_io_encoding(monkeypatch, config_file):
             mock_path.read_text.return_value = ""
             mock_conn_file.return_value = mock_path
             _read_connections_toml()
-            mock_path.read_text.assert_called_once_with(encoding="cp1252")
+            mock_path.read_text.assert_called_once_with()
 
 
-def test_read_connections_toml_uses_none_when_encoding_not_configured(
+def test_update_connections_toml_uses_platform_default_encoding(
     monkeypatch, config_file
 ):
-    """_read_connections_toml passes None (platform default) when no encoding is configured."""
-    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", raising=False)
-    with config_file("") as cfg:
-        config_init(cfg)
-        from snowflake.cli.api.config import _read_connections_toml
-
-        with mock.patch(
-            "snowflake.cli.api.config.get_connections_file"
-        ) as mock_conn_file:
-            mock_path = mock.MagicMock()
-            mock_path.read_text.return_value = ""
-            mock_conn_file.return_value = mock_path
-            _read_connections_toml()
-            mock_path.read_text.assert_called_once_with(encoding=None)
-
-
-def test_update_connections_toml_uses_file_io_encoding(monkeypatch, config_file):
-    """_update_connections_toml passes the configured file_io encoding to open()."""
+    """_update_connections_toml always uses platform default encoding regardless of file_io config."""
     config_content = '[cli.encoding]\nfile_io = "cp1252"\n'
     with config_file(config_content) as cfg:
         config_init(cfg)
@@ -1136,31 +1090,30 @@ def test_update_connections_toml_uses_file_io_encoding(monkeypatch, config_file)
             mock_open.return_value.__exit__ = mock.Mock(return_value=False)
             mock_open.return_value.write = mock.Mock()
             _update_connections_toml({})
-            mock_open.assert_called_once_with(
-                mock_conn_file.return_value, "w", encoding="cp1252"
-            )
+            mock_open.assert_called_once_with(mock_conn_file.return_value, "w")
 
 
-def test_update_connections_toml_uses_none_when_encoding_not_configured(
-    monkeypatch, config_file
-):
-    """_update_connections_toml passes None (platform default) when no encoding is configured."""
-    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", raising=False)
+def test_connections_toml_round_trip(monkeypatch, tmp_path, config_file):
+    """Write and read connections.toml; non-ASCII content survives the round trip."""
+    from snowflake.cli.api.config import (
+        _read_connections_toml,
+        _update_connections_toml,
+    )
+
+    connections_toml = tmp_path / "connections.toml"
+    connections_toml.write_text("")
+
     with config_file("") as cfg:
         config_init(cfg)
-        from snowflake.cli.api.config import _update_connections_toml
+        monkeypatch.setattr(
+            "snowflake.cli.api.config.get_connections_file", lambda: connections_toml
+        )
 
-        with mock.patch(
-            "snowflake.cli.api.config.get_connections_file"
-        ) as mock_conn_file, mock.patch("builtins.open") as mock_open:
-            mock_conn_file.return_value = mock.MagicMock()
-            mock_open.return_value.__enter__ = lambda s: s
-            mock_open.return_value.__exit__ = mock.Mock(return_value=False)
-            mock_open.return_value.write = mock.Mock()
-            _update_connections_toml({})
-            mock_open.assert_called_once_with(
-                mock_conn_file.return_value, "w", encoding=None
-            )
+        original = {"myconn": {"password": "pässwörð"}}
+        _update_connections_toml(original)
+        result = _read_connections_toml()
+
+    assert result == original
 
 
 @pytest.mark.parametrize("bad_value", ["just-a-string", 42, True, ["a", "b"]])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1044,6 +1044,125 @@ show_warnings = false
             config_init(cfg)
 
 
+def test_get_file_io_encoding_env_only_returns_none_when_unset(monkeypatch):
+    """_get_file_io_encoding_env_only returns None when env var not set."""
+    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", raising=False)
+    from snowflake.cli.api.config import _get_file_io_encoding_env_only
+
+    assert _get_file_io_encoding_env_only() is None
+
+
+def test_get_file_io_encoding_env_only_returns_env_value(monkeypatch):
+    """_get_file_io_encoding_env_only returns the env var value without reading config."""
+    monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "cp1252")
+    from snowflake.cli.api.config import _get_file_io_encoding_env_only
+
+    assert _get_file_io_encoding_env_only() == "cp1252"
+
+
+def test_get_file_io_encoding_env_only_rejects_invalid_encoding(monkeypatch):
+    """_get_file_io_encoding_env_only raises ClickException for an invalid codec."""
+    monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "not-a-real-encoding")
+    from snowflake.cli.api.config import _get_file_io_encoding_env_only
+
+    with pytest.raises(ClickException, match="Invalid encoding 'not-a-real-encoding'"):
+        _get_file_io_encoding_env_only()
+
+
+def test_read_config_file_toml_uses_env_only_encoding(monkeypatch, config_file):
+    """_read_config_file_toml uses env-var encoding, not the config-file encoding setting."""
+    config_content = '[cli.encoding]\nfile_io = "latin-1"\n'
+    with config_file(config_content) as cfg:
+        config_init(cfg)
+        from snowflake.cli.api.config import _read_config_file_toml
+
+        monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "utf-8")
+        mock_path = mock.MagicMock()
+        mock_path.read_text.return_value = ""
+        with mock.patch("snowflake.cli.api.config.get_config_manager") as mock_mgr:
+            mock_mgr.return_value.file_path = mock_path
+            _read_config_file_toml()
+            mock_path.read_text.assert_called_once_with(encoding="utf-8")
+
+
+def test_read_connections_toml_uses_file_io_encoding(monkeypatch, config_file):
+    """_read_connections_toml passes the configured file_io encoding to read_text."""
+    config_content = '[cli.encoding]\nfile_io = "cp1252"\n'
+    with config_file(config_content) as cfg:
+        config_init(cfg)
+        from snowflake.cli.api.config import _read_connections_toml
+
+        with mock.patch(
+            "snowflake.cli.api.config.get_connections_file"
+        ) as mock_conn_file:
+            mock_path = mock.MagicMock()
+            mock_path.read_text.return_value = ""
+            mock_conn_file.return_value = mock_path
+            _read_connections_toml()
+            mock_path.read_text.assert_called_once_with(encoding="cp1252")
+
+
+def test_read_connections_toml_uses_none_when_encoding_not_configured(
+    monkeypatch, config_file
+):
+    """_read_connections_toml passes None (platform default) when no encoding is configured."""
+    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", raising=False)
+    with config_file("") as cfg:
+        config_init(cfg)
+        from snowflake.cli.api.config import _read_connections_toml
+
+        with mock.patch(
+            "snowflake.cli.api.config.get_connections_file"
+        ) as mock_conn_file:
+            mock_path = mock.MagicMock()
+            mock_path.read_text.return_value = ""
+            mock_conn_file.return_value = mock_path
+            _read_connections_toml()
+            mock_path.read_text.assert_called_once_with(encoding=None)
+
+
+def test_update_connections_toml_uses_file_io_encoding(monkeypatch, config_file):
+    """_update_connections_toml passes the configured file_io encoding to open()."""
+    config_content = '[cli.encoding]\nfile_io = "cp1252"\n'
+    with config_file(config_content) as cfg:
+        config_init(cfg)
+        from snowflake.cli.api.config import _update_connections_toml
+
+        with mock.patch(
+            "snowflake.cli.api.config.get_connections_file"
+        ) as mock_conn_file, mock.patch("builtins.open") as mock_open:
+            mock_conn_file.return_value = mock.MagicMock()
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = mock.Mock(return_value=False)
+            mock_open.return_value.write = mock.Mock()
+            _update_connections_toml({})
+            mock_open.assert_called_once_with(
+                mock_conn_file.return_value, "w", encoding="cp1252"
+            )
+
+
+def test_update_connections_toml_uses_none_when_encoding_not_configured(
+    monkeypatch, config_file
+):
+    """_update_connections_toml passes None (platform default) when no encoding is configured."""
+    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", raising=False)
+    with config_file("") as cfg:
+        config_init(cfg)
+        from snowflake.cli.api.config import _update_connections_toml
+
+        with mock.patch(
+            "snowflake.cli.api.config.get_connections_file"
+        ) as mock_conn_file, mock.patch("builtins.open") as mock_open:
+            mock_conn_file.return_value = mock.MagicMock()
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = mock.Mock(return_value=False)
+            mock_open.return_value.write = mock.Mock()
+            _update_connections_toml({})
+            mock_open.assert_called_once_with(
+                mock_conn_file.return_value, "w", encoding=None
+            )
+
+
 @pytest.mark.parametrize("bad_value", ["just-a-string", 42, True, ["a", "b"]])
 def test_connection_config_from_dict_rejects_non_mapping(bad_value):
     with pytest.raises(InvalidConnectionConfigurationError) as exc_info:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,8 +167,8 @@ def test_apply_stdout_encoding_from_env_valid(monkeypatch):
     mock_stdout.reconfigure.assert_called_once_with(encoding="utf-8")
 
 
-def test_apply_stdout_encoding_from_env_invalid_warns_and_skips(monkeypatch, capsys):
-    """_apply_stdout_encoding_from_env prints a warning and does NOT reconfigure for invalid codecs."""
+def test_apply_stdout_encoding_from_env_invalid_skips(monkeypatch):
+    """_apply_stdout_encoding_from_env silently skips reconfigure for invalid codecs."""
     monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_STDOUT", "not-a-real-encoding")
     mock_stdout = mock.MagicMock()
     monkeypatch.setattr("sys.stdout", mock_stdout)
@@ -178,9 +178,6 @@ def test_apply_stdout_encoding_from_env_invalid_warns_and_skips(monkeypatch, cap
     _apply_stdout_encoding_from_env()
 
     mock_stdout.reconfigure.assert_not_called()
-    captured = capsys.readouterr()
-    assert "not-a-real-encoding" in captured.err
-    assert "SNOWFLAKE_CLI_ENCODING_STDOUT" in captured.err
 
 
 def test_apply_stdout_encoding_from_env_unset_is_noop(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,6 +154,48 @@ def test_if_there_are_no_option_duplicates(runner, get_click_context):
     assert duplicates == {}, "\n".join(duplicates)
 
 
+def test_apply_stdout_encoding_from_env_valid(monkeypatch):
+    """_apply_stdout_encoding_from_env applies a valid codec without warnings."""
+    monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_STDOUT", "utf-8")
+    mock_stdout = mock.MagicMock()
+    monkeypatch.setattr("sys.stdout", mock_stdout)
+
+    from snowflake.cli._app.__main__ import _apply_stdout_encoding_from_env
+
+    _apply_stdout_encoding_from_env()
+
+    mock_stdout.reconfigure.assert_called_once_with(encoding="utf-8")
+
+
+def test_apply_stdout_encoding_from_env_invalid_warns_and_skips(monkeypatch, capsys):
+    """_apply_stdout_encoding_from_env prints a warning and does NOT reconfigure for invalid codecs."""
+    monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_STDOUT", "not-a-real-encoding")
+    mock_stdout = mock.MagicMock()
+    monkeypatch.setattr("sys.stdout", mock_stdout)
+
+    from snowflake.cli._app.__main__ import _apply_stdout_encoding_from_env
+
+    _apply_stdout_encoding_from_env()
+
+    mock_stdout.reconfigure.assert_not_called()
+    captured = capsys.readouterr()
+    assert "not-a-real-encoding" in captured.err
+    assert "SNOWFLAKE_CLI_ENCODING_STDOUT" in captured.err
+
+
+def test_apply_stdout_encoding_from_env_unset_is_noop(monkeypatch):
+    """_apply_stdout_encoding_from_env does nothing when the env var is absent."""
+    monkeypatch.delenv("SNOWFLAKE_CLI_ENCODING_STDOUT", raising=False)
+    mock_stdout = mock.MagicMock()
+    monkeypatch.setattr("sys.stdout", mock_stdout)
+
+    from snowflake.cli._app.__main__ import _apply_stdout_encoding_from_env
+
+    _apply_stdout_encoding_from_env()
+
+    mock_stdout.reconfigure.assert_not_called()
+
+
 @pytest.mark.skip("Causes fails in specific tests order - SNOW-1057111")
 def test_fail_command_when_default_config_has_too_wide_permissions(
     snowflake_home: Path,


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
Three fixes to the encoding configuration added in #2792:

1. Validate SNOWFLAKE_CLI_ENCODING_STDOUT env var before applying it

_apply_stdout_encoding_from_env was calling sys.stdout.reconfigure with unvalidated input. Invalid codec names now produce a clear warning on stderr instead of silently failing.

2. Restore platform-default encoding for connections.toml

_read_connections_toml and _update_connections_toml were hardcoded to utf-8 after #2792. They now use get_file_io_encoding(), which returns None when not configured — preserving the pre-#2792 platform-default behavior and avoiding potential breakage for users with non-UTF-8 encoded files.

3. Use env-var-only encoding for _read_config_file_toml

_read_config_file_toml now uses a new _get_file_io_encoding_env_only() helper that reads only from SNOWFLAKE_CLI_ENCODING_FILE_IO, not from the config file itself. This avoids a chicken-and-egg dependency and similarly restores the platform-default behavior when no env var is set.

No behavioral change for users who have not configured any encoding settings.
