### PR TITLE
Snowflake Apps: upload code files in parallel

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@
 * Fixed `snow app` commands (e.g. `snow app deploy`, `snow app validate`) failing on Windows with a `UnicodeDecodeError` when `snowflake.yml` contained non-ASCII characters (e.g. a non-Latin app title or description). The `snow app` command group now defaults to reading and writing `snowflake.yml` as UTF-8 instead of falling back to the platform default code page (cp1252/cp932 on Windows). An explicit `cli.encoding.file_io` setting still takes precedence when configured; UTF-8 is only the default for `snow app` commands. Other commands continue to honor the `cli.encoding.file_io` setting / platform default when reading project files.
 * The `--deploy-only` flag of `snow app deploy` has been renamed to `--promote-only`. The previous `--deploy-only` name continues to work as a hidden alias for now, but this backward compatibility is temporary and will be removed soon.
 * `snow app deploy` now drops and recreates the code stage before uploading (instead of clearing it with `REMOVE`) so each deploy always starts from an empty stage. This prevents stale files from a previous deploy from being mixed into the build, which could produce incorrect or conflicting build artifacts.
+* `snow app deploy` now uploads app code files in parallel (up to 5 at a time) instead of one at a time, reducing upload time for apps with many files. This applies to both the stage and workspace upload paths.
 
 
 # v3.20.0

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -19,9 +19,22 @@ import json
 import logging
 import re
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
+from contextvars import copy_context
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Optional, Set, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
 DEFAULT_PERSONAL_SCHEMA = "PUBLIC"
 # Shared workspace name used when ``snow app setup`` resolves the destination
@@ -166,6 +179,13 @@ def app_fqn(
 
 DEFINITION_FILENAME = "snowflake.yml"
 SNOWFLAKE_APP_ENTITY_TYPE = "snowflake-app"
+
+# Maximum number of files uploaded concurrently during the code-upload phase.
+# Each file is sent with its own ``PUT``; the Snowflake connector permits a
+# single connection to be shared across threads (DB API 2.0 threadsafety
+# level 2), so several PUTs can run at once to hide per-statement round-trip
+# latency. Capped to avoid overwhelming the connection or the local machine.
+MAX_PARALLEL_UPLOADS = 5
 
 
 # Mapping from SHOW PARAMETERS result names to internal resolution keys.
@@ -717,6 +737,10 @@ class SnowflakeAppManager(SqlExecutionMixin):
         # callers (e.g. ``snow app deploy``) pass the resolved
         # ``--interactive`` / ``--no-interactive`` flag.
         self._interactive = interactive
+        # Set while uploads run concurrently. The per-query spinner uses a Rich
+        # live display, of which only one may be active at a time, so concurrent
+        # PUTs must not each open their own spinner.
+        self._suppress_query_spinner = False
 
     @property
     def _is_interactive(self) -> bool:
@@ -733,8 +757,12 @@ class SnowflakeAppManager(SqlExecutionMixin):
         skipped for non-interactive runs (``--no-interactive``, piped/redirected
         output, CI, etc.) where its control characters would pollute captured
         output.
+
+        The spinner is also skipped while ``_suppress_query_spinner`` is set
+        (during concurrent uploads) because Rich permits only one live display
+        at a time.
         """
-        if not self._is_interactive:
+        if self._suppress_query_spinner or not self._is_interactive:
             return super().execute_query(query, **kwargs)
         with cli_console.spinner() as spinner:
             spinner.add_task(description="", total=None)
@@ -944,6 +972,52 @@ class SnowflakeAppManager(SqlExecutionMixin):
             f"REMOVE {self.workspace_subdirectory_uri(workspace_fqn, directory_name)}/"
         )
 
+    def _run_uploads(
+        self, uploads: List[Tuple[str, Dict[str, str]]]
+    ) -> Iterator[Dict[str, str]]:
+        """Run a batch of ``PUT`` statements, up to :data:`MAX_PARALLEL_UPLOADS`
+        at a time, yielding each file's result dict as its upload completes.
+
+        *uploads* is a list of ``(put_sql, result)`` pairs.  Each ``PUT`` is
+        executed on its own cursor; the Snowflake connector allows a single
+        connection to be shared across threads (DB API 2.0 threadsafety level
+        2), so running several at once hides per-statement round-trip latency.
+        The per-query spinner is suppressed for the duration because Rich
+        permits only one live display at a time and concurrent spinners would
+        corrupt the terminal; callers still stream progress from the yielded
+        results.
+
+        The CLI context (used to resolve the shared connection, among other
+        things) lives in a :class:`~contextvars.ContextVar`, which is *not*
+        inherited by ``ThreadPoolExecutor`` worker threads.  Each ``PUT`` is
+        therefore run inside a per-task :func:`~contextvars.copy_context`
+        snapshot of the current context, so workers resolve the same connection
+        the main thread would.  A fresh copy per task is required: a single
+        ``Context`` cannot be entered by two threads at once.
+
+        Results are yielded in completion order.  The first worker error is
+        re-raised after the pool shuts down so a failed upload surfaces to the
+        caller.
+        """
+        if not uploads:
+            return
+        previous_suppress = self._suppress_query_spinner
+        self._suppress_query_spinner = True
+        try:
+            with ThreadPoolExecutor(max_workers=MAX_PARALLEL_UPLOADS) as executor:
+                future_to_result = {}
+                for put_sql, result in uploads:
+                    ctx = copy_context()
+                    future = executor.submit(ctx.run, self.execute_query, put_sql)
+                    future_to_result[future] = result
+                for future in as_completed(future_to_result):
+                    # Propagate the first failure; remaining futures are
+                    # cancelled/awaited by the context manager on exit.
+                    future.result()
+                    yield future_to_result[future]
+        finally:
+            self._suppress_query_spinner = previous_suppress
+
     def upload_to_workspace(
         self,
         local_root: Path,
@@ -959,8 +1033,9 @@ class SnowflakeAppManager(SqlExecutionMixin):
         one-at-a-time (rather than via ``PUT <dir>/*``) because the glob
         form also matches subdirectories, and the Snowflake PUT endpoint
         rejects directories with ``253006: Not a file but a directory``.
+        Up to :data:`MAX_PARALLEL_UPLOADS` files are uploaded concurrently.
         Each uploaded file is yielded as a dict with ``source`` and
-        ``target`` keys so callers can display progress.
+        ``target`` keys (in completion order) so callers can display progress.
         """
         base_uri = self.workspace_uri(workspace_fqn)
         if target_subdirectory:
@@ -971,6 +1046,7 @@ class SnowflakeAppManager(SqlExecutionMixin):
         overwrite_str = str(overwrite).lower()
         from snowflake.cli.api.project.util import to_string_literal
 
+        uploads: List[Tuple[str, Dict[str, str]]] = []
         for path in sorted(local_root.rglob("*")):
             if not path.is_file():
                 continue
@@ -987,11 +1063,15 @@ class SnowflakeAppManager(SqlExecutionMixin):
             # ER_FILE_NOT_EXISTS). ``local_path_to_file_uri`` returns a value
             # ready to embed directly, so it must not be re-quoted.
             local_uri = _local_path_to_file_uri(str(path.resolve()))
-            self.execute_query(
+            put_sql = (
                 f"PUT {local_uri} {to_string_literal(dest_dir)} "
                 f"auto_compress=false overwrite={overwrite_str}"
             )
-            yield {"source": str(rel), "target": f"{dest_dir}{path.name}"}
+            uploads.append(
+                (put_sql, {"source": str(rel), "target": f"{dest_dir}{path.name}"})
+            )
+
+        yield from self._run_uploads(uploads)
 
     def upload_to_stage(
         self,
@@ -1010,12 +1090,14 @@ class SnowflakeAppManager(SqlExecutionMixin):
         and, unlike a recursive ``PUT`` of the bundle root, does not mutate
         the local bundle while uploading.
 
+        Up to :data:`MAX_PARALLEL_UPLOADS` files are uploaded concurrently.
         Each uploaded file is yielded as a dict with ``source`` and
-        ``target`` keys so callers can display progress.
+        ``target`` keys (in completion order) so callers can display progress.
         """
         local_root = local_root.resolve()
         base_path = StagePath.from_stage_str(f"@{stage_fqn.identifier}")
         overwrite_str = str(overwrite).lower()
+        uploads: List[Tuple[str, Dict[str, str]]] = []
         for path in sorted(local_root.rglob("*")):
             if not path.is_file():
                 continue
@@ -1029,14 +1111,21 @@ class SnowflakeAppManager(SqlExecutionMixin):
             # paths like ``file://C:/...``. ``_local_path_to_file_uri`` returns
             # a value ready to embed directly, so it must not be re-quoted.
             local_uri = _local_path_to_file_uri(str(path.resolve()))
-            self.execute_query(
+            put_sql = (
                 f"PUT {local_uri} {dest_path.path_for_sql()} "
                 f"auto_compress=false overwrite={overwrite_str}"
             )
-            yield {
-                "source": str(rel),
-                "target": f"{dest_path.absolute_path()}/{path.name}",
-            }
+            uploads.append(
+                (
+                    put_sql,
+                    {
+                        "source": str(rel),
+                        "target": f"{dest_path.absolute_path()}/{path.name}",
+                    },
+                )
+            )
+
+        yield from self._run_uploads(uploads)
 
     def get_service_status(self, service_fqn: FQN) -> str:
         """

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -1339,6 +1339,164 @@ class TestSnowflakeAppManager:
         local = source[len("file://") :]
         assert globmod.glob(local) == [str((nested / "page.tsx").resolve())]
 
+    @pytest.mark.parametrize("upload", ["stage", "workspace"])
+    @patch(EXECUTE_QUERY)
+    def test_uploads_run_up_to_max_parallel(self, mock_execute, upload, tmp_path):
+        """Files are PUT concurrently, up to ``MAX_PARALLEL_UPLOADS`` at once.
+
+        Each worker records the live concurrency; the peak must reach the
+        configured limit (proving real parallelism) and never exceed it
+        (proving the cap holds) even with more files than the limit."""
+        import threading
+
+        from snowflake.cli._plugins.apps.manager import MAX_PARALLEL_UPLOADS
+
+        # More files than the parallel limit, so the cap is actually exercised.
+        num_files = MAX_PARALLEL_UPLOADS + 3
+        for i in range(num_files):
+            (tmp_path / f"f{i}.py").write_text(str(i))
+        fqn = FQN(database="DB", schema="SCHEMA", name="THING")
+
+        lock = threading.Lock()
+        state = {"current": 0, "peak": 0}
+        # Released once the parallel limit is reached, so the peak reflects true
+        # concurrency rather than scheduling luck. A sequential implementation
+        # would never set the event and trip the (failure-only) wait timeout.
+        limit_reached = threading.Event()
+
+        def fake_execute(query, **kwargs):
+            with lock:
+                state["current"] += 1
+                state["peak"] = max(state["peak"], state["current"])
+                if state["current"] >= MAX_PARALLEL_UPLOADS:
+                    limit_reached.set()
+            limit_reached.wait(timeout=5)
+            with lock:
+                state["current"] -= 1
+            return Mock()
+
+        mock_execute.side_effect = fake_execute
+
+        if upload == "stage":
+            results = list(
+                SnowflakeAppManager().upload_to_stage(
+                    local_root=tmp_path, stage_fqn=fqn
+                )
+            )
+        else:
+            results = list(
+                SnowflakeAppManager().upload_to_workspace(
+                    local_root=tmp_path, workspace_fqn=fqn, target_subdirectory="MY_APP"
+                )
+            )
+
+        assert len(results) == num_files
+        assert mock_execute.call_count == num_files
+        assert state["peak"] == MAX_PARALLEL_UPLOADS
+
+    @patch("snowflake.cli.api.sql_execution.BaseSqlExecutor.execute_query")
+    @patch(MANAGER_CLI_CONSOLE)
+    def test_parallel_uploads_suppress_per_query_spinner(
+        self, mock_console, mock_base_execute, tmp_path
+    ):
+        """Concurrent PUTs must not each open a per-query spinner (Rich allows
+        only one live display at a time), and the spinner is restored for
+        queries issued after the upload batch completes."""
+        for i in range(3):
+            (tmp_path / f"f{i}.py").write_text(str(i))
+        fqn = FQN(database="DB", schema="SCHEMA", name="MY_STAGE")
+
+        manager = SnowflakeAppManager(interactive=True)
+        list(manager.upload_to_stage(local_root=tmp_path, stage_fqn=fqn))
+
+        # No spinner was opened for any of the concurrent PUTs.
+        mock_console.spinner.assert_not_called()
+
+        # Suppression is scoped to the batch: a later query opens the spinner.
+        manager.execute_query("SELECT 1")
+        mock_console.spinner.assert_called_once_with()
+
+    @patch(EXECUTE_QUERY)
+    def test_uploads_propagate_cli_context_to_workers(self, mock_execute, tmp_path):
+        """Each PUT must run inside the caller's context so the CLI context —
+        which resolves the shared connection — is reachable from the worker
+        thread. A bare ``ThreadPoolExecutor`` thread starts with an empty
+        context and would fail with 'There is no active click context'; the
+        context is propagated via ``copy_context`` instead."""
+        import contextvars
+
+        # A ContextVar set on the main thread stands in for the CLI context;
+        # workers must observe the main-thread value, not the empty default.
+        sentinel = contextvars.ContextVar("apps_upload_test_sentinel", default=None)
+        token = sentinel.set("main-thread-value")
+        seen = []
+
+        def fake_execute(query, **kwargs):
+            seen.append(sentinel.get())
+            return Mock()
+
+        mock_execute.side_effect = fake_execute
+        try:
+            (tmp_path / "a.py").write_text("1")
+            (tmp_path / "b.py").write_text("2")
+            fqn = FQN(database="DB", schema="SCHEMA", name="MY_STAGE")
+            list(
+                SnowflakeAppManager().upload_to_stage(
+                    local_root=tmp_path, stage_fqn=fqn
+                )
+            )
+        finally:
+            sentinel.reset(token)
+
+        assert seen == ["main-thread-value", "main-thread-value"]
+
+    @pytest.mark.parametrize("upload", ["stage", "workspace"])
+    @patch(EXECUTE_QUERY)
+    def test_upload_propagates_worker_error(self, mock_execute, upload, tmp_path):
+        """A failed PUT in any worker surfaces to the caller."""
+        for i in range(4):
+            (tmp_path / f"f{i}.py").write_text(str(i))
+        fqn = FQN(database="DB", schema="SCHEMA", name="THING")
+        mock_execute.side_effect = ProgrammingError("upload failed")
+
+        with pytest.raises(ProgrammingError):
+            if upload == "stage":
+                list(
+                    SnowflakeAppManager().upload_to_stage(
+                        local_root=tmp_path, stage_fqn=fqn
+                    )
+                )
+            else:
+                list(
+                    SnowflakeAppManager().upload_to_workspace(
+                        local_root=tmp_path,
+                        workspace_fqn=fqn,
+                        target_subdirectory="MY_APP",
+                    )
+                )
+
+    @pytest.mark.parametrize("upload", ["stage", "workspace"])
+    @patch(EXECUTE_QUERY)
+    def test_upload_empty_bundle_yields_nothing(self, mock_execute, upload, tmp_path):
+        """An empty bundle issues no PUTs and yields no results."""
+        fqn = FQN(database="DB", schema="SCHEMA", name="THING")
+
+        if upload == "stage":
+            results = list(
+                SnowflakeAppManager().upload_to_stage(
+                    local_root=tmp_path, stage_fqn=fqn
+                )
+            )
+        else:
+            results = list(
+                SnowflakeAppManager().upload_to_workspace(
+                    local_root=tmp_path, workspace_fqn=fqn, target_subdirectory="MY_APP"
+                )
+            )
+
+        assert results == []
+        mock_execute.assert_not_called()
+
     @pytest.mark.parametrize(
         "native_path,expected_uri",
         [


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
`snow app deploy` previously uploaded app code one file at a time, issuing a
separate `PUT` and waiting for each round-trip to complete before starting the
next. For apps with many files this serialized upload dominates deploy time.

This change uploads up to 5 files concurrently across both upload code paths:

- `SnowflakeAppManager.upload_to_workspace` (used for workspace destinations)
- `SnowflakeAppManager.upload_to_stage` (used for stage destinations)
