### PR TITLE
Snowflake Apps: keep setup dry runs non-failing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 
 ## Fixes and improvements
 * `snow app setup` no longer writes `build_compute_pool` / `service_compute_pool` to the generated `snowflake.yml`, and no longer reads the `DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL` / `DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL` account parameters. Snowflake App Runtime services now always run on server-managed compute pools. Existing projects that set these fields in `snowflake.yml` continue to be honored by `snow app deploy`.
+* `snow app setup --dry-run` now exits with code 0 while still printing the same setup validation errors that a non-dry-run invocation surfaces.
 
 
 # v3.21.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -197,190 +197,196 @@ def snowflake_app_setup(
     """
     ctx = get_cli_context()
     metrics = ctx.metrics
-    with metrics.span("snowflake_app.setup"):
-        resolved_app_name = app_name
-        if resolved_app_name is None:
-            derived_app_name = Path.cwd().name
-            # For implicit names, normalize directory strings into a valid
-            # identifier by mapping common separators to "_" and stripping
-            # all other disallowed characters.
-            resolved_app_name = re.sub(
-                r"[^a-zA-Z0-9_]",
-                "",
-                derived_app_name.replace(" ", "_").replace("-", "_"),
-            )
-
-        if not resolved_app_name:
-            raise ClickException(
-                "Could not derive app name from the current directory. "
-                "Please provide --app-name."
-            )
-
-        if not re.fullmatch(r"[a-zA-Z0-9_]+", resolved_app_name):
-            raise ClickException(
-                f"Invalid app name '{resolved_app_name}'. "
-                "Only letters, digits, and underscores are allowed."
-            )
-        # snowflake.yml is a CLI-owned manifest that the ``snow app`` commands read
-        # back with the same encoding policy (see _app_group_callback): an explicit
-        # cli.encoding.file_io setting wins, otherwise UTF-8. Writing it the same
-        # way keeps the round-trip consistent regardless of the host code page, even
-        # when the generated content (e.g. a non-Latin app title) is non-ASCII.
-        encoding = get_file_io_encoding() or "utf-8"
-        project_file = Path.cwd() / DEFINITION_FILENAME
-        if not dry_run and project_file.exists():
-            return MessageResult(
-                f"{DEFINITION_FILENAME} already exists. Skipping initialization."
-            )
-
-        connection_name = (
-            ctx.connection_context.connection_name or get_default_connection_name()
-        )
-        conn_config = get_connection_dict(connection_name)
-
-        manager = SnowflakeAppManager()
-        with metrics.span("snowflake_app.setup.resolve_defaults"):
-            params = manager.fetch_snow_apps_parameters()
-            # Drop the account-configured destination database/schema the current
-            # role cannot access so resolution falls back to the personal database.
-            params = _filter_accessible_remote_defaults(manager, params)
-
-        def _resolve(
-            user_input=None,
-            account_param=None,
-            default_value=None,
-            current_session=None,
-        ):
-            """Return (value, source) using a fixed resolution order.
-
-            Resolution: user_input > account_param > default_value > current_session.
-            """
-            if user_input is not None:
-                return user_input, SOURCE_USER_INPUT
-            if account_param is not None:
-                return account_param, SOURCE_ACCOUNT_PARAM
-            if default_value is not None:
-                return default_value, SOURCE_DEFAULT
-            if current_session is not None:
-                return current_session, SOURCE_CURRENT_SESSION
-            return None, SOURCE_MISSING
-
-        # ── Pre-compute current session values ─────────────────────────────
-        conn = ctx.connection_context
-        # ``conn.warehouse/database/schema`` are only non-None when the user
-        # explicitly passed the corresponding connection-override flag on the
-        # command line (e.g. ``--warehouse MY_WH``).  Values from the
-        # connection config file come through ``conn_config`` instead.
-        cli_wh = getattr(conn, "warehouse", None) or None
-        cli_db = getattr(conn, "database", None) or None
-        cli_schema = getattr(conn, "schema", None) or None
-
-        # A user-supplied database must be paired with an explicit schema: schema
-        # resolution would otherwise fall back to an account parameter or the
-        # personal-database default, silently placing the app in a schema that does
-        # not belong to the requested database.
-        if cli_db and not cli_schema:
-            raise CliError(
-                "--schema is required when --database is specified. "
-                "Provide --schema to select the schema within the requested database."
-            )
-
-        session_wh = conn_config.get("warehouse") or None
-        session_db = conn_config.get("database") or None
-        session_schema = conn_config.get("schema") or None
-
-        with metrics.span("snowflake_app.setup.get_personal_database"):
-            personal_db = manager.get_personal_database()
-        personal_schema = DEFAULT_PERSONAL_SCHEMA if personal_db else None
-
-        # ── Resolve each field ────────────────────────────────────────────
-        resolved = {
-            "database": _resolve(
-                user_input=cli_db,
-                account_param=params.get("database"),
-                default_value=personal_db,
-                current_session=session_db,
-            ),
-            # TODO: Support per-app schema (e.g. APPS.APP_<app_id>) instead of
-            # a single shared schema for all apps.
-            "schema": _resolve(
-                user_input=cli_schema,
-                account_param=params.get("schema"),
-                default_value=personal_schema,
-                current_session=session_schema,
-            ),
-            "warehouse": _resolve(
-                user_input=cli_wh,
-                account_param=params.get("query_warehouse"),
-                current_session=session_wh,
-            ),
-            # Compute pools are intentionally not resolved or written: app
-            # services always run on server-managed compute pools, so
-            # ``snow app setup`` never configures ``build_compute_pool`` /
-            # ``service_compute_pool``. The (hidden) ``--compute-pool`` flag is
-            # accepted for backward compatibility but no longer has any effect.
-            # TODO: Remove --build-eai argument once the builder service no longer
-            # requires an external access integration.
-            "build_eai": _resolve(
-                user_input=build_eai,
-                account_param=params.get("build_eai"),
-            ),
-        }
-
-        # ── Validate required values ─────────────────────────────────────
-        if not resolved["database"][0]:
-            raise ClickException(
-                "Missing database. Provide --database, set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE account parameter, or check your connection."
-            )
-        if not resolved["schema"][0]:
-            raise ClickException(
-                "Missing schema. Provide --schema, set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA account parameter, or check your connection."
-            )
-        if not resolved["warehouse"][0]:
-            raise ClickException(
-                "Missing warehouse. Provide --warehouse, set the DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE account parameter, or check your connection."
-            )
-
-        resolved_values = {k: v[0] for k, v in resolved.items()}
-
-        if not dry_run:
-            # Use a workspace whenever the destination is a personal database:
-            # either it was resolved from the built-in personal-DB default tier,
-            # or it arrived via an account parameter / the current session but is
-            # still a ``USER$<user>`` personal database. Personal databases do not
-            # support stages, so emitting ``code_stage`` for one would produce a
-            # ``snowflake.yml`` that always fails at deploy time.
-            use_workspace = resolved["database"][
-                1
-            ] == SOURCE_DEFAULT or is_personal_database(resolved_values["database"])
-            with metrics.span("snowflake_app.setup.write_manifest"):
-                project_file.write_text(
-                    _generate_snowflake_yml(
-                        resolved_app_name,
-                        resolved_values,
-                        use_workspace=use_workspace,
-                    ),
-                    encoding=encoding,
+    try:
+        with metrics.span("snowflake_app.setup"):
+            resolved_app_name = app_name
+            if resolved_app_name is None:
+                derived_app_name = Path.cwd().name
+                # For implicit names, normalize directory strings into a valid
+                # identifier by mapping common separators to "_" and stripping
+                # all other disallowed characters.
+                resolved_app_name = re.sub(
+                    r"[^a-zA-Z0-9_]",
+                    "",
+                    derived_app_name.replace(" ", "_").replace("-", "_"),
                 )
 
-        is_json = get_cli_context().output_format.is_json
-        if is_json:
-            return ObjectResult({"success": not dry_run, **resolved_values})
+            if not resolved_app_name:
+                raise ClickException(
+                    "Could not derive app name from the current directory. "
+                    "Please provide --app-name."
+                )
 
-        if dry_run:
-            cli_console.step("Dry run — resolved configuration:")
-        else:
-            cli_console.step(
-                f"Initialized Snowflake App Runtime project in {DEFINITION_FILENAME}."
+            if not re.fullmatch(r"[a-zA-Z0-9_]+", resolved_app_name):
+                raise ClickException(
+                    f"Invalid app name '{resolved_app_name}'. "
+                    "Only letters, digits, and underscores are allowed."
+                )
+            # snowflake.yml is a CLI-owned manifest that the ``snow app`` commands read
+            # back with the same encoding policy (see _app_group_callback): an explicit
+            # cli.encoding.file_io setting wins, otherwise UTF-8. Writing it the same
+            # way keeps the round-trip consistent regardless of the host code page, even
+            # when the generated content (e.g. a non-Latin app title) is non-ASCII.
+            encoding = get_file_io_encoding() or "utf-8"
+            project_file = Path.cwd() / DEFINITION_FILENAME
+            if not dry_run and project_file.exists():
+                return MessageResult(
+                    f"{DEFINITION_FILENAME} already exists. Skipping initialization."
+                )
+
+            connection_name = (
+                ctx.connection_context.connection_name or get_default_connection_name()
             )
-        for key, (value, source) in resolved.items():
-            # Skip optional fields that could not be resolved (e.g. ``build_eai``
-            # when no value was provided and no account parameter is set).
-            # Emitting ``build_eai: None  (missing)`` is noisy and implies the
-            # field is required when it is not.
-            if value is None and source == SOURCE_MISSING:
-                continue
-            cli_console.step(f"  {key}: {value}  ({source})")
+            conn_config = get_connection_dict(connection_name)
+
+            manager = SnowflakeAppManager()
+            with metrics.span("snowflake_app.setup.resolve_defaults"):
+                params = manager.fetch_snow_apps_parameters()
+                # Drop the account-configured destination database/schema the current
+                # role cannot access so resolution falls back to the personal database.
+                params = _filter_accessible_remote_defaults(manager, params)
+
+            def _resolve(
+                user_input=None,
+                account_param=None,
+                default_value=None,
+                current_session=None,
+            ):
+                """Return (value, source) using a fixed resolution order.
+
+                Resolution: user_input > account_param > default_value > current_session.
+                """
+                if user_input is not None:
+                    return user_input, SOURCE_USER_INPUT
+                if account_param is not None:
+                    return account_param, SOURCE_ACCOUNT_PARAM
+                if default_value is not None:
+                    return default_value, SOURCE_DEFAULT
+                if current_session is not None:
+                    return current_session, SOURCE_CURRENT_SESSION
+                return None, SOURCE_MISSING
+
+            # ── Pre-compute current session values ─────────────────────────────
+            conn = ctx.connection_context
+            # ``conn.warehouse/database/schema`` are only non-None when the user
+            # explicitly passed the corresponding connection-override flag on the
+            # command line (e.g. ``--warehouse MY_WH``).  Values from the
+            # connection config file come through ``conn_config`` instead.
+            cli_wh = getattr(conn, "warehouse", None) or None
+            cli_db = getattr(conn, "database", None) or None
+            cli_schema = getattr(conn, "schema", None) or None
+
+            # A user-supplied database must be paired with an explicit schema: schema
+            # resolution would otherwise fall back to an account parameter or the
+            # personal-database default, silently placing the app in a schema that does
+            # not belong to the requested database.
+            if cli_db and not cli_schema:
+                raise CliError(
+                    "--schema is required when --database is specified. "
+                    "Provide --schema to select the schema within the requested database."
+                )
+
+            session_wh = conn_config.get("warehouse") or None
+            session_db = conn_config.get("database") or None
+            session_schema = conn_config.get("schema") or None
+
+            with metrics.span("snowflake_app.setup.get_personal_database"):
+                personal_db = manager.get_personal_database()
+            personal_schema = DEFAULT_PERSONAL_SCHEMA if personal_db else None
+
+            # ── Resolve each field ────────────────────────────────────────────
+            resolved = {
+                "database": _resolve(
+                    user_input=cli_db,
+                    account_param=params.get("database"),
+                    default_value=personal_db,
+                    current_session=session_db,
+                ),
+                # TODO: Support per-app schema (e.g. APPS.APP_<app_id>) instead of
+                # a single shared schema for all apps.
+                "schema": _resolve(
+                    user_input=cli_schema,
+                    account_param=params.get("schema"),
+                    default_value=personal_schema,
+                    current_session=session_schema,
+                ),
+                "warehouse": _resolve(
+                    user_input=cli_wh,
+                    account_param=params.get("query_warehouse"),
+                    current_session=session_wh,
+                ),
+                # Compute pools are intentionally not resolved or written: app
+                # services always run on server-managed compute pools, so
+                # ``snow app setup`` never configures ``build_compute_pool`` /
+                # ``service_compute_pool``. The (hidden) ``--compute-pool`` flag is
+                # accepted for backward compatibility but no longer has any effect.
+                # TODO: Remove --build-eai argument once the builder service no longer
+                # requires an external access integration.
+                "build_eai": _resolve(
+                    user_input=build_eai,
+                    account_param=params.get("build_eai"),
+                ),
+            }
+
+            # ── Validate required values ─────────────────────────────────────
+            if not resolved["database"][0]:
+                raise ClickException(
+                    "Missing database. Provide --database, set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_DATABASE account parameter, or check your connection."
+                )
+            if not resolved["schema"][0]:
+                raise ClickException(
+                    "Missing schema. Provide --schema, set the DEFAULT_SNOWFLAKE_APPS_DESTINATION_SCHEMA account parameter, or check your connection."
+                )
+            if not resolved["warehouse"][0]:
+                raise ClickException(
+                    "Missing warehouse. Provide --warehouse, set the DEFAULT_SNOWFLAKE_APPS_QUERY_WAREHOUSE account parameter, or check your connection."
+                )
+
+            resolved_values = {k: v[0] for k, v in resolved.items()}
+
+            if not dry_run:
+                # Use a workspace whenever the destination is a personal database:
+                # either it was resolved from the built-in personal-DB default tier,
+                # or it arrived via an account parameter / the current session but is
+                # still a ``USER$<user>`` personal database. Personal databases do not
+                # support stages, so emitting ``code_stage`` for one would produce a
+                # ``snowflake.yml`` that always fails at deploy time.
+                use_workspace = resolved["database"][
+                    1
+                ] == SOURCE_DEFAULT or is_personal_database(resolved_values["database"])
+                with metrics.span("snowflake_app.setup.write_manifest"):
+                    project_file.write_text(
+                        _generate_snowflake_yml(
+                            resolved_app_name,
+                            resolved_values,
+                            use_workspace=use_workspace,
+                        ),
+                        encoding=encoding,
+                    )
+
+            is_json = get_cli_context().output_format.is_json
+            if is_json:
+                return ObjectResult({"success": not dry_run, **resolved_values})
+
+            if dry_run:
+                cli_console.step("Dry run — resolved configuration:")
+            else:
+                cli_console.step(
+                    f"Initialized Snowflake App Runtime project in {DEFINITION_FILENAME}."
+                )
+            for key, (value, source) in resolved.items():
+                # Skip optional fields that could not be resolved (e.g. ``build_eai``
+                # when no value was provided and no account parameter is set).
+                # Emitting ``build_eai: None  (missing)`` is noisy and implies the
+                # field is required when it is not.
+                if value is None and source == SOURCE_MISSING:
+                    continue
+                cli_console.step(f"  {key}: {value}  ({source})")
+            return EmptyResult()
+    except ClickException as exc:
+        if not dry_run:
+            raise
+        typer.rich_utils.rich_format_error(exc)
         return EmptyResult()
 
 

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -197,7 +197,8 @@ def snowflake_app_setup(
     """
     ctx = get_cli_context()
     metrics = ctx.metrics
-    try:
+
+    def _run() -> CommandResult:
         with metrics.span("snowflake_app.setup"):
             resolved_app_name = app_name
             if resolved_app_name is None:
@@ -383,11 +384,17 @@ def snowflake_app_setup(
                     continue
                 cli_console.step(f"  {key}: {value}  ({source})")
             return EmptyResult()
+
+    try:
+        return _run()
     except ClickException as exc:
-        if not dry_run:
-            raise
-        typer.rich_utils.rich_format_error(exc)
-        return EmptyResult()
+        # A dry run is a non-committal preview, so a failed setup should not
+        # break callers that gate on the exit code (e.g. CI). Neutralize the
+        # exit code but re-raise so the error is rendered by the exact same
+        # path as a normal failure.
+        if dry_run:
+            exc.exit_code = 0
+        raise
 
 
 def snowflake_app_bundle(entity_id: Optional[str]) -> CommandResult:

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -3308,6 +3308,45 @@ class TestSetupCommand:
             assert "PARAM_DB" in result.output
             assert "PARAM_WH" in result.output
 
+    @patch("snowflake.cli._plugins.apps.commands.get_connection_dict", return_value={})
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_dry_run_keeps_error_output_but_exits_zero(
+        self, mock_mgr_cls, _mock_get_connection_dict, runner, tmp_path
+    ):
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+        }
+        mock_mgr.get_personal_database.return_value = None
+
+        with change_directory(tmp_path):
+            result = runner.invoke(
+                ["app", "setup", "--app-name", "my_app", "--dry-run"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Missing warehouse. Provide --warehouse" in result.output
+        assert not (tmp_path / "snowflake.yml").exists()
+
+    @patch("snowflake.cli._plugins.apps.commands.get_connection_dict", return_value={})
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    def test_setup_still_exits_nonzero_on_missing_required_values(
+        self, mock_mgr_cls, _mock_get_connection_dict, runner, tmp_path
+    ):
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.fetch_snow_apps_parameters.return_value = {
+            "database": "PARAM_DB",
+            "schema": "PARAM_SCHEMA",
+        }
+        mock_mgr.get_personal_database.return_value = None
+
+        with change_directory(tmp_path):
+            result = runner.invoke(["app", "setup", "--app-name", "my_app"])
+
+        assert result.exit_code == 1
+        assert "Missing warehouse. Provide --warehouse" in result.output
+
     @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
     def test_dry_run_omits_missing_build_eai(self, mock_mgr_cls, runner, tmp_path):
         """``--build-eai`` is optional: when no value is resolved the dry-run


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description

Running `snow app setup --dry-run` should always exit with code 0, even when setup validation fails.

The diff is mostly indentations, the change is basically wrapping the setup command in `_run()` and calling:
```python
try:
    return _run()
except ClickException as exc:
    if dry_run:
        exc.exit_code = 0
    raise
```
