### PR TITLE
Snowflake Apps: always use managed compute pools

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 ## New additions
 
 ## Fixes and improvements
+* `snow app setup` no longer writes `build_compute_pool` / `service_compute_pool` to the generated `snowflake.yml`, and no longer reads the `DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL` / `DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL` account parameters. Snowflake App Runtime services now always run on server-managed compute pools. Existing projects that set these fields in `snowflake.yml` continue to be honored by `snow app deploy`.
 
 
 # v3.21.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -314,19 +314,11 @@ def snowflake_app_setup(
                 account_param=params.get("query_warehouse"),
                 current_session=session_wh,
             ),
-            # Compute pools are resolved from the (hidden) ``--compute-pool`` flag
-            # and the ``DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL`` /
-            # ``DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL`` account parameters.
-            # Both stay omitted from the generated ``snowflake.yml`` when neither
-            # source provides a value, letting the server pick pools at deploy time.
-            "build_compute_pool": _resolve(
-                user_input=compute_pool,
-                account_param=params.get("build_compute_pool"),
-            ),
-            "service_compute_pool": _resolve(
-                user_input=compute_pool,
-                account_param=params.get("service_compute_pool"),
-            ),
+            # Compute pools are intentionally not resolved or written: app
+            # services always run on server-managed compute pools, so
+            # ``snow app setup`` never configures ``build_compute_pool`` /
+            # ``service_compute_pool``. The (hidden) ``--compute-pool`` flag is
+            # accepted for backward compatibility but no longer has any effect.
             # TODO: Remove --build-eai argument once the builder service no longer
             # requires an external access integration.
             "build_eai": _resolve(

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -28,11 +28,14 @@ def _generate_snowflake_yml(
 
     Required keys: ``database``, ``schema``, ``warehouse``.
 
-    Optional keys: ``build_compute_pool``, ``service_compute_pool``,
-    ``build_eai``.  When omitted or ``None`` the corresponding block is left
-    out of the generated YAML, letting the server allocate compute pools at
-    deploy time.  ``build_eai`` is omitted when no external access
-    integration is required by the builder service.
+    Optional keys: ``build_eai``.  When omitted or ``None`` the corresponding
+    block is left out of the generated YAML.  ``build_eai`` is omitted when no
+    external access integration is required by the builder service.
+
+    Compute pools are never written: app services always run on
+    server-managed compute pools, so ``snow app setup`` does not configure
+    ``build_compute_pool`` / ``service_compute_pool``. Existing projects that
+    set those fields by hand continue to work at deploy time.
 
     The artifact repository is omitted from the generated YAML; the CLI
     will default to ``<app-id>_REPO`` at deploy time.
@@ -51,8 +54,6 @@ def _generate_snowflake_yml(
     database = resolved["database"]
     schema = resolved["schema"]
     warehouse = resolved["warehouse"]
-    build_compute_pool = resolved.get("build_compute_pool")
-    service_compute_pool = resolved.get("service_compute_pool")
     build_eai = resolved.get("build_eai")
 
     if use_workspace:
@@ -66,18 +67,6 @@ def _generate_snowflake_yml(
         )
     else:
         code_storage_block = f"\n            code_stage: {app_id.upper()}_CODE\n"
-
-    build_compute_pool_block = (
-        f"\n            build_compute_pool:\n              name: {build_compute_pool}"
-        if build_compute_pool
-        else ""
-    )
-
-    service_compute_pool_block = (
-        f"\n            service_compute_pool:\n              name: {service_compute_pool}"
-        if service_compute_pool
-        else ""
-    )
 
     build_eai_block = (
         f"\n            build_eai:\n              name: {build_eai}"
@@ -109,8 +98,6 @@ def _generate_snowflake_yml(
                   - snowflake.log
 
             query_warehouse: {warehouse}"""
-        + build_compute_pool_block
-        + service_compute_pool_block
         + build_eai_block
         + code_storage_block
     )

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -189,10 +189,13 @@ MAX_PARALLEL_UPLOADS = 5
 
 
 # Mapping from SHOW PARAMETERS result names to internal resolution keys.
+#
+# Compute pools are intentionally absent: app services always run on
+# server-managed compute pools, so the ``DEFAULT_SNOWFLAKE_APPS_*_COMPUTE_POOL``
+# account parameters are no longer fetched. Compute pools are only honored when
+# set explicitly in an existing ``snowflake.yml``.
 _SNOW_APPS_PARAM_MAP = {
     "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE": "query_warehouse",
-    "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL": "build_compute_pool",
-    "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL": "service_compute_pool",
     "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION": "build_eai",
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE": "database",
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA": "schema",
@@ -508,6 +511,11 @@ def _resolve_deploy_defaults(
     ``artifact_repo_database``, ``artifact_repo_schema``, ``database``,
     and ``schema``.  Any of them may still be ``None`` if no source
     provides a value.
+
+    ``build_compute_pool`` and ``service_compute_pool`` are resolved only
+    from ``snowflake.yml`` (tier 1): app services otherwise run on
+    server-managed compute pools, so the account parameters and built-in
+    defaults never supply them.
     """
 
     # ── 1. snowflake.yml values ───────────────────────────────────────
@@ -1187,7 +1195,9 @@ class SnowflakeAppManager(SqlExecutionMixin):
 
         Runs ``SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER``
         and returns a dict whose keys match the internal resolution names
-        (``query_warehouse``, ``build_compute_pool``, etc.).
+        (``query_warehouse``, ``build_eai``, etc.). Compute pool parameters
+        are intentionally ignored — app services run on server-managed
+        compute pools.
 
         Empty-string parameter values are treated as "not set" and omitted.
         Returns an empty dict on any error (e.g. insufficient privileges).

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -598,8 +598,6 @@ class TestGenerateSnowflakeYml:
         "database": "TEST_DB",
         "schema": "SNOW_APPS",
         "warehouse": "TEST_WH",
-        "build_compute_pool": "MY_POOL",
-        "service_compute_pool": "MY_POOL",
         "build_eai": "MY_EAI",
     }
 
@@ -612,7 +610,6 @@ class TestGenerateSnowflakeYml:
         assert "database: TEST_DB" in result
         assert "schema: SNOW_APPS" in result
         assert "query_warehouse: TEST_WH" in result
-        assert "name: MY_POOL" in result
         assert "name: MY_EAI" in result
         # code_workspace is a shared workspace, fully-qualified.
         assert "code_workspace: TEST_DB.SNOW_APPS.SNOWFLAKE_APPS" in result
@@ -647,42 +644,14 @@ class TestGenerateSnowflakeYml:
         result = _generate_snowflake_yml("my_app", resolved, use_workspace=False)
         assert "build_eai" not in result
 
-    def test_build_compute_pool_omitted_when_none(self):
-        """When ``build_compute_pool`` is None (e.g. account opted into a
-        managed build compute pool), the generated YAML omits the
-        ``build_compute_pool`` block but still emits
-        ``service_compute_pool``."""
-        resolved = {**self._BASE_RESOLVED, "build_compute_pool": None}
-        result = _generate_snowflake_yml("my_app", resolved, use_workspace=False)
-        assert "build_compute_pool" not in result
-        assert "service_compute_pool" in result
-        assert "None" not in result
-
-    def test_build_compute_pool_omitted_when_missing_key(self):
-        """``build_compute_pool`` may be omitted from the resolved dict
-        entirely; the generated YAML still produces a valid project."""
-        resolved = {
-            k: v for k, v in self._BASE_RESOLVED.items() if k != "build_compute_pool"
-        }
-        result = _generate_snowflake_yml("my_app", resolved, use_workspace=False)
-        assert "build_compute_pool" not in result
-        assert "service_compute_pool" in result
-
-    def test_service_compute_pool_omitted_when_none(self):
-        """When ``service_compute_pool`` is None the generated YAML omits
-        the ``service_compute_pool`` block."""
-        resolved = {**self._BASE_RESOLVED, "service_compute_pool": None}
-        result = _generate_snowflake_yml("my_app", resolved, use_workspace=False)
-        assert "service_compute_pool" not in result
-        assert "None" not in result
-
-    def test_both_compute_pools_omitted_when_none(self):
-        """The managed-compute-pool flow omits both pool blocks while still
-        producing a valid YAML body."""
+    def test_compute_pools_never_emitted(self):
+        """App services run on server-managed compute pools, so the generated
+        YAML never contains compute-pool blocks — even if the resolved values
+        somehow carry them."""
         resolved = {
             **self._BASE_RESOLVED,
-            "build_compute_pool": None,
-            "service_compute_pool": None,
+            "build_compute_pool": "MY_POOL",
+            "service_compute_pool": "SVC_POOL",
         }
         result = _generate_snowflake_yml("my_app", resolved, use_workspace=False)
         assert "build_compute_pool" not in result
@@ -691,20 +660,17 @@ class TestGenerateSnowflakeYml:
         assert "query_warehouse: TEST_WH" in result
         assert "build_eai" in result
 
-    def test_yml_without_compute_pools_is_valid_project_definition(self):
-        """A generated YAML without either compute-pool block still parses
-        cleanly into a project definition."""
+    def test_generated_yml_has_unset_compute_pools_when_parsed(self):
+        """The generated YAML (without compute-pool blocks) parses cleanly
+        into a project definition with unset compute pools."""
         import yaml
         from snowflake.cli.api.utils.definition_rendering import (
             render_definition_template,
         )
 
-        resolved = {
-            **self._BASE_RESOLVED,
-            "build_compute_pool": None,
-            "service_compute_pool": None,
-        }
-        raw_yml = _generate_snowflake_yml("my_app", resolved, use_workspace=False)
+        raw_yml = _generate_snowflake_yml(
+            "my_app", self._BASE_RESOLVED, use_workspace=False
+        )
         definition_input = yaml.safe_load(raw_yml)
         result = render_definition_template(definition_input, {})
         entity = result.project_definition.entities["my_app"]
@@ -2403,16 +2369,6 @@ class TestFetchSnowAppsParameters:
                         "level": "ACCOUNT",
                     },
                     {
-                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
-                        "value": "MY_POOL",
-                        "level": "ACCOUNT",
-                    },
-                    {
-                        "key": "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL",
-                        "value": "SVC_POOL",
-                        "level": "ACCOUNT",
-                    },
-                    {
                         "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION",
                         "value": "MY_EAI",
                         "level": "ACCOUNT",
@@ -2434,14 +2390,44 @@ class TestFetchSnowAppsParameters:
         result = SnowflakeAppManager().fetch_snow_apps_parameters()
         assert result == {
             "query_warehouse": "MY_WH",
-            "build_compute_pool": "MY_POOL",
-            "service_compute_pool": "SVC_POOL",
             "build_eai": "MY_EAI",
             "database": "MY_DB",
             "schema": "MY_SCHEMA",
         }
         query = mock_execute.call_args[0][0]
         assert "SHOW PARAMETERS LIKE 'DEFAULT_SNOWFLAKE_APPS_%' IN USER" in query
+
+    @patch(EXECUTE_QUERY)
+    def test_ignores_compute_pool_parameters(self, mock_execute):
+        """Compute pool account parameters are no longer fetched — app
+        services run on server-managed compute pools."""
+        cursor = Mock()
+        cursor.__iter__ = Mock(
+            return_value=iter(
+                [
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE",
+                        "value": "MY_WH",
+                        "level": "ACCOUNT",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
+                        "value": "MY_POOL",
+                        "level": "ACCOUNT",
+                    },
+                    {
+                        "key": "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL",
+                        "value": "SVC_POOL",
+                        "level": "ACCOUNT",
+                    },
+                ]
+            )
+        )
+        mock_execute.return_value = cursor
+        result = SnowflakeAppManager().fetch_snow_apps_parameters()
+        assert result == {"query_warehouse": "MY_WH"}
+        assert "build_compute_pool" not in result
+        assert "service_compute_pool" not in result
 
     @patch(EXECUTE_QUERY)
     def test_ignores_empty_string_values(self, mock_execute):
@@ -2455,7 +2441,7 @@ class TestFetchSnowAppsParameters:
                         "level": "ACCOUNT",
                     },
                     {
-                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION",
                         "value": "",
                         "level": "ACCOUNT",
                     },
@@ -2465,7 +2451,7 @@ class TestFetchSnowAppsParameters:
         mock_execute.return_value = cursor
         result = SnowflakeAppManager().fetch_snow_apps_parameters()
         assert result == {"query_warehouse": "MY_WH"}
-        assert "build_compute_pool" not in result
+        assert "build_eai" not in result
 
     @patch(EXECUTE_QUERY)
     def test_ignores_unknown_parameters(self, mock_execute):
@@ -2535,13 +2521,13 @@ class TestFetchSnowAppsParameters:
                     # level="" means Snowflake is reporting the built-in default
                     # (e.g. after ALTER ACCOUNT UNSET). Should be skipped.
                     {
-                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL",
-                        "value": "SYSTEM_COMPUTE_POOL_CPU",
+                        "key": "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION",
+                        "value": "SYSTEM_DEFAULT_EAI",
                         "level": "",
                     },
                     {
-                        "key": "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL",
-                        "value": "SYSTEM_COMPUTE_POOL_CPU",
+                        "key": "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE",
+                        "value": "SYSTEM_DEFAULT_DB",
                         "level": "",
                     },
                     # Explicitly set at account level — should be included.
@@ -2556,8 +2542,8 @@ class TestFetchSnowAppsParameters:
         mock_execute.return_value = cursor
         result = SnowflakeAppManager().fetch_snow_apps_parameters()
         assert result == {"query_warehouse": "MY_WH"}
-        assert "build_compute_pool" not in result
-        assert "service_compute_pool" not in result
+        assert "build_eai" not in result
+        assert "database" not in result
 
 
 # ── _resolve_deploy_defaults tests ────────────────────────────────────
@@ -2631,8 +2617,6 @@ class TestResolveDeployDefaults:
         FETCH_SNOW_APPS_PARAMS,
         return_value={
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -2647,11 +2631,13 @@ class TestResolveDeployDefaults:
         entity = self._make_entity(database=None, schema=None)
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
         assert result["query_warehouse"] == "PARAM_WH"
-        assert result["build_compute_pool"] == "PARAM_POOL"
-        assert result["service_compute_pool"] == "PARAM_SVC_POOL"
         assert result["build_eai"] == "PARAM_EAI"
         assert result["database"] == "PARAM_DB"
         assert result["schema"] == "PARAM_SCHEMA"
+        # Compute pools are never supplied by account parameters; with no
+        # snowflake.yml values they stay unset (server-managed).
+        assert result["build_compute_pool"] is None
+        assert result["service_compute_pool"] is None
 
     @patch(
         FETCH_SNOW_APPS_PARAMS,
@@ -3083,8 +3069,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 
@@ -3097,8 +3081,9 @@ class TestSetupCommand:
         resolved = mock_gen.call_args[0][1]
         assert resolved["database"] == "PARAM_DB"
         assert resolved["warehouse"] == "PARAM_WH"
-        assert resolved["build_compute_pool"] == "PARAM_POOL"
         assert resolved["build_eai"] == "PARAM_EAI"
+        assert "build_compute_pool" not in resolved
+        assert "service_compute_pool" not in resolved
         assert mock_gen.call_args.kwargs["use_workspace"] is False
 
     @patch(
@@ -3231,8 +3216,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 
@@ -3311,8 +3294,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 
@@ -3337,8 +3318,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             # no build_eai
         }
 
@@ -3361,8 +3340,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 
@@ -3385,8 +3362,9 @@ class TestSetupCommand:
             assert parsed["success"] is False
             assert parsed["database"] == "PARAM_DB"
             assert parsed["warehouse"] == "PARAM_WH"
-            assert parsed["build_compute_pool"] == "PARAM_POOL"
             assert parsed["build_eai"] == "PARAM_EAI"
+            assert "build_compute_pool" not in parsed
+            assert "service_compute_pool" not in parsed
 
     @patch(
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
@@ -3403,8 +3381,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 
@@ -3440,8 +3416,6 @@ class TestSetupCommand:
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 
@@ -3452,7 +3426,8 @@ class TestSetupCommand:
             assert result.exit_code == 0, result.output
             assert "database: PARAM_DB" in result.output
             assert "warehouse: PARAM_WH" in result.output
-            assert "build_compute_pool: PARAM_POOL" in result.output
+            assert "build_compute_pool" not in result.output
+            assert "service_compute_pool" not in result.output
 
     @patch(
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
@@ -3463,8 +3438,6 @@ class TestSetupCommand:
         """CLI flags should override Snowflake App Runtime parameters."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3480,8 +3453,6 @@ class TestSetupCommand:
                     "setup",
                     "--app-name",
                     "my_app",
-                    "--compute-pool",
-                    "FLAG_POOL",
                     "--build-eai",
                     "FLAG_EAI",
                 ]
@@ -3489,7 +3460,6 @@ class TestSetupCommand:
             assert result.exit_code == 0, result.output
 
         resolved = mock_gen.call_args[0][1]
-        assert resolved["build_compute_pool"] == "FLAG_POOL"
         assert resolved["build_eai"] == "FLAG_EAI"
         # These come from params since no flag overrides them
         assert resolved["database"] == "PARAM_DB"
@@ -3783,8 +3753,6 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
@@ -3809,8 +3777,6 @@ class TestSetupCommand:
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
         mock_mgr.get_personal_database.return_value = "USER$MYUSER"
@@ -3839,8 +3805,6 @@ class TestSetupCommand:
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
         mock_mgr.get_personal_database.return_value = None
@@ -3885,13 +3849,12 @@ class TestSetupCommand:
         return_value="definition_version: '2'\n",
     )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_compute_pools_resolved_from_account_params(
+    def test_compute_pools_not_resolved_from_account_params(
         self, mock_mgr_cls, mock_gen, runner, tmp_path
     ):
-        """``build_compute_pool`` and ``service_compute_pool`` are resolved
-        from the ``DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL`` /
-        ``DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL`` account parameters and
-        forwarded to the generated snowflake.yml."""
+        """App services run on server-managed compute pools, so ``snow app
+        setup`` never writes compute pools — even if a (legacy) account
+        parameter still surfaces them."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
@@ -3906,26 +3869,22 @@ class TestSetupCommand:
             assert result.exit_code == 0, result.output
 
         resolved = mock_gen.call_args[0][1]
-        assert resolved["build_compute_pool"] == "PARAM_POOL"
-        assert resolved["service_compute_pool"] == "PARAM_SVC_POOL"
+        assert "build_compute_pool" not in resolved
+        assert "service_compute_pool" not in resolved
 
     @patch(
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
         return_value="definition_version: '2'\n",
     )
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_compute_pool_flag_overrides_account_params(
-        self, mock_mgr_cls, mock_gen, runner, tmp_path
-    ):
-        """The (hidden) ``--compute-pool`` flag takes precedence over the
-        account-parameter compute pools for both build and service pools."""
+    def test_compute_pool_flag_is_noop(self, mock_mgr_cls, mock_gen, runner, tmp_path):
+        """The (hidden) ``--compute-pool`` flag is accepted for backward
+        compatibility but no longer configures any compute pool."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "PARAM_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
         }
 
         with change_directory(tmp_path):
@@ -3942,16 +3901,15 @@ class TestSetupCommand:
             assert result.exit_code == 0, result.output
 
         resolved = mock_gen.call_args[0][1]
-        assert resolved["build_compute_pool"] == "FLAG_POOL"
-        assert resolved["service_compute_pool"] == "FLAG_POOL"
+        assert "build_compute_pool" not in resolved
+        assert "service_compute_pool" not in resolved
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_compute_pools_omitted_when_no_source_provides_them(
         self, mock_mgr_cls, runner, tmp_path
     ):
-        """When neither the flag nor account parameters provide compute pools,
-        both fields are omitted from setup output so the server allocates the
-        pools at deploy time."""
+        """Compute pools are always omitted from setup output so the server
+        allocates the pools at deploy time."""
         mock_mgr = mock_mgr_cls.return_value
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
@@ -3968,9 +3926,11 @@ class TestSetupCommand:
             assert "service_compute_pool" not in result.output
 
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
-    def test_compute_pools_dry_run_json_output(self, mock_mgr_cls, runner, tmp_path):
-        """In JSON output mode, the account-parameter compute pools are
-        reported under their resolution keys."""
+    def test_compute_pools_absent_from_dry_run_json_output(
+        self, mock_mgr_cls, runner, tmp_path
+    ):
+        """JSON output never reports compute pools, even when a legacy account
+        parameter still surfaces them."""
         import json as json_mod
 
         mock_mgr = mock_mgr_cls.return_value
@@ -3997,8 +3957,8 @@ class TestSetupCommand:
             assert result.exit_code == 0, result.output
 
         parsed = json_mod.loads(result.output)
-        assert parsed["build_compute_pool"] == "PARAM_POOL"
-        assert parsed["service_compute_pool"] == "PARAM_SVC_POOL"
+        assert "build_compute_pool" not in parsed
+        assert "service_compute_pool" not in parsed
 
     @patch(
         "snowflake.cli._plugins.apps.commands._generate_snowflake_yml",
@@ -4014,14 +3974,10 @@ class TestSetupCommand:
         content round-trips without corruption on non-UTF-8 platforms."""
         monkeypatch.setenv("SNOWFLAKE_CLI_ENCODING_FILE_IO", "utf-8")
         mock_mgr = mock_mgr_cls.return_value
-        mock_mgr.is_managed_compute_pool_enabled.return_value = False
-        mock_mgr.is_managed_compute_pool_fallback_enabled.return_value = False
         mock_mgr.fetch_snow_apps_parameters.return_value = {
             "database": "PARAM_DB",
             "schema": "PARAM_SCHEMA",
             "query_warehouse": "ENTREPÔT_WH",
-            "build_compute_pool": "PARAM_POOL",
-            "service_compute_pool": "PARAM_SVC_POOL",
             "build_eai": "PARAM_EAI",
         }
 

--- a/tests_integration/apps/test_snowflake_apps.py
+++ b/tests_integration/apps/test_snowflake_apps.py
@@ -42,7 +42,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-COMPUTE_POOL = "snowcli_compute_pool"
 DATABASE = os.environ.get("SNOWFLAKE_CONNECTIONS_INTEGRATION_DATABASE", "SNOWCLI_DB")
 SCHEMA = os.environ.get("SNOWFLAKE_CONNECTIONS_INTEGRATION_SCHEMA", "public")
 WAREHOUSE = os.environ.get("SNOWFLAKE_CONNECTIONS_INTEGRATION_WAREHOUSE", "xsmall")
@@ -50,8 +49,6 @@ BUILD_EAI = "cli_test_integration"
 
 _ACCOUNT_PARAMS = {
     "DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE": WAREHOUSE,
-    "DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL": COMPUTE_POOL,
-    "DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL": COMPUTE_POOL,
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE": DATABASE,
     "DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA": SCHEMA,
     "DEFAULT_SNOWFLAKE_APPS_BUILD_EXTERNAL_ACCESS_INTEGRATION": "",
@@ -85,10 +82,14 @@ def test_setup_resolves_from_account_parameters(
 ):
     """All ``DEFAULT_SNOWFLAKE_APPS_*`` account parameters drive ``snow app setup``.
 
-    No CLI flags for compute/db/warehouse are passed, so values must come from
+    No CLI flags for db/warehouse are passed, so values must come from
     the USER ("account") parameters set by the autouse session fixture.
     Asserts every resolved field is reflected in the generated YAML and that
     the source label printed by the resolver is ``(account parameter)``.
+
+    Compute pools are intentionally not resolved or written: app services run
+    on server-managed compute pools, so ``snow app setup`` never emits
+    ``build_compute_pool`` / ``service_compute_pool``.
     """
     result = runner.invoke_with_connection(
         ["app", "setup", "--app-name", "param_app", "--build-eai", BUILD_EAI]
@@ -99,11 +100,12 @@ def test_setup_resolves_from_account_parameters(
         f"database: {DATABASE}  (account parameter)",
         f"schema: {SCHEMA}  (account parameter)",
         f"warehouse: {WAREHOUSE}  (account parameter)",
-        f"build_compute_pool: {COMPUTE_POOL}  (account parameter)",
-        f"service_compute_pool: {COMPUTE_POOL}  (account parameter)",
     ]
     for expected in expected_source_lines:
         assert expected in result.output, result.output
+
+    assert "build_compute_pool" not in result.output, result.output
+    assert "service_compute_pool" not in result.output, result.output
 
     yml_path = Path(temporary_working_directory) / "snowflake.yml"
     assert yml_path.exists(), "snowflake.yml was not created"
@@ -115,5 +117,5 @@ def test_setup_resolves_from_account_parameters(
     assert entity["identifier"]["database"] == DATABASE
     assert entity["identifier"]["schema"] == SCHEMA
     assert entity["query_warehouse"] == WAREHOUSE
-    assert entity["build_compute_pool"]["name"] == COMPUTE_POOL
-    assert entity["service_compute_pool"]["name"] == COMPUTE_POOL
+    assert "build_compute_pool" not in entity
+    assert "service_compute_pool" not in entity


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description

Snowflake App Runtime services now always run on server-managed compute pools, so the CLI no longer configures compute pools.

- `snow app setup` no longer writes `build_compute_pool` / `service_compute_pool` to the generated `snowflake.yml`, and no longer prints them in the resolved-config / `--dry-run` / JSON output. The hidden `--compute-pool` flag is now a no-op, kept only for backward compatibility.
- The `DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL` / `DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL` account parameters are no longer fetched or resolved.
- Existing projects that set `build_compute_pool` / `service_compute_pool` in `snowflake.yml` keep working: the fields stay parseable and `snow app deploy` still forwards them to the server.
