### PR TITLE
`snow dcm plan` now supports the `--delta` flag

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 * `snow spcs service events` is now generally available. This command returns service-level and service-instance-level platform events in addition to container-level events.
 * `snow app open` now accepts a `--watch` flag for Snowflake App Runtime projects. With `--watch`, the command no longer fails when the app service does not exist yet; it polls until the service is created and its endpoint is ready before opening (or printing) the URL.
 * `snow app --help` is now context-aware: when the current project's `snowflake.yml` unambiguously targets one app family (Native Apps or Snowflake App Runtime), the help listing hides the other family's commands. Detection is conservative — a mixed, missing, or unparsable project shows every command — and hidden commands remain fully runnable. Because the same filtering backs shell completion and Click's "did you mean" suggestions, the hidden family's commands also stop appearing in `snow app <TAB>` completion for such a project (they still run when invoked explicitly).
+* `snow dcm plan` now supports the `--delta` flag for incremental deployments. This option enables processing only statements that have changed since the last deploy, plus statements potentially impacted by those changes.
 
 ## Fixes and improvements
 * `snow app deploy` now drops the code stage before recreating it only when the stage already exists. A first deploy has nothing to clear, so it no longer issues `DROP STAGE` unnecessarily, letting a role with only `CREATE STAGE` (and not `OWNERSHIP`) deploy successfully.

--- a/src/snowflake/cli/_plugins/dcm/commands.py
+++ b/src/snowflake/cli/_plugins/dcm/commands.py
@@ -448,7 +448,6 @@ def plan(
         False,
         "--delta",
         help="Process only statements changed since the last `deploy`, plus statements potentially impacted by those changes.",
-        hidden=not FeatureFlag.ENABLE_DCM_EARLY_ACCESS.is_enabled(),
     ),
     **options,
 ):

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -9708,6 +9708,9 @@
   |                              default_target if not specified.                |
   | --save-output                Save command response and artifacts to local    |
   |                              'out/' directory.                               |
+  | --delta                      Process only statements changed since the last  |
+  |                              deploy, plus statements potentially impacted by |
+  |                              those changes.                                  |
   | --help         -h            Show this message and exit.                     |
   +------------------------------------------------------------------------------+
   +- Connection configuration ---------------------------------------------------+


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed.

### Changes description
`snow dcm plan` now supports the `--delta` flag. This option enables processing only of statements that have changed since the last deploy, plus statements potentially impacted by those changes.
The feature is no longer early-access, but it's PuPr as the whole DCM Projects feature.
