### PR TITLE
feat: add TOON output format (--format toon)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,8 +20,10 @@
 ## Deprecations
 
 ## New additions
+* Added new `TOON` output format (`--format toon`) — token-efficient structured output for LLM consumption.
 
 ## Fixes and improvements
+* Commands that previously emitted no output under `--format csv` (e.g. `snow stage diff`, `snow app diff`) now return structured results for all structured output formats.
 
 
 # v3.23.0

--- a/pylock.toml
+++ b/pylock.toml
@@ -771,6 +771,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa3881
 wheels = [{ url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", upload-time = 2025-06-05T07:13:43Z, size = 38901, hashes = { sha256 = "c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0" } }]
 
 [[packages]]
+name = "toon-format"
+version = "0.9.0b1"
+sdist = { url = "https://files.pythonhosted.org/packages/fa/15/d23d6d3e36aa4ec96dd5692bc7715fe17015b669e8f0d1c5c7fa906a3ceb/toon_format-0.9.0b1.tar.gz", upload-time = 2025-11-08T19:22:53Z, size = 87398, hashes = { sha256 = "8f391dd6ad9677c78366bd8eb6762d064a2183f67b9b7da1f348fdb6ee8738e7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/63/f3/27ab1d982bb81bf9ac5be70b4c774996eb8562b93c77e93c253c22be951f/toon_format-0.9.0b1-py3-none-any.whl", upload-time = 2025-11-08T19:22:51Z, size = 36173, hashes = { sha256 = "efeee919501f91137f017f7bed34789c067f76178111aa872a49bc8653dce3be" } }]
+
+[[packages]]
 name = "typer"
 version = "0.17.3"
 sdist = { url = "https://files.pythonhosted.org/packages/dd/82/f4bfed3bc18c6ebd6f828320811bbe4098f92a31adf4040bee59c4ae02ea/typer-0.17.3.tar.gz", upload-time = 2025-08-30T12:35:24Z, size = 103517, hashes = { sha256 = "0c600503d472bcf98d29914d4dcd67f80c24cc245395e2e00ba3603c9332e8ba" } }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   'snowflake-snowpark-python==1.53.0',
   "snowflake.core==1.10.0",
   "tomlkit==0.13.3",
+  "toon-format==0.9.0b1",
   "typer==0.17.3",
   "urllib3>=2.6.3,<3",
   "websocket-client>=1.6.0,<2",

--- a/snyk/requirements.txt
+++ b/snyk/requirements.txt
@@ -59,6 +59,7 @@ snowflake-core==1.10.0
 snowflake-snowpark-python==1.53.0
 sortedcontainers==2.4.0
 tomlkit==0.13.3
+toon-format==0.9.0b1
 typer==0.17.3
 typing-extensions==4.14.1
 typing-inspection==0.4.2

--- a/src/snowflake/cli/_app/printing.py
+++ b/src/snowflake/cli/_app/printing.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import csv
 import json
+import math
 import sys
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -29,6 +30,7 @@ from rich import print as rich_print
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
+from toon_format import encode as toon_encode
 from snowflake.cli.api.cli_global_context import get_cli_context
 from snowflake.cli.api.output.formats import OutputFormat
 from snowflake.cli.api.output.types import (
@@ -224,8 +226,50 @@ def __to_str(val):
     return str(val)
 
 
-def is_structured_format(output_format):
-    return output_format.is_json or output_format == OutputFormat.CSV
+def _to_encodable_value(value):
+    """Convert a value to a primitive encodable type (same semantics as CustomJSONEncoder)."""
+    if isinstance(value, str):
+        return sanitize_for_terminal(value)
+    if isinstance(value, (date, datetime, time)):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (bytes, bytearray)):
+        return value.hex()
+    if isinstance(value, float) and not math.isfinite(value):
+        # toon_encode would collapse non-finite floats to null, making them
+        # indistinguishable from SQL NULL; use the same tokens JSON output emits
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    if isinstance(value, dict):
+        # keys can be server-controlled column names — sanitize them too
+        return {
+            sanitize_for_terminal(str(k)): _to_encodable_value(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_to_encodable_value(v) for v in value]
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    return str(value)
+
+
+def _print_toon_result(result: CommandResult):
+    """Print a single CommandResult as a TOON document."""
+    if isinstance(result, CollectionResult):
+        # ponytail: toon-format has no streaming encoder; we materialize all rows
+        # in memory, same ceiling as pre-streaming --format json.
+        data: Any = [_to_encodable_value(row) for row in result.result]
+    elif isinstance(result, (ObjectResult, MessageResult)):
+        # ObjectResult(None) — e.g. SingleQueryResult of an empty cursor —
+        # encodes as `null`, matching the JSON output for the same result
+        data = _to_encodable_value(result.result)
+    else:
+        return
+    print(toon_encode(data), flush=True)
 
 
 def print_structured(
@@ -233,11 +277,13 @@ def print_structured(
 ):
     """Handles outputs like json, csv and other structured and parsable formats with streaming."""
     printed_end_line = False
+    # Non-JSON structured formats share the same dispatch shape; JSON is the fallback.
+    printer = _RESULT_PRINTERS.get(output_format)
 
     if isinstance(result, MultipleResults):
-        if output_format == OutputFormat.CSV:
+        if printer:
             for command_result in result.result:
-                _print_csv_result_streaming(command_result)
+                printer(command_result)
                 print(flush=True)
             printed_end_line = True
         else:
@@ -246,15 +292,15 @@ def print_structured(
         # A StreamResult prints each value onto its own line
         # instead of joining all the values into a JSON array or CSV entry set
         for r in result.result:
-            if output_format == OutputFormat.CSV:
-                _print_csv_result_streaming(r)
+            if printer:
+                printer(r)
             else:
                 json.dump(r, sys.stdout, cls=StreamingJSONEncoder)
             print(flush=True)
             printed_end_line = True
     else:
-        if output_format == OutputFormat.CSV:
-            _print_csv_result_streaming(result)
+        if printer:
+            printer(result)
             printed_end_line = True
         else:
             _print_json_result_streaming(result)
@@ -308,6 +354,13 @@ def _print_csv_result_streaming(result: CommandResult):
         _print_object_result_as_csv(result)
     elif isinstance(result, MessageResult):
         _print_message_result_as_csv(result)
+
+
+# Per-result printers for non-JSON structured formats (JSON is the dispatch fallback)
+_RESULT_PRINTERS = {
+    OutputFormat.CSV: _print_csv_result_streaming,
+    OutputFormat.TOON: _print_toon_result,
+}
 
 
 def _stream_json(result):
@@ -365,7 +418,7 @@ def print_result(cmd_result: CommandResult, output_format: OutputFormat | None =
     match cmd_result:
         case EmptyResult():
             return
-        case _ if is_structured_format(output_format):
+        case _ if output_format.is_structured:
             print_structured(cmd_result, output_format)
         case MultipleResults() | StreamResult():
             for res in cmd_result.result:

--- a/src/snowflake/cli/_plugins/apps/commands.py
+++ b/src/snowflake/cli/_plugins/apps/commands.py
@@ -417,8 +417,7 @@ def snowflake_app_setup(
                         encoding=encoding,
                     )
 
-            is_json = get_cli_context().output_format.is_json
-            if is_json:
+            if get_cli_context().output_format.is_structured:
                 return ObjectResult({"success": not dry_run, **resolved_values})
 
             if dry_run:

--- a/src/snowflake/cli/_plugins/helpers/commands.py
+++ b/src/snowflake/cli/_plugins/helpers/commands.py
@@ -466,7 +466,7 @@ def generate_project_schema(
     # Under a structured output format, return the schema as an object so the
     # command emits the JSON Schema document itself rather than a stringified
     # blob nested under a "message" key.
-    if get_cli_context().output_format.is_json:
+    if get_cli_context().output_format.is_structured:
         return ObjectResult(schema)
 
     return MessageResult(json.dumps(schema, indent=2, sort_keys=True))

--- a/src/snowflake/cli/_plugins/nativeapp/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/commands.py
@@ -345,9 +345,9 @@ def app_diff(
     diff = ws.perform_action(
         package_id,
         EntityActions.DIFF,
-        print_to_console=not cli_context.output_format.is_json,
+        print_to_console=not cli_context.output_format.is_structured,
     )
-    if cli_context.output_format.is_json:
+    if cli_context.output_format.is_structured:
         return ObjectResult(diff.to_dict())
 
     return None
@@ -726,7 +726,7 @@ def app_validate(
     )
     package_id = options["package_entity_id"]
     package = ws.get_entity(package_id)
-    if cli_context.output_format.is_json:
+    if cli_context.output_format.is_structured:
         return ObjectResult(
             package.get_validation_result(
                 action_ctx=ws.action_ctx,

--- a/src/snowflake/cli/_plugins/nativeapp/release_channel/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/release_channel/commands.py
@@ -67,7 +67,7 @@ def release_channel_list(
         release_channel=channel,
     )
 
-    if cli_context.output_format.is_json:
+    if cli_context.output_format.is_structured:
         return CollectionResult(channels)
 
 

--- a/src/snowflake/cli/_plugins/nativeapp/version/commands.py
+++ b/src/snowflake/cli/_plugins/nativeapp/version/commands.py
@@ -104,7 +104,7 @@ def create(
     )
 
     message = "Version create is now complete."
-    if cli_context.output_format.is_json:
+    if cli_context.output_format.is_structured:
         return ObjectResult(
             {
                 "message": message,

--- a/src/snowflake/cli/_plugins/stage/commands.py
+++ b/src/snowflake/cli/_plugins/stage/commands.py
@@ -218,7 +218,7 @@ def stage_diff(
         local_root=Path(folder_name),
         stage_path=StageManager.stage_path_parts_from_str(stage_name),  # noqa: SLF001
     )
-    if get_cli_context().output_format.is_json:
+    if get_cli_context().output_format.is_structured:
         return ObjectResult(diff.to_dict())
     else:
         print_diff_to_console(diff)

--- a/src/snowflake/cli/_plugins/streamlit/log_streaming.py
+++ b/src/snowflake/cli/_plugins/streamlit/log_streaming.py
@@ -153,13 +153,13 @@ def _result_for_entry(entry, output_format: OutputFormat) -> CommandResult:
     """
     Pick the CommandResult subclass best matched to the current output format.
 
-    - JSON / CSV: yield a dict via ObjectResult so the framework produces
+    - JSON / CSV / TOON: yield a dict via ObjectResult so the framework produces
       valid JSONL / CSV rows that downstream tools (e.g. ``jq``) can parse.
     - TABLE / plain: yield a pre-formatted line via MessageResult so each
       log entry renders as a single human-readable row instead of a
       two-column key/value table.
     """
-    if output_format == OutputFormat.CSV or output_format.is_json:
+    if output_format.is_structured:
         return ObjectResult(entry.to_dict())
     return MessageResult(entry.format_line())
 

--- a/src/snowflake/cli/api/cli_global_context.py
+++ b/src/snowflake/cli/api/cli_global_context.py
@@ -293,10 +293,7 @@ class _CliGlobalContextAccess:
     @property
     def _should_force_mute_intermediate_output(self) -> bool:
         """Computes whether cli_console output should be muted."""
-        return (
-            self._manager.output_format.is_json
-            or self._manager.output_format == OutputFormat.CSV
-        )
+        return self._manager.output_format.is_structured
 
     @property
     def enhanced_exit_codes(self) -> bool:

--- a/src/snowflake/cli/api/output/formats.py
+++ b/src/snowflake/cli/api/output/formats.py
@@ -20,7 +20,12 @@ class OutputFormat(Enum):
     JSON = "JSON"
     JSON_EXT = "JSON_EXT"
     CSV = "CSV"
+    TOON = "TOON"
 
     @property
     def is_json(self) -> bool:
         return self in (OutputFormat.JSON, OutputFormat.JSON_EXT)
+
+    @property
+    def is_structured(self) -> bool:
+        return self.is_json or self in (OutputFormat.CSV, OutputFormat.TOON)

--- a/tests/__snapshots__/test_docs_generation_output.ambr
+++ b/tests/__snapshots__/test_docs_generation_output.ambr
@@ -285,7 +285,7 @@
   Keep the session active indefinitely, even if there is no activity from the user.
   
   </dd>
-  <dt>`--format [TABLE|JSON|JSON_EXT|CSV]`</dt>
+  <dt>`--format [TABLE|JSON|JSON_EXT|CSV|TOON]`</dt>
   <dd>
   
   Specifies the output format. Default: TABLE.

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -79,7 +79,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -337,7 +337,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -499,7 +499,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -743,7 +743,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -926,7 +926,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -1175,7 +1175,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -1345,7 +1345,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -1514,7 +1514,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -1679,7 +1679,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -1849,7 +1849,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -2018,7 +2018,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -2182,7 +2182,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -2377,7 +2377,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -2553,7 +2553,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -2725,7 +2725,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -2906,7 +2906,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -3073,7 +3073,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -3353,7 +3353,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -3512,7 +3512,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -3720,7 +3720,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -3892,7 +3892,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -4127,7 +4127,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -4320,7 +4320,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -4481,7 +4481,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -4585,7 +4585,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -4708,7 +4708,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -4856,7 +4856,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5006,7 +5006,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5050,7 +5050,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5095,7 +5095,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5141,7 +5141,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5289,7 +5289,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5367,7 +5367,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5579,7 +5579,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5731,7 +5731,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -5885,7 +5885,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -6047,7 +6047,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -6235,7 +6235,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -6423,7 +6423,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -6611,7 +6611,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -6799,7 +6799,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -6987,7 +6987,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -7175,7 +7175,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -7363,7 +7363,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -7551,7 +7551,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -7739,7 +7739,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -7927,7 +7927,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -8115,7 +8115,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -8303,7 +8303,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -8490,7 +8490,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -8674,7 +8674,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -8840,7 +8840,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9000,7 +9000,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9169,7 +9169,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9331,7 +9331,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9491,7 +9491,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9656,7 +9656,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9821,7 +9821,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -9987,7 +9987,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -10171,7 +10171,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -10335,7 +10335,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -10498,7 +10498,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -10661,7 +10661,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -10862,7 +10862,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11014,7 +11014,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11168,7 +11168,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11342,7 +11342,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11495,7 +11495,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11652,7 +11652,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11810,7 +11810,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -11967,7 +11967,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -12128,7 +12128,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -12293,7 +12293,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -12380,7 +12380,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -12548,7 +12548,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -12704,7 +12704,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -12869,7 +12869,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -13022,7 +13022,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -13175,7 +13175,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -13328,7 +13328,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -13523,7 +13523,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -13683,7 +13683,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -13845,7 +13845,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14018,7 +14018,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14083,7 +14083,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14127,7 +14127,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14168,7 +14168,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14357,7 +14357,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14526,7 +14526,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14684,7 +14684,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -14844,7 +14844,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -15004,7 +15004,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -15169,7 +15169,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -15336,7 +15336,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -15488,7 +15488,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -15643,7 +15643,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -15905,7 +15905,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -16063,7 +16063,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -16216,7 +16216,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -16371,7 +16371,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -16524,7 +16524,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -16677,7 +16677,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -16850,7 +16850,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17004,7 +17004,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17157,7 +17157,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17311,7 +17311,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17473,7 +17473,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17657,7 +17657,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17808,7 +17808,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -17968,7 +17968,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -18145,7 +18145,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -18301,7 +18301,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -18456,7 +18456,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -18613,7 +18613,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -18772,7 +18772,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -18933,7 +18933,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -19086,7 +19086,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -19313,7 +19313,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -19523,7 +19523,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -19682,7 +19682,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -19834,7 +19834,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -19991,7 +19991,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -20166,7 +20166,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -20344,7 +20344,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -20496,7 +20496,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -20648,7 +20648,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -20800,7 +20800,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -20952,7 +20952,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -21113,7 +21113,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -21277,7 +21277,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -21439,7 +21439,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -21591,7 +21591,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -21790,7 +21790,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -21946,7 +21946,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -22098,7 +22098,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -22267,7 +22267,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -22421,7 +22421,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -22739,7 +22739,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -22923,7 +22923,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -23084,7 +23084,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -23236,7 +23236,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -23390,7 +23390,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -23544,7 +23544,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -23715,7 +23715,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -23871,7 +23871,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -24032,7 +24032,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -24186,7 +24186,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -24386,7 +24386,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -24539,7 +24539,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -24694,7 +24694,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -24847,7 +24847,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -25001,7 +25001,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -25162,7 +25162,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -25337,7 +25337,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -25492,7 +25492,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -25919,7 +25919,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |

--- a/tests/api/commands/__snapshots__/test_flags.ambr
+++ b/tests/api/commands/__snapshots__/test_flags.ambr
@@ -5,7 +5,7 @@
   Try 'root stage list-files --help' for help.
   +- Error ----------------------------------------------------------------------+
   | Invalid value for '--format': 'invalid_format' is not one of 'TABLE',        |
-  | 'JSON', 'JSON_EXT', 'CSV'.                                                   |
+  | 'JSON', 'JSON_EXT', 'CSV', 'TOON'.                                           |
   +------------------------------------------------------------------------------+
   
   '''

--- a/tests/api/commands/__snapshots__/test_snow_typer.ambr
+++ b/tests/api/commands/__snapshots__/test_snow_typer.ambr
@@ -119,7 +119,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -161,7 +161,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |
@@ -225,7 +225,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |

--- a/tests/output/__snapshots__/test_silent_output.ambr
+++ b/tests/output/__snapshots__/test_silent_output.ambr
@@ -124,7 +124,7 @@
   +------------------------------------------------------------------------------+
   +- Global configuration -------------------------------------------------------+
   | --format                       [TABLE|JSON|JSON_EXT|  Specifies the output   |
-  |                                CSV]                   format.                |
+  |                                CSV|TOON]              format.                |
   |                                                       [default: TABLE]       |
   | --verbose              -v                             Displays log entries   |
   |                                                       for log levels info    |

--- a/tests/output/test_printing.py
+++ b/tests/output/test_printing.py
@@ -30,6 +30,7 @@ from snowflake.cli.api.output.types import (
     SingleQueryResult,
     StreamResult,
 )
+from toon_format import decode as toon_decode
 
 from tests.testing_utils.conversion import get_output, get_output_as_json
 
@@ -617,3 +618,100 @@ def _bytearray_result(mock_cursor):
             rows=[(bytearray("THIS SHOULD WORK", "utf-8"),)],
         )
     )
+
+
+def test_toon_collection_result(capsys):
+    collection = CollectionResult([{"a": 1, "b": "x"}, {"a": 2, "b": "y,z"}])
+    print_result(collection, output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == [
+        {"a": 1, "b": "x"},
+        {"a": 2, "b": "y,z"},
+    ]
+
+
+def test_toon_object_result(capsys):
+    print_result(ObjectResult({"key": "value", "n": 7}), output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == {"key": "value", "n": 7}
+
+
+def test_toon_message_result(capsys):
+    print_result(MessageResult("done"), output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == {"message": "done"}
+
+
+def test_toon_multiple_results(capsys):
+    results = MultipleResults([CollectionResult([{"a": 1}]), MessageResult("done")])
+    print_result(results, output_format=OutputFormat.TOON)
+    docs = get_output(capsys).strip("\n").split("\n\n")
+    assert len(docs) == 2
+    assert toon_decode(docs[0]) == [{"a": 1}]
+    assert toon_decode(docs[1]) == {"message": "done"}
+
+
+def test_toon_query_result(capsys, mock_cursor):
+    result = QueryResult(
+        mock_cursor(columns=["A", "TS"], rows=[(1, datetime(2022, 3, 21))])
+    )
+    print_result(result, output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == [
+        {"A": 1, "TS": "2022-03-21T00:00:00"}
+    ]
+
+
+def test_toon_special_types(capsys):
+    row = {
+        "date": datetime(2022, 3, 21, 1, 2, 3),
+        "dec": Decimal("1.5"),
+        "bytes": bytearray("THIS SHOULD WORK", "utf-8"),
+        "none": None,
+        "num": 42,
+    }
+    print_result(CollectionResult([row]), output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == [
+        {
+            "date": "2022-03-21T01:02:03",
+            "dec": "1.5",
+            "bytes": "544849532053484f554c4420574f524b",
+            "none": None,
+            "num": 42,
+        }
+    ]
+
+
+def test_print_stream_result_toon(capsys, _stream):
+    print_result(_stream, output_format=OutputFormat.TOON)
+    docs = get_output(capsys).strip("\n").split("\n\n")
+    assert [toon_decode(doc) for doc in docs] == [
+        {"message": "1"},
+        {"2": "3"},
+    ]
+
+
+def test_toon_empty_single_query_result_prints_null(capsys, mock_cursor):
+    result = SingleQueryResult(mock_cursor(columns=["A"], rows=[]))
+    print_result(result, output_format=OutputFormat.TOON)
+    assert get_output(capsys) == "null\n"
+
+
+def test_toon_sanitizes_keys(capsys):
+    collection = CollectionResult([{"a\x1b[31mb": 1}])
+    print_result(collection, output_format=OutputFormat.TOON)
+    output = get_output(capsys)
+    assert "\x1b" not in output
+    assert toon_decode(output.rstrip("\n")) == [{"ab": 1}]
+
+
+def test_toon_non_finite_floats_match_json_tokens(capsys):
+    collection = CollectionResult(
+        [{"nan": float("nan"), "inf": float("inf"), "ninf": float("-inf"), "null": None}]
+    )
+    print_result(collection, output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == [
+        {"nan": "NaN", "inf": "Infinity", "ninf": "-Infinity", "null": None}
+    ]
+
+
+def test_toon_bytes_and_bytearray_hex_encoded(capsys):
+    collection = CollectionResult([{"b": b"\x01\x02", "ba": bytearray(b"\x01\x02")}])
+    print_result(collection, output_format=OutputFormat.TOON)
+    assert toon_decode(get_output(capsys).rstrip("\n")) == [{"b": "0102", "ba": "0102"}]


### PR DESCRIPTION
### Pre-review checklist
   * [ ] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)). — **Requesting design sign-off in this PR; see "Design sign-off requested" below.**
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code. *(11 TOON tests in `tests/output/test_printing.py`, round-trip via `toon_format.decode`)*
   * [ ] I've added or updated integration tests to verify correctness of my new code. — **Happy to add once the design is signed off.**
   * [x] Manually tested on macOS
   * [ ] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch. *(rebased on latest `main`)*
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [ ] I've updated documentation if behavior changed. — **No in-repo user docs mention output formats; help-text snapshots regenerated.**

### Changes description

Adds **TOON** (Token-Oriented Object Notation, [spec](https://github.com/toon-format/toon)) as a new structured output format: `snow sql -q "..." --format toon` (available on every command, like CSV/JSON).

#### Why TOON

TOON is a compact, lossless text format designed for LLM consumption — YAML-style indentation plus CSV-style tabular arrays, which is exactly the shape of `snow sql` query results. Numbers below are from the project's [published benchmarks](https://github.com/toon-format/toon#benchmarks):

- **Token efficiency**: 39.9% fewer tokens than JSON on mixed datasets; up to **−59.0%** on fully tabular data (9,115 vs 22,245 tokens on time-series rows — the `snow sql` result shape). E-commerce −33.3%, nested config −31.9%.
- **LLM comprehension is not worse than JSON**: mean retrieval accuracy **76.4% (TOON) vs 75.0% (JSON)** while using 39.9% fewer tokens; TOON beats JSON on 3 of 4 evaluated models (Claude Haiku 59.8 vs 57.4, GPT-5 Nano 90.9 vs 89.0, Grok-4 58.4 vs 56.5; Gemini 3 Flash essentially tied at 96.7 vs 97.1). Field-retrieval accuracy 99.6%.
- **Use case**: `snow sql` output consumed by agents/LLM pipelines — materially lower context cost with no loss of parseability (encode/decode round-trips are lossless; asserted in the unit tests).

#### Implementation

- New `OutputFormat.TOON` enum value and an `is_structured` property that consolidates the previously-triplicated "structured format" check (printing dispatch, intermediate-output muting, streamlit log streaming).
- TOON printer mirrors the CSV dispatch shape. Rows are pre-converted by `_to_encodable_value` to preserve data fidelity: `Decimal` as exact string (never `float`), `bytes`/`bytearray` as hex, non-finite floats as `NaN`/`Infinity` tokens (matching JSON output, since the toon encoder would collapse them to `null`), dates as ISO-8601, keys and string values passed through `sanitize_for_terminal`. Empty single-row results print `null`, matching JSON semantics.
- **Related fix**: several commands gated their structured return on `output_format.is_json` (`stage diff`, `app diff`, `app validate`, `app version create`, `app release-channel list`, `apps init`, `helpers write-project-definition-schema`). Under `--format csv` these emitted *no output at all* (console muted + `None` return). They now use `is_structured`, so CSV and TOON get structured results.
- Dependency: `toon-format==0.9.0b1` (MIT, zero runtime dependencies, Python ≥3.8). **Note**: this pins a beta — the `0.1.0` release on PyPI is a stale placeholder; `0.9.0b1` is the spec-aligned implementation. Flagging explicitly for dependency review.

#### Design sign-off requested

Per [adding-commands.md](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code), a new output format needs maintainer sign-off — requesting it here:

1. **Format value**: `--format toon` (case-insensitive, like the existing values).
2. **Lifecycle stage**: proposed GA alongside CSV/JSON; if you prefer PrPr/PuPr, I'm happy to gate it behind a `FeatureFlag` (e.g. `ENABLE_TOON_OUTPUT_FORMAT`) in this PR.
3. **Result mapping**: collections → tabular TOON; objects/messages → key-value TOON; multiple results → one TOON document per result separated by a blank line (mirrors CSV); empty single result → `null` (mirrors JSON).

#### Proposed follow-ups (out of scope here)

- Consolidate the four parallel scalar-conversion tables in `printing.py` (`CustomJSONEncoder`, `StreamingJSONEncoder`, `_write_csv_row`, `_to_encodable_value`) into one shared converter.
- Sanitize CSV header keys (same terminal-safety gap, pre-existing).
- Fix the dead-code type guard in `_stream_collection_as_csv` (raises after the `.keys()` call that already crashes).
