### PR TITLE
fix: [SNOW-3444081] skip role validation in profiles.yml for Jinja-templated values and improve output message

### DIFF
--- a/src/snowflake/cli/_plugins/dbt/manager.py
+++ b/src/snowflake/cli/_plugins/dbt/manager.py
@@ -45,6 +45,9 @@ DBT_ENV_SECRET_PREFIX = "DBT_ENV_SECRET_"
 _ENV_VAR_KEY_PREFIX = "DBT_"
 _ENV_VAR_KEY_RE = re.compile(r"^[A-Za-z0-9_]+$")
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+# Matches any Jinja expression ({{ ... }}). Used to skip local role validation for
+# templated values that GS resolves at CREATE/execute time.
+_JINJA_EXPR = re.compile(r"\{\{.*?\}\}", re.DOTALL)
 
 
 def _reject_control_chars(value: Optional[str], flag_name: str) -> Optional[str]:
@@ -506,7 +509,7 @@ class DBTManager(SqlExecutionMixin):
                 f"Missing required fields: {', '.join(sorted(missing_keys))} in target {target_name}"
             )
         if role := target_details.get("role"):
-            if not self._validate_role(role_name=role):
+            if not _JINJA_EXPR.search(role) and not self._validate_role(role_name=role):
                 errors.append(f"Role '{role}' does not exist or is not accessible.")
         return errors
 
@@ -576,27 +579,31 @@ class DBTManager(SqlExecutionMixin):
         if use_shell_env_vars:
             shell_vars, dropped_secret_count, skipped_count = _collect_shell_env_vars()
             if dropped_secret_count:
+                _var = "variable" if dropped_secret_count == 1 else "variables"
                 cli_console.message(
                     f"--use-shell-env-vars: dropped {dropped_secret_count} "
-                    f"{DBT_ENV_SECRET_PREFIX}* environment variable(s) from "
+                    f"{DBT_ENV_SECRET_PREFIX}* environment {_var} from "
                     "shell. To forward secrets, use the secrets: block in "
                     "env.yml referencing a Snowflake SECRET object, or if "
                     "those are not sensitive, pass them explicitly via "
                     "--env-vars."
                 )
             if skipped_count:
+                _var = "variable" if skipped_count == 1 else "variables"
                 cli_console.message(
                     f"--use-shell-env-vars: skipped {skipped_count} DBT_* shell "
-                    "environment variable(s) that can't be forwarded; keys "
+                    f"environment {_var} that can't be forwarded; keys "
                     "must be uppercase and contain only letters, digits, and "
                     "underscores (e.g. export DBT_FOO, not DBT_Foo)."
                 )
             if shell_vars:
+                _var = "variable" if len(shell_vars) == 1 else "variables"
                 cli_console.warning(
                     f"--use-shell-env-vars: forwarded {len(shell_vars)} shell "
-                    "environment variable(s) into query text. Never put "
-                    "credentials, tokens, passwords, or other confidential "
-                    "data in shell environment variables with the DBT_ prefix."
+                    f"environment {_var} starting with DBT_* into query text. "
+                    "Never put credentials, tokens, passwords, or other "
+                    "confidential data in shell environment variables with "
+                    "the DBT_ prefix."
                 )
             elif not dropped_secret_count and not skipped_count:
                 cli_console.message(

--- a/tests/dbt/test_dbt_commands.py
+++ b/tests/dbt/test_dbt_commands.py
@@ -1175,7 +1175,11 @@ class TestDBTExecute:
             mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
             "ENV_VARS=('DBT_BAR'='2', 'DBT_FOO'='1') args='run'"
         )
-        assert "forwarded 2 shell environment variable(s)" in result.output
+        assert (
+            "forwarded 2 shell environment variables starting with DBT_*"
+            in result.output
+        )
+        assert "the DBT_ prefix" in result.output
 
     def test_use_shell_env_vars_drops_secret_prefix(
         self, mock_connect, mock_cursor, runner, clean_dbt_env
@@ -1205,7 +1209,7 @@ class TestDBTExecute:
         )
         assert "should-not-appear" not in query
         assert "should-not-appear" not in result.output
-        assert "dropped 1 DBT_ENV_SECRET_* environment variable(s)" in result.output
+        assert "dropped 1 DBT_ENV_SECRET_* environment variable from" in result.output
 
     def test_use_shell_env_vars_only_secrets_present(
         self, mock_connect, mock_cursor, runner, clean_dbt_env
@@ -1233,7 +1237,7 @@ class TestDBTExecute:
             mock_connect.mocked_ctx.get_query()
             == "EXECUTE DBT PROJECT pipeline_name args='run'"
         )
-        assert "dropped 1 DBT_ENV_SECRET_* environment variable(s)" in result.output
+        assert "dropped 1 DBT_ENV_SECRET_* environment variable from" in result.output
         # The dropped-secret message explains the empty result; the generic
         # "no DBT_* found / how to export" hint must NOT fire (the user clearly
         # knows how to export — they exported a secret).
@@ -1303,7 +1307,7 @@ class TestDBTExecute:
             mock_connect.mocked_ctx.get_query() == "EXECUTE DBT PROJECT pipeline_name "
             "ENV_VARS=('DBT_FOO'='1') args='run'"
         )
-        assert "skipped 1 DBT_* shell environment variable(s)" in result.output
+        assert "skipped 1 DBT_* shell environment variable that" in result.output
         # Forwarding still happened, so the empty-state hint must not fire.
         assert "no DBT_* environment variables found" not in result.output
 

--- a/tests/dbt/test_manager.py
+++ b/tests/dbt/test_manager.py
@@ -707,6 +707,29 @@ dev
         assert "does not exist or is not accessible" in exc_info.value.message
         assert "test_role" in exc_info.value.message
 
+    @pytest.mark.parametrize(
+        "role_expr",
+        [
+            "{{ env_var('DBT_ROLE') }}",
+            '{{ env_var("DBT_ROLE") }}',
+            "{{ env_var('DBT_ROLE', 'default_role') }}",
+            "{{env_var('DBT_ROLE')}}",
+            "{{ select CURRENT_ROLE() }}",
+            "{{ some_unknown_expr }}",
+        ],
+    )
+    def test_validate_profiles_skips_role_validation_for_jinja_expression(
+        self, mock_validate_role, project_path, profile, role_expr
+    ):
+        profile["dev"]["outputs"]["local"]["role"] = role_expr
+        self._generate_profile(project_path, profile)
+
+        DBTManager()._validate_profiles(  # noqa: SLF001
+            SecurePath(project_path), "dev", None
+        )
+
+        mock_validate_role.assert_not_called()
+
     @mock.patch("snowflake.cli._plugins.dbt.manager.StageManager.create")
     @mock.patch("snowflake.cli._plugins.dbt.manager.StageManager.put_recursive")
     def test_deploy_create_with_dbt_version(


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [ ] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [ ] I've confirmed my changes are up-to-date with the target branch.
   * [ ] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
1. When profiles.yml uses a Jinja expression as the role value (e.g. {{ env_var('DBT_ROLE') }}), _validate_role tried to USE ROLE with the raw template string, which Snowflake rejects. Jinja-templated values are resolved by GS at CREATE/execute time — skip local validation for them and let the server surface any errors.
2. Improve `--use-shell-env-vars` output messages — replaces variable(s) with proper singular/plural, and adds "starting with DBT_*" to the forwarded-vars warning for clarity.     
