### PR TITLE
Snowflake Apps: add deploy privilege checks to "snow app validate"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,7 @@
 * Fixed `snow sql` table output rendering as a series of `|` characters when selecting many columns into a non-terminal destination (e.g. piped or redirected output).
 * `get_account_identifier()` and `snow spcs service build-image` now raise a clear, user-visible error when `CURRENT_ORGANIZATION_NAME()` / `CURRENT_ACCOUNT_NAME()` return no row or a NULL value, instead of a cryptic `TypeError: 'NoneType' object is not subscriptable` / `AttributeError: 'NoneType' object has no attribute 'lower'`.
 * `snow app setup` and `snow app deploy` now verify the current role can deploy to the account-configured destination (the `DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE` / `DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA` account defaults) before using it. When the role is missing the required privileges, the commands fall back to your personal database — as if no account default were set — and print a warning listing the missing grants and pointing you to your account administrator.
+* `snow app validate` now checks whether the current role has the privileges required to deploy to the destination configured in `snowflake.yml` (the privileges to create a stage and an artifact repository in the target database/schema), giving a quick signal of whether a subsequent `snow app deploy` would succeed. Validation fails with the list of missing privileges when the role cannot deploy. Because `snow app validate` performs this check up front, `snow app deploy` no longer repeats the (now redundant) account-default privilege probe.
 
 
 # v3.19.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -419,6 +419,30 @@ def snowflake_app_validate(entity_id: Optional[str]) -> CommandResult:
                         f"or is not accessible."
                     )
 
+            # ── Validate deploy privileges ────────────────────────────
+            # Probe the representative DDL ``snow app deploy`` runs against the
+            # destination so the user gets a quick, up-front signal of whether a
+            # deploy would succeed instead of failing late mid-deploy. ``snow app
+            # deploy`` trusts this check and skips its own privilege probe.
+            cli_console.step(
+                f"Checking deploy privileges on "
+                f"{sanitize_for_terminal(database)}.{sanitize_for_terminal(schema)}..."
+            )
+            with metrics.span("snowflake_app.validate.check_privileges"):
+                role = manager.current_role()
+                missing_privileges = manager.missing_deploy_privileges(
+                    database, schema, role
+                )
+            if missing_privileges:
+                role_label = f" '{sanitize_for_terminal(role)}'" if role else ""
+                raise CliError(
+                    f"Your current role{role_label} is missing privileges "
+                    f"required to deploy to "
+                    f"'{sanitize_for_terminal(database)}.{sanitize_for_terminal(schema)}': "
+                    f"{', '.join(missing_privileges)}. Grant the missing "
+                    f"privileges or update the destination in {DEFINITION_FILENAME}."
+                )
+
     # ── Validate project can bundle artifacts ─────────────────────────
     project_paths = None
     try:
@@ -609,8 +633,13 @@ def snowflake_app_deploy(
     app_icon = entity.meta.icon if entity.meta else None
 
     # ── Resolve defaults (snowflake.yml > account parameters > built-in) ──
+    # ``check_account_default_privileges=False``: ``snow app validate`` already
+    # probes deploy privileges up front, so re-running the account-default
+    # privilege check here would be redundant.
     manager = SnowflakeAppManager(interactive=interactive)
-    defaults = _resolve_deploy_defaults(entity, manager, app_name=app_name)
+    defaults = _resolve_deploy_defaults(
+        entity, manager, app_name=app_name, check_account_default_privileges=False
+    )
 
     database = defaults["database"]
     schema = defaults["schema"]

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -475,6 +475,7 @@ def _resolve_deploy_defaults(
     entity: "SnowflakeAppEntityModel",
     manager: "SnowflakeAppManager",
     app_name: Optional[str] = None,
+    check_account_default_privileges: bool = True,
 ) -> Dict[str, Optional[str]]:
     """Resolve deploy defaults using a four-tier precedence:
 
@@ -488,6 +489,14 @@ def _resolve_deploy_defaults(
     ``artifact_repo_database``, ``artifact_repo_schema``, ``database``,
     and ``schema``.  Any of them may still be ``None`` if no source
     provides a value.
+
+    When *check_account_default_privileges* is true (the default) the
+    account-configured destination database/schema is probed with
+    ``EXPLAIN_PRIVILEGES`` and dropped — falling back to the personal database —
+    when the current role cannot deploy there. ``snow app deploy`` passes
+    ``False`` because ``snow app validate`` already performs a comprehensive
+    privilege check up front (see :meth:`SnowflakeAppManager.missing_deploy_privileges`),
+    making the deploy-time probe redundant.
     """
 
     # ── 1. snowflake.yml values ───────────────────────────────────────
@@ -527,8 +536,10 @@ def _resolve_deploy_defaults(
         )
         # Drop the account-configured destination database/schema when the
         # current role cannot access them so resolution falls back to the
-        # personal database below.
-        raw_params = _filter_accessible_remote_defaults(manager, raw_params)
+        # personal database below. Skipped for callers (``snow app deploy``)
+        # that rely on ``snow app validate`` to have already checked privileges.
+        if check_account_default_privileges:
+            raw_params = _filter_accessible_remote_defaults(manager, raw_params)
         param_vals = dict(raw_params)
 
     # ── 3. Built-in defaults ────────────────────────────────────────────
@@ -831,6 +842,53 @@ class SnowflakeAppManager(SqlExecutionMixin):
             log.debug("Could not parse EXPLAIN_PRIVILEGES output: %r", row[0])
             return []
         return _flatten_missing_privileges(payload)
+
+    def missing_deploy_privileges(
+        self,
+        database: str,
+        schema: str,
+        role: Optional[str] = None,
+    ) -> list[str]:
+        """Return descriptions of the privileges *role* is missing to deploy to
+        *database*.*schema*, or an empty list when the role can deploy there.
+
+        Each representative DDL statement ``snow app deploy`` runs against the
+        destination (see :func:`_deploy_privilege_check_statements`) is analyzed
+        with ``EXPLAIN_PRIVILEGES`` via :meth:`get_missing_privileges`. A
+        statement that cannot be analyzed at all — e.g. the role cannot resolve
+        the destination, which ``EXPLAIN_PRIVILEGES`` rejects with "requires
+        access on all objects" — is itself treated as a failure rather than
+        skipped, mirroring deploy's own access requirements.
+
+        Results are returned as de-duplicated, terminal-safe strings ready to
+        embed in an error message. When the destination could not be analyzed
+        and no specific privileges were reported, a generic "access to database"
+        description is returned so the caller still surfaces an actionable
+        failure. ``snow app validate`` calls this to give the user a quick
+        signal of whether a subsequent ``snow app deploy`` would succeed.
+        """
+        statements = _deploy_privilege_check_statements(database, schema)
+        missing: list[Dict[str, str]] = []
+        check_failed = False
+        for statement in statements:
+            try:
+                statement_missing = self.get_missing_privileges(statement, role)
+            except Exception:
+                check_failed = True
+                log.debug(
+                    "Could not analyze deploy privilege statement: %s",
+                    statement,
+                    exc_info=True,
+                )
+                continue
+            if statement_missing:
+                check_failed = True
+                missing.extend(statement_missing)
+        if not check_failed:
+            return []
+        return _format_missing_privileges(missing) or [
+            f"access to database '{sanitize_for_terminal(database)}'"
+        ]
 
     def stage_exists(self, stage_fqn: FQN) -> bool:
         """Check if a stage exists."""

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -979,6 +979,65 @@ class TestGetMissingPrivileges:
         )
 
 
+class TestMissingDeployPrivileges:
+    """Unit tests for the aggregate deploy privilege probe that backs
+    ``snow app validate``."""
+
+    @patch(GET_MISSING_PRIVILEGES, return_value=[])
+    def test_no_missing_privileges_returns_empty(self, mock_missing):
+        result = SnowflakeAppManager().missing_deploy_privileges(
+            "APPS", "PUBLIC", "ENGINEER"
+        )
+        assert result == []
+        # Every representative deploy statement is probed for the given role.
+        assert mock_missing.call_count == 2
+        for call in mock_missing.call_args_list:
+            assert call.args[1] == "ENGINEER"
+
+    @patch(GET_MISSING_PRIVILEGES)
+    def test_aggregates_and_formats_missing_privileges(self, mock_missing):
+        mock_missing.side_effect = [
+            [
+                {
+                    "privilege": "CREATE STAGE",
+                    "objectType": "SCHEMA",
+                    "objectName": "A.B",
+                }
+            ],
+            [
+                {
+                    "privilege": "CREATE ARTIFACT REPOSITORY",
+                    "objectType": "SCHEMA",
+                    "objectName": "A.B",
+                }
+            ],
+        ]
+        result = SnowflakeAppManager().missing_deploy_privileges("A", "B", "ENGINEER")
+        assert result == [
+            "CREATE STAGE on SCHEMA A.B",
+            "CREATE ARTIFACT REPOSITORY on SCHEMA A.B",
+        ]
+
+    @patch(GET_MISSING_PRIVILEGES)
+    def test_analysis_error_reports_generic_access(self, mock_missing):
+        # Every probe statement fails to analyze, which means the role cannot
+        # resolve the destination at all -> generic, actionable description.
+        mock_missing.side_effect = ProgrammingError("requires access on all objects")
+        result = SnowflakeAppManager().missing_deploy_privileges("A", "B", "ENGINEER")
+        assert result == ["access to database 'A'"]
+
+    @patch(GET_MISSING_PRIVILEGES)
+    def test_partial_error_still_fails(self, mock_missing):
+        # One statement cannot be analyzed while the other is clean: the role
+        # cannot fully deploy, so the check still fails.
+        mock_missing.side_effect = [
+            ProgrammingError("requires access on all objects"),
+            [],
+        ]
+        result = SnowflakeAppManager().missing_deploy_privileges("A", "B", "ENGINEER")
+        assert result == ["access to database 'A'"]
+
+
 class TestAppFqn:
     """``app_fqn`` is the apps-plugin FQN factory: it routes each component
     through :func:`to_identifier` so the resulting FQN's ``identifier`` /
@@ -2675,6 +2734,38 @@ class TestResolveDeployDefaults:
         mock_console.warning.assert_called_once()
         assert "PARAM_DB" in mock_console.warning.call_args[0][0]
 
+    @patch(MANAGER_CLI_CONSOLE)
+    @patch(
+        FETCH_SNOW_APPS_PARAMS,
+        return_value={"database": "PARAM_DB", "schema": "PARAM_SCHEMA"},
+    )
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    @patch(GET_MISSING_PRIVILEGES)
+    @patch(CURRENT_ROLE, return_value="ENGINEER")
+    def test_check_account_default_privileges_false_skips_probe(
+        self,
+        mock_role,
+        mock_missing,
+        mock_ctx,
+        mock_params,
+        mock_console,
+    ):
+        """With the privilege probe disabled (as ``snow app deploy`` calls it,
+        trusting ``snow app validate``) the account-configured destination is
+        used as-is and ``EXPLAIN_PRIVILEGES`` is never invoked."""
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(database=None, schema=None)
+        result = _resolve_deploy_defaults(
+            entity,
+            SnowflakeAppManager(),
+            check_account_default_privileges=False,
+        )
+        assert result["database"] == "PARAM_DB"
+        assert result["schema"] == "PARAM_SCHEMA"
+        mock_missing.assert_not_called()
+        mock_console.warning.assert_not_called()
+
 
 class TestFlattenMissingPrivileges:
     def test_authorized_returns_empty(self):
@@ -4100,6 +4191,8 @@ class TestValidateCommand:
         mock_mgr = mock_manager_cls.return_value
         mock_mgr.database_exists.return_value = True
         mock_mgr.schema_exists.return_value = True
+        mock_mgr.current_role.return_value = "ENGINEER"
+        mock_mgr.missing_deploy_privileges.return_value = []
         return mock_mgr
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
@@ -4182,6 +4275,111 @@ class TestValidateCommand:
             result = runner.invoke(["app", "validate"])
             assert result.exit_code == 1
             assert "Schema 'TEST_DB.TEST_SCHEMA' does not exist" in result.output
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_validate_checks_deploy_privileges(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_perform_bundle,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """A valid project probes deploy privileges on the resolved destination."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        mock_get_entity.return_value = self._make_validate_entity()
+        mock_mgr = self._configure_manager_mock(mock_manager_cls)
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "validate"])
+            assert result.exit_code == 0, result.output
+            assert "Checking deploy privileges on TEST_DB.TEST_SCHEMA" in result.output
+            mock_mgr.missing_deploy_privileges.assert_called_once_with(
+                "TEST_DB", "TEST_SCHEMA", "ENGINEER"
+            )
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_validate_fails_when_deploy_privileges_missing(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_perform_bundle,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """Missing deploy privileges fail validation with an actionable message
+        and skip bundling (no point bundling a project that cannot deploy)."""
+        mock_get_entity.return_value = self._make_validate_entity()
+        mock_mgr = self._configure_manager_mock(mock_manager_cls)
+        mock_mgr.missing_deploy_privileges.return_value = [
+            "CREATE STAGE on SCHEMA TEST_DB.TEST_SCHEMA",
+            "CREATE ARTIFACT REPOSITORY on SCHEMA TEST_DB.TEST_SCHEMA",
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "validate"])
+            assert result.exit_code == 1
+            assert "is missing privileges required to deploy" in result.output
+            assert "'ENGINEER'" in result.output
+            assert "CREATE STAGE on SCHEMA TEST_DB.TEST_SCHEMA" in result.output
+            assert "snowflake.yml" in result.output
+            mock_perform_bundle.assert_not_called()
+
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_validate_skips_privilege_check_without_schema(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_perform_bundle,
+        mock_manager_cls,
+        runner,
+        tmp_path,
+    ):
+        """Without a resolved schema the privilege probe (which needs a fully
+        qualified destination) is skipped rather than guessed."""
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        entity.fqn = Mock(database="TEST_DB", schema=None, name="MY_APP")
+        mock_get_entity.return_value = entity
+        mock_mgr = self._configure_manager_mock(mock_manager_cls)
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        mock_perform_bundle.return_value = ProjectPaths(project_root=tmp_path)
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "validate"])
+            assert result.exit_code == 0, result.output
+            mock_mgr.missing_deploy_privileges.assert_not_called()
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
@@ -5010,6 +5208,67 @@ class TestDeployCommand:
             mock_mgr.build_app_artifact_repo.assert_not_called()
             mock_mgr.artifact_repo_exists.assert_not_called()
             mock_mgr.create_app_service.assert_called_once()
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": None,
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": None,
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_skips_redundant_account_default_privilege_probe(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        """Deploy resolves defaults with the account-default privilege probe
+        disabled — ``snow app validate`` owns that check now."""
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = None
+        entity.artifacts = []
+        entity.meta = None
+        entity.artifact_repository = None
+        mock_get_entity.return_value = entity
+
+        mock_poll.return_value = {
+            "url": "my-app.snowflakecomputing.app",
+            "is_upgrading": "false",
+        }
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy", "--promote-only"])
+            assert result.exit_code == 0, result.output
+            mock_defaults.assert_called_once()
+            assert (
+                mock_defaults.call_args.kwargs["check_account_default_privileges"]
+                is False
+            )
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

Make `snow app validate` a quick pre-flight signal for whether a subsequent `snow app deploy` would succeed, for projects generated by `snow app setup` (and possibly hand-edited afterwards).

**`snow app validate`** — after confirming the destination database/schema exist, it now goes over the SQL `snow app deploy` executes and converts the analyzable statements into a permission check. It probes the representative DDL deploy runs against the destination (`CREATE STAGE` and `CREATE ARTIFACT REPOSITORY`) using `EXPLAIN_PRIVILEGES`, reusing the existing `get_missing_privileges`. Validation fails with the concrete list of missing privileges (and the active role) when the current role cannot deploy there, telling the user to grant the privileges or fix the destination in `snowflake.yml`. Statements that `EXPLAIN_PRIVILEGES` cannot analyze (objects that do not exist yet, e.g. the application service / package), statements that only need `USAGE`, and the workspace-upload path used solely for the personal-database default are intentionally not probed — they cannot be checked reliably before deploy.

**`snow app deploy`** — because `snow app validate` now owns the privilege gate, deploy no longer repeats the redundant account-default privilege probe. A new `check_account_default_privileges` flag on `_resolve_deploy_defaults` lets deploy opt out; `snow app setup` and `snow app teardown` keep their existing fallback behavior.
