### PR TITLE
Snowflake Apps: recreate code stage before upload

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@
 * `snow dbt` no longer rejects valid `--dbt-version` values (e.g. `2.0.0-preview.175`) that don't match a hard-coded client-side regex. Versions are now validated against the server's supported list, with unsupported versions failing fast and listing the actual supported set.
 * Fixed `snow app` commands (e.g. `snow app deploy`, `snow app validate`) failing on Windows with a `UnicodeDecodeError` when `snowflake.yml` contained non-ASCII characters (e.g. a non-Latin app title or description). The `snow app` command group now defaults to reading and writing `snowflake.yml` as UTF-8 instead of falling back to the platform default code page (cp1252/cp932 on Windows). An explicit `cli.encoding.file_io` setting still takes precedence when configured; UTF-8 is only the default for `snow app` commands. Other commands continue to honor the `cli.encoding.file_io` setting / platform default when reading project files.
 * The `--deploy-only` flag of `snow app deploy` has been renamed to `--promote-only`. The previous `--deploy-only` name continues to work as a hidden alias for now, but this backward compatibility is temporary and will be removed soon.
+* `snow app deploy` now drops and recreates the code stage before uploading (instead of clearing it with `REMOVE`) so each deploy always starts from an empty stage. This prevents stale files from a previous deploy from being mixed into the build, which could produce incorrect or conflicting build artifacts.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -716,34 +716,22 @@ def snowflake_app_deploy(
                         manager.ensure_workspace_live_version(storage_fqn)
                 else:
                     with metrics.span("snowflake_app.upload.prepare_stage"):
-                        stage_already_exists = manager.stage_exists(storage_fqn)
+                        # Recreate the stage from scratch so the upload always
+                        # starts from an empty stage. Clearing an existing stage
+                        # with REMOVE can leave stale chunks behind that would
+                        # otherwise be mixed into the build and may conflict.
                         try:
-                            if stage_already_exists:
-                                cli_console.step(
-                                    f"Clearing existing stage @{storage_fqn}"
-                                )
-                                manager.clear_stage(storage_fqn)
-                            else:
-                                cli_console.step(f"Creating stage @{storage_fqn}")
-                                manager.create_stage(storage_fqn, encryption_type)
+                            cli_console.step(f"Recreating stage @{storage_fqn}")
+                            manager.drop_stage_if_exists(storage_fqn)
+                            manager.create_stage(storage_fqn, encryption_type)
                         except ProgrammingError as e:
-                            action = (
-                                "clear existing stage"
-                                if stage_already_exists
-                                else "create stage"
-                            )
-                            required_privilege = (
-                                "WRITE on the stage"
-                                if stage_already_exists
-                                else "CREATE STAGE on the schema"
-                            )
                             role = manager.current_role()
                             role_clause = f"role '{role}'" if role else "your role"
                             raise CliError(
-                                f"Failed to {action} '{storage_fqn.identifier}': {e}. "
+                                f"Failed to recreate stage '{storage_fqn.identifier}': {e}. "
                                 f"Verify that {role_clause} has the required "
                                 f"privileges (USAGE on the database and schema, "
-                                f"and {required_privilege})."
+                                f"OWNERSHIP on the stage, and CREATE STAGE on the schema)."
                             ) from e
 
                     with metrics.span("snowflake_app.upload.push_stage_files"):

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -832,18 +832,6 @@ class SnowflakeAppManager(SqlExecutionMixin):
             return []
         return _flatten_missing_privileges(payload)
 
-    def stage_exists(self, stage_fqn: FQN) -> bool:
-        """Check if a stage exists."""
-        try:
-            self.execute_query(f"DESCRIBE STAGE {stage_fqn.sql_identifier}")
-            return True
-        except Exception:
-            return False
-
-    def clear_stage(self, stage_fqn: FQN) -> None:
-        """Clear all files from a stage."""
-        self.execute_query(f"REMOVE @{stage_fqn.identifier}")
-
     def create_stage(
         self, stage_fqn: FQN, encryption_type: str = "SNOWFLAKE_SSE"
     ) -> None:

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1116,25 +1116,6 @@ class TestSnowflakeAppManager:
         assert is_personal_database(database) is expected
 
     @patch(EXECUTE_QUERY)
-    def test_stage_exists_returns_true(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        assert SnowflakeAppManager().stage_exists(fqn) is True
-        mock_execute.assert_called_once_with(
-            "DESCRIBE STAGE IDENTIFIER('DB.SCHEMA.STAGE')"
-        )
-
-    @patch(EXECUTE_QUERY, side_effect=Exception("not found"))
-    def test_stage_exists_returns_false(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        assert SnowflakeAppManager().stage_exists(fqn) is False
-
-    @patch(EXECUTE_QUERY)
-    def test_clear_stage(self, mock_execute):
-        fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
-        SnowflakeAppManager().clear_stage(fqn)
-        mock_execute.assert_called_once_with("REMOVE @DB.SCHEMA.STAGE")
-
-    @patch(EXECUTE_QUERY)
     def test_create_stage(self, mock_execute):
         fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
         SnowflakeAppManager().create_stage(fqn)
@@ -1148,6 +1129,14 @@ class TestSnowflakeAppManager:
         SnowflakeAppManager().create_stage(fqn, "SNOWFLAKE_FULL")
         mock_execute.assert_called_once_with(
             "CREATE STAGE IF NOT EXISTS IDENTIFIER('DB.SCHEMA.STAGE') ENCRYPTION = (TYPE = 'SNOWFLAKE_FULL')"
+        )
+
+    @patch(EXECUTE_QUERY)
+    def test_drop_stage_if_exists(self, mock_execute):
+        fqn = FQN(database="DB", schema="SCHEMA", name="STAGE")
+        SnowflakeAppManager().drop_stage_if_exists(fqn)
+        mock_execute.assert_called_once_with(
+            "DROP STAGE IF EXISTS IDENTIFIER('DB.SCHEMA.STAGE')"
         )
 
     @patch(EXECUTE_QUERY)
@@ -5779,7 +5768,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
             "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
@@ -5797,6 +5785,9 @@ class TestDeployCommand:
             result = runner.invoke(["app", "deploy"])
             assert result.exit_code == 0, result.output
 
+        # The stage is dropped and recreated so the upload always starts from
+        # an empty stage, never reusing files left over from a prior deploy.
+        mock_mgr.drop_stage_if_exists.assert_called_once()
         mock_mgr.create_stage.assert_called_once()
         mock_mgr.create_workspace.assert_not_called()
         mock_mgr.build_app_artifact_repo.assert_called_once_with(
@@ -5872,7 +5863,6 @@ class TestDeployCommand:
         create_error.errno = 3001
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.stage_exists.return_value = False
         mock_mgr.create_stage.side_effect = create_error
         mock_mgr.current_role.return_value = "APP_DEPLOYER"
 
@@ -5882,10 +5872,11 @@ class TestDeployCommand:
             result = runner.invoke(["app", "deploy"])
             assert result.exit_code == 1, result.output
             assert (
-                "Failed to create stage 'TEST_DB.TEST_SCHEMA.MY_STAGE'" in result.output
+                "Failed to recreate stage 'TEST_DB.TEST_SCHEMA.MY_STAGE'"
+                in result.output
             )
             assert "role 'APP_DEPLOYER'" in result.output
-            assert "CREATE STAGE on the schema" in result.output
+            assert "OWNERSHIP on the stage" in result.output
             prepare_span = _get_completed_span("snowflake_app.upload.prepare_stage")
             assert prepare_span[CLIMetricsSpan.ERROR_KEY] == CliError.__name__
 
@@ -5912,7 +5903,7 @@ class TestDeployCommand:
         "snowflake.cli._plugins.apps.commands._resolve_entity_id",
         return_value="my_app",
     )
-    def test_deploy_clear_stage_privilege_error_includes_role_guidance(
+    def test_deploy_drop_stage_privilege_error_includes_role_guidance(
         self,
         mock_resolve,
         mock_get_entity,
@@ -5922,9 +5913,9 @@ class TestDeployCommand:
         runner,
         tmp_path,
     ):
-        """A privilege error while clearing an existing stage reports the clear
-        action and the WRITE privilege hint, and falls back to a generic role
-        phrase when the role cannot be resolved."""
+        """A privilege error while dropping the existing stage reports the
+        recreate action and the OWNERSHIP privilege hint, and falls back to a
+        generic role phrase when the role cannot be resolved."""
         from snowflake.cli.api.project.project_paths import ProjectPaths
 
         entity = Mock()
@@ -5950,8 +5941,9 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.stage_exists.return_value = True
-        mock_mgr.clear_stage.side_effect = ProgrammingError("Insufficient privileges")
+        mock_mgr.drop_stage_if_exists.side_effect = ProgrammingError(
+            "Insufficient privileges"
+        )
         mock_mgr.current_role.return_value = None
 
         with change_directory(tmp_path):
@@ -5960,11 +5952,11 @@ class TestDeployCommand:
             result = runner.invoke(["app", "deploy"])
             assert result.exit_code == 1, result.output
             assert (
-                "Failed to clear existing stage 'TEST_DB.TEST_SCHEMA.MY_STAGE'"
+                "Failed to recreate stage 'TEST_DB.TEST_SCHEMA.MY_STAGE'"
                 in result.output
             )
             assert "your role" in result.output
-            assert "WRITE on the stage" in result.output
+            assert "OWNERSHIP on the stage" in result.output
 
         mock_mgr.create_stage.assert_not_called()
         mock_mgr.build_app_artifact_repo.assert_not_called()
@@ -6193,7 +6185,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
             "Build job submitted: USER$SNOTEBAERT.PUBLIC.BUILD_JOB_123"
@@ -6391,7 +6382,6 @@ class TestDeployCommand:
         mock_mgr.workspace_last_subdirectory_uri.return_value = (
             _WORKSPACE_BUILD_SOURCE_URI
         )
-        mock_mgr.stage_exists.return_value = False
         mock_mgr.artifact_repo_exists.return_value = False
         mock_mgr.build_app_artifact_repo.return_value = (
             "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
@@ -6468,7 +6458,6 @@ class TestDeployCommand:
         mock_perform_bundle.return_value = project_paths
 
         mock_mgr = mock_manager_cls.return_value
-        mock_mgr.stage_exists.return_value = False
 
         from tests_common import change_directory
 
@@ -6552,7 +6541,7 @@ class TestDeployCommand:
         mock_mgr.create_artifact_repo.assert_called_once()
         mock_mgr.build_app_artifact_repo.assert_called_once()
         mock_mgr.create_app_service.assert_not_called()
-        mock_mgr.stage_exists.assert_not_called()
+        mock_mgr.create_stage.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -6614,7 +6603,7 @@ class TestDeployCommand:
 
         mock_mgr.create_app_service.assert_called_once()
         mock_mgr.build_app_artifact_repo.assert_not_called()
-        mock_mgr.stage_exists.assert_not_called()
+        mock_mgr.create_stage.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -6678,7 +6667,7 @@ class TestDeployCommand:
 
         mock_mgr.create_app_service.assert_called_once()
         mock_mgr.build_app_artifact_repo.assert_not_called()
-        mock_mgr.stage_exists.assert_not_called()
+        mock_mgr.create_stage.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -6726,7 +6715,6 @@ class TestDeployCommand:
         bundle_dir = tmp_path / "output" / "bundle"
         bundle_dir.mkdir(parents=True)
         mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
-        mock_manager_cls.return_value.stage_exists.return_value = False
 
         from tests_common import change_directory
 


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
When `snow app deploy` uploads app code to a stage, the stage must be empty before the upload begins. Previously the deploy flow cleared an existing stage with `REMOVE` (`clear_stage`). `REMOVE` does not reliably guarantee an empty stage, so stale chunks from a prior deploy could remain and get mixed into the build, producing incorrect or even conflicting build artifacts.

This PR drops and recreates the code stage before uploading so each deploy always starts from a guaranteed-empty stage.