### PR TITLE
Snowflake Apps: wire fqn.using_context() and expand USER$ via SQL fallback

### DIFF
--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -413,6 +413,7 @@ def snowflake_app_validate(entity_id: Optional[str]) -> CommandResult:
 
     # ── Validate database and schema ──────────────────────────────────
     fqn = entity.fqn
+    fqn.using_context()
     database = fqn.database
     schema = fqn.schema
 
@@ -454,6 +455,7 @@ def snowflake_app_open(
     entity = _get_entity(resolved_entity_id)
 
     fqn = entity.fqn
+    fqn.using_context()
     ctx = get_cli_context()
     metrics = ctx.metrics
 
@@ -516,6 +518,7 @@ def snowflake_app_events(
     entity = _get_entity(resolved_entity_id)
 
     fqn = entity.fqn
+    fqn.using_context()
     # Rebuild to a 3-part name; entity FQN may carry extra fields (e.g. prefix)
     service_fqn = app_fqn(database=fqn.database, schema=fqn.schema, name=fqn.name)
 
@@ -602,6 +605,7 @@ def snowflake_app_deploy(
 
     # ── Extract entity configuration ──────────────────────────────────
     fqn = entity.fqn
+    fqn.using_context()
     app_name = fqn.name
 
     ctx = get_cli_context()
@@ -977,6 +981,7 @@ def snowflake_app_teardown(
     entity = _get_entity(resolved_entity_id)
 
     fqn = entity.fqn
+    fqn.using_context()
     manager = SnowflakeAppManager()
     metrics = get_cli_context().metrics
     with metrics.span("snowflake_app.teardown.resolve_defaults"):

--- a/src/snowflake/cli/_plugins/apps/manager.py
+++ b/src/snowflake/cli/_plugins/apps/manager.py
@@ -494,6 +494,22 @@ def _filter_accessible_remote_defaults(
     return filtered
 
 
+def _expand_personal_database(
+    database: Optional[str], manager: "SnowflakeAppManager"
+) -> Optional[str]:
+    """Expand bare ``USER$`` to the full PDB name via a server-side query.
+
+    ``FQN.using_context()`` already handles this when the username is present
+    in the connection config (e.g. username/password auth).  This fallback
+    covers auth methods (SSO, browser, keypair without user field) where
+    ``connection_context.user`` is ``None``, by running
+    ``SELECT 'USER$' || CURRENT_USER()``.
+    """
+    if database and identifier_to_str(database.strip()).upper() == PERSONAL_DATABASE_PREFIX:
+        return manager.get_personal_database() or database
+    return database
+
+
 def _resolve_deploy_defaults(
     entity: "SnowflakeAppEntityModel",
     manager: "SnowflakeAppManager",
@@ -521,6 +537,7 @@ def _resolve_deploy_defaults(
 
     # ── 1. snowflake.yml values ───────────────────────────────────────
     fqn = entity.fqn
+    fqn.using_context()
     if app_name is None:
         app_name = fqn.name
     yml_vals: Dict[str, Optional[str]] = {
@@ -542,7 +559,7 @@ def _resolve_deploy_defaults(
         "artifact_repo_schema": (
             entity.artifact_repository.schema_ if entity.artifact_repository else None
         ),
-        "database": fqn.database,
+        "database": _expand_personal_database(fqn.database, manager),
         "schema": fqn.schema,
     }
 

--- a/src/snowflake/cli/api/identifiers.py
+++ b/src/snowflake/cli/api/identifiers.py
@@ -227,7 +227,7 @@ class FQN:
         """Update the instance with database and schema from connection in current cli context."""
         from snowflake.cli.api.cli_global_context import get_cli_context
 
-        return self.using_connection(get_cli_context().connection)
+        return self.using_connection(get_cli_context().connection_context)
 
     def to_dict(self) -> dict:
         return {"name": self.name, "schema": self.schema, "database": self.database}

--- a/tests/api/test_fqn.py
+++ b/tests/api/test_fqn.py
@@ -341,7 +341,7 @@ def test_using_connection_skips_expansion_when_no_user():
 
 @mock.patch("snowflake.cli.api.cli_global_context.get_cli_context")
 def test_using_context(mock_ctx):
-    mock_ctx().connection = MagicMock(database="database_test", schema="test_schema")
+    mock_ctx().connection_context = MagicMock(database="database_test", schema="test_schema")
     fqn = FQN.from_string("name").using_context()
     assert fqn.identifier == "database_test.test_schema.name"
 
@@ -364,7 +364,7 @@ class TestFromResource:
         with mock.patch(
             "snowflake.cli.api.cli_global_context.get_cli_context"
         ) as _fixture:
-            _fixture().connection = MagicMock(database="test_db", schema="test_schema")
+            _fixture().connection_context = MagicMock(database="test_db", schema="test_schema")
             yield _fixture
 
     def test_basic_functionality(self, mock_ctx, mock_time):
@@ -422,7 +422,7 @@ class TestFromResource:
         expected_db,
         expected_schema,
     ):
-        mock_ctx().connection = MagicMock(database=context_db, schema=context_schema)
+        mock_ctx().connection_context = MagicMock(database=context_db, schema=context_schema)
         resource_fqn = FQN(
             name="resource", database=resource_db, schema=resource_schema
         )

--- a/tests/apps/test_commands.py
+++ b/tests/apps/test_commands.py
@@ -2673,6 +2673,17 @@ class TestResolveDeployDefaults:
         assert result["schema"] == "MY_SCHEMA"
 
     @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
+    @patch(GET_CLI_CONTEXT, return_value=_mock_connection_context())
+    @patch(GET_PERSONAL_DATABASE, return_value="USER$TESTUSER")
+    def test_bare_user_dollar_in_yml_is_expanded(self, mock_pdb, mock_ctx, mock_params):
+        """USER$ in snowflake.yml expands via SQL for any auth method."""
+        from snowflake.cli._plugins.apps.manager import _resolve_deploy_defaults
+
+        entity = self._make_entity(database="USER$", schema="PUBLIC")
+        result = _resolve_deploy_defaults(entity, SnowflakeAppManager())
+        assert result["database"] == "USER$TESTUSER"
+
+    @patch(FETCH_SNOW_APPS_PARAMS, return_value={})
     @patch(
         GET_CLI_CONTEXT,
         return_value=_mock_connection_context(


### PR DESCRIPTION
## Summary

Depends on #3139.

- Updates every `entity.fqn` access in the apps plugin to call `fqn.using_context()` so `USER$` is expanded before the database value reaches deploy defaults resolution, stage creation, and validation
- Adds `_expand_personal_database()` as a SQL-based fallback for auth methods (SSO, browser, keypair without explicit `user` field) where `connection_context.user` is `None` — runs `SELECT 'USER$' || CURRENT_USER()` to guarantee expansion regardless of auth method
- With these two changes, `database: USER$` in `snowflake.yml` works end-to-end for `snow app deploy`, `snow app validate`, and `snow app open`

## Test plan

- [ ] `test_bare_user_dollar_in_yml_is_expanded` in `TestResolveDeployDefaults` — SQL fallback expands `USER$` when `connection_context.user` is unavailable
- [ ] All existing `TestValidateCommand`, `TestOpenCommand`, and `TestResolveDeployDefaults` tests continue to pass

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)