### PR TITLE
Snowflake Apps: add a dedicated service_eai field

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 ## Fixes and improvements
 * `snow app setup` no longer writes `build_compute_pool` / `service_compute_pool` to the generated `snowflake.yml`, and no longer reads the `DEFAULT_SNOWFLAKE_APPS_BUILD_COMPUTE_POOL` / `DEFAULT_SNOWFLAKE_APPS_SERVICE_COMPUTE_POOL` account parameters. Snowflake App Runtime services now always run on server-managed compute pools. Existing projects that set these fields in `snowflake.yml` continue to be honored by `snow app deploy`.
 * `snow app setup --dry-run` now exits with code 0 while still printing the same setup validation errors that a non-dry-run invocation surfaces.
+* `snow app deploy` now supports a separate `service_eai` field on `snowflake-app` entities for newly created application services. When `service_eai` is not set, deploy continues to fall back to `build_eai` for backward compatibility.
 
 
 # v3.21.0

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -609,13 +609,6 @@ def snowflake_app_deploy(
     database = fqn.database or conn.database
     schema = fqn.schema or conn.schema
 
-    build_compute_pool = (
-        entity.build_compute_pool.name if entity.build_compute_pool else None
-    )
-    build_eai = entity.build_eai.name if entity.build_eai else None
-    service_compute_pool = (
-        entity.service_compute_pool.name if entity.service_compute_pool else None
-    )
     query_warehouse = entity.query_warehouse
 
     app_title = entity.meta.title if entity.meta else None
@@ -632,6 +625,9 @@ def snowflake_app_deploy(
     service_compute_pool = defaults["service_compute_pool"]
     query_warehouse = defaults["query_warehouse"]
     build_eai = defaults["build_eai"]
+    # ``service_eai`` is optional; when omitted, continue using ``build_eai``
+    # for the deployed application service to preserve existing projects.
+    service_eai = defaults.get("service_eai") or build_eai
 
     # ── Resolve code storage backend ──────────────────────────────────
     # ``code_stage`` and ``code_workspace`` are mutually exclusive (enforced
@@ -854,7 +850,7 @@ def snowflake_app_deploy(
         comment_data["appIcon"] = app_icon
     app_comment = json.dumps(comment_data)
 
-    eai_list = [build_eai] if build_eai else None
+    eai_list = [service_eai] if service_eai else None
 
     did_upgrade = False
     with metrics.span("snowflake_app.deploy_service"):

--- a/src/snowflake/cli/_plugins/apps/generate.py
+++ b/src/snowflake/cli/_plugins/apps/generate.py
@@ -28,9 +28,11 @@ def _generate_snowflake_yml(
 
     Required keys: ``database``, ``schema``, ``warehouse``.
 
-    Optional keys: ``build_eai``.  When omitted or ``None`` the corresponding
-    block is left out of the generated YAML.  ``build_eai`` is omitted when no
-    external access integration is required by the builder service.
+    Optional keys: ``build_eai``. When omitted or ``None`` the corresponding
+    block is left out of the generated YAML. ``build_eai`` is omitted when no
+    external access integration is required by the builder service. The setup
+    flow does not emit ``service_eai``; deploy continues to use ``build_eai``
+    for the application service unless a project adds ``service_eai`` manually.
 
     Compute pools are never written: app services always run on
     server-managed compute pools, so ``snow app setup`` does not configure

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -507,7 +507,8 @@ def _resolve_deploy_defaults(
     4. Current session values (lowest priority)
 
     Returns a dict with keys ``query_warehouse``, ``build_compute_pool``,
-    ``service_compute_pool``, ``build_eai``, ``artifact_repository``,
+    ``service_compute_pool``, ``build_eai``, ``service_eai``,
+    ``artifact_repository``,
     ``artifact_repo_database``, ``artifact_repo_schema``, ``database``,
     and ``schema``.  Any of them may still be ``None`` if no source
     provides a value.
@@ -531,6 +532,7 @@ def _resolve_deploy_defaults(
             entity.service_compute_pool.name if entity.service_compute_pool else None
         ),
         "build_eai": entity.build_eai.name if entity.build_eai else None,
+        "service_eai": entity.service_eai.name if entity.service_eai else None,
         "artifact_repository": (
             entity.artifact_repository.name if entity.artifact_repository else None
         ),

--- a/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
+++ b/src/snowflake/cli/_plugins/apps/snowflake_app_entity_model.py
@@ -147,7 +147,11 @@ class SnowflakeAppEntityModel(EntityModelBaseWithArtifacts):
         title="External access integration for build", default=None
     )
 
-    @field_validator("build_eai", mode="before")
+    service_eai: Union[ExternalAccessReference, None] = Field(
+        title="External access integration for the application service", default=None
+    )
+
+    @field_validator("build_eai", "service_eai", mode="before")
     @classmethod
     def _validate_eai(cls, value):
         """Accept a bare name string, a mapping with ``name``, or null/None.

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2565,6 +2565,7 @@ class TestResolveDeployDefaults:
         build_compute_pool=None,
         service_compute_pool=None,
         build_eai=None,
+        service_eai=None,
         artifact_repository=None,
         database="TEST_DB",
         schema="TEST_SCHEMA",
@@ -2588,6 +2589,9 @@ class TestResolveDeployDefaults:
         entity.build_eai = Mock(name_attr=build_eai) if build_eai else None
         if build_eai:
             entity.build_eai.name = build_eai
+        entity.service_eai = Mock(name_attr=service_eai) if service_eai else None
+        if service_eai:
+            entity.service_eai.name = service_eai
         entity.artifact_repository = None
         if artifact_repository:
             entity.artifact_repository = Mock()
@@ -2606,12 +2610,14 @@ class TestResolveDeployDefaults:
             build_compute_pool="YML_POOL",
             service_compute_pool="YML_SVC_POOL",
             build_eai="YML_EAI",
+            service_eai="YML_SERVICE_EAI",
         )
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
         assert result["query_warehouse"] == "YML_WH"
         assert result["build_compute_pool"] == "YML_POOL"
         assert result["service_compute_pool"] == "YML_SVC_POOL"
         assert result["build_eai"] == "YML_EAI"
+        assert result["service_eai"] == "YML_SERVICE_EAI"
 
     @patch(
         FETCH_SNOW_APPS_PARAMS,
@@ -2632,6 +2638,7 @@ class TestResolveDeployDefaults:
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
         assert result["query_warehouse"] == "PARAM_WH"
         assert result["build_eai"] == "PARAM_EAI"
+        assert result["service_eai"] is None
         assert result["database"] == "PARAM_DB"
         assert result["schema"] == "PARAM_SCHEMA"
         # Compute pools are never supplied by account parameters; with no
@@ -2653,6 +2660,7 @@ class TestResolveDeployDefaults:
         result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
         assert result["query_warehouse"] == "YML_WH"  # yml wins over param
         assert result["build_eai"] == "PARAM_EAI"  # param fills gap
+        assert result["service_eai"] is None
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
@@ -2708,6 +2716,7 @@ class TestResolveDeployDefaults:
         assert result["build_compute_pool"] is None
         assert result["service_compute_pool"] is None
         assert result["build_eai"] is None
+        assert result["service_eai"] is None
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
@@ -5729,6 +5738,111 @@ class TestDeployCommand:
             comment='{"appId": "MY_APP"}',
         )
         assert mock_poll.call_count == 2
+
+    @patch("snowflake.cli._plugins.apps.commands._poll_until")
+    @patch("snowflake.cli._plugins.apps.commands.perform_bundle")
+    @patch("snowflake.cli._plugins.apps.commands.SnowflakeAppManager")
+    @patch(
+        RESOLVE_DEPLOY_DEFAULTS,
+        return_value={
+            "query_warehouse": "WH",
+            "build_compute_pool": "BUILD_POOL",
+            "service_compute_pool": "SVC_POOL",
+            "build_eai": "MY_EAI",
+            "service_eai": "MY_SERVICE_EAI",
+            "database": "TEST_DB",
+            "schema": "TEST_SCHEMA",
+            "artifact_repository": "MY_APP_REPO",
+            "artifact_repo_database": "TEST_DB",
+            "artifact_repo_schema": "TEST_SCHEMA",
+        },
+    )
+    @patch("snowflake.cli._plugins.apps.commands._get_entity")
+    @patch(
+        "snowflake.cli._plugins.apps.commands._resolve_entity_id",
+        return_value="my_app",
+    )
+    def test_deploy_uses_service_eai_for_application_service(
+        self,
+        mock_resolve,
+        mock_get_entity,
+        mock_defaults,
+        mock_manager_cls,
+        mock_perform_bundle,
+        mock_poll,
+        runner,
+        tmp_path,
+    ):
+        from snowflake.cli.api.project.project_paths import ProjectPaths
+
+        entity = Mock()
+        fqn = Mock()
+        fqn.name = "MY_APP"
+        fqn.database = "TEST_DB"
+        fqn.schema = "TEST_SCHEMA"
+        entity.fqn = fqn
+        entity.code_stage = None
+        entity.code_workspace = Mock(database=None, schema_=None)
+        entity.code_workspace.name = "MY_APP_CODE"
+        entity.artifacts = []
+        entity.meta = None
+        entity.runtime_image = "runtime:latest"
+        entity.query_warehouse = "WH"
+        entity.artifact_repository = None
+        entity.build_compute_pool = None
+        entity.service_compute_pool = None
+        entity.build_eai = None
+        entity.service_eai = None
+        mock_get_entity.return_value = entity
+
+        bundle_dir = tmp_path / "output" / "bundle"
+        bundle_dir.mkdir(parents=True)
+        project_paths = ProjectPaths(project_root=tmp_path)
+        mock_perform_bundle.return_value = project_paths
+
+        mock_mgr = mock_manager_cls.return_value
+        mock_mgr.workspace_last_subdirectory_uri.return_value = (
+            _WORKSPACE_BUILD_SOURCE_URI
+        )
+        mock_mgr.artifact_repo_exists.return_value = False
+        mock_mgr.build_app_artifact_repo.return_value = (
+            "Build job submitted: TEST_DB.TEST_SCHEMA.BUILD_JOB_123"
+        )
+        _real_manager = SnowflakeAppManager()
+        mock_mgr.resolve_application_service_url_from_describe.side_effect = (
+            _real_manager.resolve_application_service_url_from_describe
+        )
+        mock_poll.side_effect = [
+            "DONE",
+            {"url": "my-app.snowflakecomputing.app", "is_upgrading": "false"},
+        ]
+
+        with change_directory(tmp_path):
+            _write_snowflake_app_yml(tmp_path)
+            result = runner.invoke(["app", "deploy"])
+            assert result.exit_code == 0, result.output
+
+        mock_mgr.build_app_artifact_repo.assert_called_once_with(
+            source_uri=mock_mgr.workspace_last_subdirectory_uri.return_value,
+            artifact_repo_fqn="TEST_DB.TEST_SCHEMA.MY_APP_REPO",
+            app_id="MY_APP",
+            compute_pool="BUILD_POOL",
+            database="TEST_DB",
+            schema="TEST_SCHEMA",
+            runtime_image="runtime:latest",
+            build_eai="MY_EAI",
+            project_type="",
+        )
+        mock_mgr.create_app_service.assert_called_once_with(
+            service_fqn=FQN(database="TEST_DB", schema="TEST_SCHEMA", name="MY_APP"),
+            artifact_repo_fqn="TEST_DB.TEST_SCHEMA.MY_APP_REPO",
+            package_name="MY_APP",
+            compute_pool="SVC_POOL",
+            version="LATEST",
+            query_warehouse="WH",
+            external_access_integrations=["MY_SERVICE_EAI"],
+            comment='{"appId": "MY_APP"}',
+        )
 
     @patch("snowflake.cli._plugins.apps.commands._poll_until")
     @patch("snowflake.cli._plugins.apps.commands.perform_bundle")

--- a/tests/apps/test_snowflake_app_entity_model.py
+++ b/tests/apps/test_snowflake_app_entity_model.py
@@ -37,6 +37,7 @@ class TestSnowflakeAppEntityModel:
         assert model.build_compute_pool is None
         assert model.service_compute_pool is None
         assert model.build_eai is None
+        assert model.service_eai is None
         assert model.artifact_repository is None
         assert model.code_stage is None
         assert model.meta is None
@@ -60,6 +61,7 @@ class TestSnowflakeAppEntityModel:
                 "database": "MY_DB",
             },
             build_eai={"name": "BUILD_EAI"},
+            service_eai={"name": "SERVICE_EAI"},
             artifact_repository={
                 "name": "ARTIFACT_REPO",
                 "schema": "MY_SCHEMA",
@@ -76,6 +78,7 @@ class TestSnowflakeAppEntityModel:
         assert model.service_compute_pool.schema_ == "MY_SCHEMA"
         assert model.service_compute_pool.database == "MY_DB"
         assert model.build_eai.name == "BUILD_EAI"
+        assert model.service_eai.name == "SERVICE_EAI"
         assert model.artifact_repository.name == "ARTIFACT_REPO"
         assert model.artifact_repository.schema_ == "MY_SCHEMA"
         assert model.artifact_repository.database == "MY_DB"
@@ -125,8 +128,10 @@ class TestSnowflakeAppEntityModel:
             identifier="my_app",
             artifacts=["app/*"],
             build_eai=value,
+            service_eai=value,
         )
         assert model.build_eai is None
+        assert model.service_eai is None
 
     def test_eai_validator_dict_value(self):
         """EAI validator passes through dict values."""
@@ -135,8 +140,10 @@ class TestSnowflakeAppEntityModel:
             identifier="my_app",
             artifacts=["app/*"],
             build_eai={"name": "MY_EAI"},
+            service_eai={"name": "MY_SERVICE_EAI"},
         )
         assert model.build_eai.name == "MY_EAI"
+        assert model.service_eai.name == "MY_SERVICE_EAI"
 
     def test_eai_validator_bare_string(self):
         """``build_eai: MY_EAI`` (bare string) is treated as the integration
@@ -147,8 +154,10 @@ class TestSnowflakeAppEntityModel:
             identifier="my_app",
             artifacts=["app/*"],
             build_eai="MY_EAI",
+            service_eai="MY_SERVICE_EAI",
         )
         assert model.build_eai.name == "MY_EAI"
+        assert model.service_eai.name == "MY_SERVICE_EAI"
 
     def test_code_stage_defaults(self):
         """Code stage encryption_type defaults to SNOWFLAKE_SSE."""
@@ -341,6 +350,7 @@ class TestSnowflakeAppInProjectDefinition:
                         "database": "SVC_DB",
                     },
                     "build_eai": {"name": "BUILD_EAI"},
+                    "service_eai": {"name": "SERVICE_EAI"},
                     "artifact_repository": {
                         "name": "ARTIFACT_REPO",
                         "schema": "REPO_SCHEMA",
@@ -359,6 +369,7 @@ class TestSnowflakeAppInProjectDefinition:
         assert entity.service_compute_pool.schema_ == "SVC_SCHEMA"
         assert entity.service_compute_pool.database == "SVC_DB"
         assert entity.build_eai.name == "BUILD_EAI"
+        assert entity.service_eai.name == "SERVICE_EAI"
         assert entity.artifact_repository.name == "ARTIFACT_REPO"
         assert entity.artifact_repository.schema_ == "REPO_SCHEMA"
         assert entity.artifact_repository.database == "REPO_DB"


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [ ] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
We currently use `build_eai` for both the build job and the application service. This PR adds a dedicated `service_eai` field so application services can use a different external access integration than the build job.

Keep backward compatibility by continuing to use `build_eai` for the application service when `service_eai` is not configured.
