### PR TITLE
Fixing use of `is` with string literals

### DIFF
--- a/tests/test_common_global_context.py
+++ b/tests/test_common_global_context.py
@@ -47,13 +47,13 @@ def test_connection_details_callback():
     assert cli_context_manager.connection_context.connection_name is None
     assert cli_context_manager.connection_context.account is None
     assert cli_context_manager.connection_context.database is None
-    assert cli_context_manager.connection_context.role is "newValue"
+    assert cli_context_manager.connection_context.role == "newValue"
     assert cli_context_manager.connection_context.schema is None
     assert cli_context_manager.connection_context.user is None
     assert cli_context_manager.connection_context.password is None
     assert cli_context_manager.connection_context.authenticator is None
     assert cli_context_manager.connection_context.private_key_file is None
-    assert cli_context_manager.connection_context.warehouse is "newValue2"
+    assert cli_context_manager.connection_context.warehouse == "newValue2"
     assert cli_context_manager.connection_context.temporary_connection is False
 
 


### PR DESCRIPTION
### Pre-review checklist
   * [x] If my changes add or modify user-facing interface (commands, flags, output formats), I consulted maintainers and got sign-off beforehand ([how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/adding-commands.md#design-sign-off-before-writing-code)).
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] Manually tested on macOS
   * [x] Manually tested on Windows
   * [x] I've confirmed my changes are up-to-date with the target branch.
   * [x] I've described my changes in `RELEASE-NOTES.md` (see [when and how](https://github.com/snowflakedb/snowflake-cli/blob/main/docs/contributing/lifecycle.md#release-notes-format)).
   * [x] I've updated documentation if behavior changed.

### Changes description
Fixing the use of `is` with string literals - it produces warnings during compilation and can be fragile in some cases (though apparently this time it doesn't break, just warns). 

```sh
python -m py_compile tests/test_common_global_context.py
# tests/test_common_global_context.py:50: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
#   assert cli_context_manager.connection_context.role is "newValue"
# tests/test_common_global_context.py:56: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
#   assert cli_context_manager.connection_context.warehouse is "newValue2"
```

Found by running `ruff check --select F` that triggered https://docs.astral.sh/ruff/rules/is-literal/.
`F632` can be added to `pyproject.toml` to catch similar issues in the future.
```sh
ruff check --select F tests/test_common_global_context.py
# F632 [*] Use `==` to compare constant literals
#   --> tests/test_common_global_context.py:50:12
#    |
# 48 |     assert cli_context_manager.connection_context.account is None
# 49 |     assert cli_context_manager.connection_context.database is None
# 50 |     assert cli_context_manager.connection_context.role is "newValue"
#    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# 51 |     assert cli_context_manager.connection_context.schema is None
# 52 |     assert cli_context_manager.connection_context.user is None
#    |
# help: Replace `is` with `==`
#    |
# 49 |     assert cli_context_manager.connection_context.database is None
#    -     assert cli_context_manager.connection_context.role is "newValue"
# 50 +     assert cli_context_manager.connection_context.role == "newValue"
# 51 |     assert cli_context_manager.connection_context.schema is None
#    |
#
# F632 [*] Use `==` to compare constant literals
#   --> tests/test_common_global_context.py:56:12
#    |
# 54 |     assert cli_context_manager.connection_context.authenticator is None
# 55 |     assert cli_context_manager.connection_context.private_key_file is None
# 56 |     assert cli_context_manager.connection_context.warehouse is "newValue2"
#    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# 57 |     assert cli_context_manager.connection_context.temporary_connection is False
#    |
# help: Replace `is` with `==`
#    |
# 55 |     assert cli_context_manager.connection_context.private_key_file is None
#    -     assert cli_context_manager.connection_context.warehouse is "newValue2"
# 56 +     assert cli_context_manager.connection_context.warehouse == "newValue2"
# 57 |     assert cli_context_manager.connection_context.temporary_connection is False
#    |

Found 2 errors.
```
